### PR TITLE
Append PDF iframe after content

### DIFF
--- a/js/previewplugin.js
+++ b/js/previewplugin.js
@@ -46,7 +46,7 @@
 			var self = this;
 			var $iframe;
 			var viewer = OC.generateUrl('/apps/files_pdfviewer/?file={file}', {file: downloadUrl});
-			$iframe = $('<iframe id="pdframe" style="width:100%;height:100%;display:block;position:absolute;top:0;" src="'+viewer+'" sandbox="allow-scripts allow-same-origin allow-popups allow-modals" />');
+			$iframe = $('<iframe id="pdframe" style="width:100%;height:100%;display:block;position:absolute;top:0;z-index:141;" src="'+viewer+'" sandbox="allow-scripts allow-same-origin allow-popups allow-modals" />');
 
 			if(isFileList === true) {
 				FileList.setViewerMode(true);
@@ -63,7 +63,7 @@
 				$('.directDownload').addClass('hidden');
 				$('#controls').addClass('hidden');
 			} else {
-				$('#app-content').append($iframe);
+				$('#app-content').after($iframe);
 			}
 
 			$("#pageWidthOption").attr("selected","selected");


### PR DESCRIPTION
Before:
![bildschirmfoto 2017-03-21 um 23 43 06](https://cloud.githubusercontent.com/assets/245432/24183828/2d6cff5c-0e90-11e7-8a79-11c99a903cf8.png)

After:
![bildschirmfoto 2017-03-21 um 23 45 34](https://cloud.githubusercontent.com/assets/245432/24183870/82e5fcea-0e90-11e7-9d25-95fcdbe4e52a.png)


Caused by some layout changes in core. The z-index is needed to overlap the setting area in the bottom left corner.