### PR TITLE
Enable full screen mode for PDF files

### DIFF
--- a/js/previewplugin.js
+++ b/js/previewplugin.js
@@ -47,7 +47,7 @@
 			var shown = true;
 			var $iframe;
 			var viewer = OC.generateUrl('/apps/files_pdfviewer/?file={file}', {file: downloadUrl});
-			$iframe = $('<iframe id="pdframe" style="width:100%;height:100%;display:block;position:absolute;top:0;z-index:1041;" src="'+viewer+'" sandbox="allow-scripts allow-same-origin allow-popups allow-modals allow-top-navigation" />');
+			$iframe = $('<iframe id="pdframe" style="width:100%;height:100%;display:block;position:absolute;top:0;z-index:1041;" src="'+viewer+'" sandbox="allow-scripts allow-same-origin allow-popups allow-modals allow-top-navigation" allowfullscreen="true"/>');
 
 			if(isFileList === true) {
 				FileList.setViewerMode(true);


### PR DESCRIPTION
The PDF viewer provides a _Full screen_ button when it detects that the browser supports the full screen mode and that the PDF is inside an element that can be displayed full screen. Therefore, as the PDF viewer is shown inside an `iframe` element [its `allowfullscreen` attribute must be set to `true`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#attr-allowfullscreen).

Note that the _Full screen_ button was already shown in Chromium before this pull request (although, unless I am missing something, it should not have been shown); now the button is available too in Firefox. I have not tested other browsers.
