### PR TITLE
enable pdf viewer by default to view example files

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -18,6 +18,7 @@ about the PDF.js project at [https://mozilla.github.io/pdf.js/](https://mozilla.
     <licence>agpl</licence>
     <author>Thomas Müller, Lukas Reschke</author>
     <namespace>Files_PdfViewer</namespace>
+    <default_enable/>
     <category>files</category>
     <category>office</category>
     <bugs>https://github.com/nextcloud/files_pdfviewer/issues</bugs>


### PR DESCRIPTION
With Nextcloud 14 we have a example PDF, so I think it makes sense to enable the pdf viewer by default so that people can view the example file.