### PR TITLE
Adjust layout to changes in server

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -6,3 +6,9 @@
 	display: block;
 }
 
+#pdframe {
+	/* The PDF frame uses an absolute position and thus fills the whole padding
+	 * box of the content, so the top padding is needed here too to not overlap
+	 * the header. */
+	padding-top: inherit;
+}


### PR DESCRIPTION
The PDF frame is a direct child of `#content` that fills the whole element. This is done using absolute positioning, so the containing box for the PDF frame is the padding box of `#content`. Thus, the same
padding used in `#content` to show it below the header must be used in the PDF frame too (otherwise the PDF frame would appear behind the header).

Note that the scrolling element is not the body, but the `#viewContainer` element inside the PDF frame. Probably the body could be made the scrolling element instead by adding the PDF frame as the first child of `#content` (before `app-*` elements), hiding the `app-*` elements using something like `#content #pdframe ~ div { display: none }`, and then somehow cause the body to get the height of the PDF, but although I tried I was not successful in that last part. If you know how to fix that feel free to do it :-)

Also note that, when shown for a public share, the PDF frame does not reach the bottom of the page. The [`min-height` of `#content` is always set to `100vh - 160px`](https://github.com/nextcloud/server/blob/440b5c944f1d5bb759da1f90ad7fb17ba0e2b302/core/css/public.scss#L40), even when there is no footer; as the height is also set to `initial` the height of the content only expands to the minimum height, and thus does not vertically fill the whole page. The `min-height` rule could be overridden for the PDF viewer, but I think that it is something that should be fixed in the server instead.

@nextcloud/designers 
