### PR TITLE
Fix duplicate iframe id

### DIFF
--- a/js/previewplugin.js
+++ b/js/previewplugin.js
@@ -149,7 +149,7 @@ $(document).ready(function(){
 			var downloadUrl = Files.getDownloadUrl(model.get('name'), model.get('path'));
 
 			var viewer = OC.generateUrl('/apps/files_pdfviewer/?minmode=true&file={file}', {file: downloadUrl});
-			var $iframe = $('<iframe id="pdframe" style="width:100%;height:' + previewHeight + 'px;display:block;" src="' + viewer + '" sandbox="allow-scripts allow-same-origin allow-popups allow-modals" />');
+			var $iframe = $('<iframe id="pdframe-sidebar" style="width:100%;height:' + previewHeight + 'px;display:block;" src="' + viewer + '" sandbox="allow-scripts allow-same-origin allow-popups allow-modals" />');
 			$thumbnailDiv.append($iframe);
 
 			$iframe.on('load', function() {


### PR DESCRIPTION
The duplicate id caused issues when closing the pdf preview while the
sidebar was visible. In that case two DOM elements with the same id were
present and the click event handler was registered to the wrong element.

backport of #49 