### PR TITLE
Fix z index for small screen sizes

### DIFF
--- a/js/previewplugin.js
+++ b/js/previewplugin.js
@@ -46,7 +46,7 @@
 			var self = this;
 			var $iframe;
 			var viewer = OC.generateUrl('/apps/files_pdfviewer/?file={file}', {file: downloadUrl});
-			$iframe = $('<iframe id="pdframe" style="width:100%;height:100%;display:block;position:absolute;top:0;z-index:141;" src="'+viewer+'" sandbox="allow-scripts allow-same-origin allow-popups allow-modals allow-top-navigation" />');
+			$iframe = $('<iframe id="pdframe" style="width:100%;height:100%;display:block;position:absolute;top:0;z-index:1041;" src="'+viewer+'" sandbox="allow-scripts allow-same-origin allow-popups allow-modals allow-top-navigation" />');
 
 			if(isFileList === true) {
 				FileList.setViewerMode(true);


### PR DESCRIPTION
* open a PDF
* decrease the window width (for smaller than 756 px) the PDF gets overlaid with a white panel
* this fixes it

@karlitschek For this backport - I will also create a master version of this.