### PR TITLE
Iframe gets hidden behind app-content

### DIFF
--- a/js/previewplugin.js
+++ b/js/previewplugin.js
@@ -46,7 +46,7 @@
 			var self = this;
 			var $iframe;
 			var viewer = OC.generateUrl('/apps/files_pdfviewer/?file={file}', {file: downloadUrl});
-			$iframe = $('<iframe id="pdframe" style="width:100%;height:100%;display:block;position:absolute;top:0;z-index:141;" src="'+viewer+'" sandbox="allow-scripts allow-same-origin allow-popups allow-modals allow-top-navigation" />');
+			$iframe = $('<iframe id="pdframe" style="width:100%;height:100%;display:block;position:absolute;top:0;z-index:1000;" src="'+viewer+'" sandbox="allow-scripts allow-same-origin allow-popups allow-modals allow-top-navigation" />');
 
 			if(isFileList === true) {
 				FileList.setViewerMode(true);

--- a/js/previewplugin.js
+++ b/js/previewplugin.js
@@ -6,7 +6,7 @@
  *
  * See the COPYING-README file.
  *
- */
+ */ 
 
 (function(OCA) {
 


### PR DESCRIPTION
The iframe gets hidden behind the app-content when screen is smaller than 678px.
This fixes it by putting the viewer in front.