### PR TITLE
Fix undefined variable

### DIFF
--- a/templates/viewer.php
+++ b/templates/viewer.php
@@ -2,7 +2,7 @@
   /** @var array $_ */
   /** @var OCP\IURLGenerator $urlGenerator */
   $urlGenerator = $_['urlGenerator'];
-  $version = \OC::$server->getAppManager()->getAppVersion($app);
+  $version = \OC::$server->getAppManager()->getAppVersion('files_pdfviewer');
 ?>
 <!DOCTYPE html>
 <!--


### PR DESCRIPTION
This pull request fixes a regression introduced in #70 

`getAppVersion()` expects the ID of the app, but `$app` is not defined in the templates, so it was just replaced by the hardcoded ID of the app.

**How to test**
- Open a PDF file in the Files app

**Expected result**
The PDF viewer is opened

**Actual result**
An error page is shown where the PDF viewer should be
