### PR TITLE
Fix embedded viewer with new server layout on IE 11

### DIFF
--- a/js/previewplugin.js
+++ b/js/previewplugin.js
@@ -47,7 +47,7 @@
 			var shown = true;
 			var $iframe;
 			var viewer = OC.generateUrl('/apps/files_pdfviewer/?file={file}', {file: downloadUrl});
-			$iframe = $('<iframe id="pdframe" style="width:100%;height:100%;display:block;position:absolute;top:0;z-index:1041;" src="'+viewer+'" sandbox="allow-scripts allow-same-origin allow-popups allow-modals allow-top-navigation" allowfullscreen="true"/>');
+			$iframe = $('<iframe id="pdframe" style="width:100%;height:100%;display:block;position:absolute;top:0;z-index:1041;left:0;" src="'+viewer+'" sandbox="allow-scripts allow-same-origin allow-popups allow-modals allow-top-navigation" allowfullscreen="true"/>');
 
 			if(isFileList === true) {
 				FileList.setViewerMode(true);


### PR DESCRIPTION
The embedded PDF viewer is shown in an iframe in front of the of the Files app by using absolute positioning. [Since Nextcloud 14 the parent element of the iframe uses a flex layout](https://github.com/nextcloud/server/commit/e27e430f1fa756c0425b34611dfa16867ba97029#diff-bf0066932907b556b49ffe55b209a501R585), and the previous sibling of the iframe, [the `app-content` element, is shown with `flex-basis: 100vw`](https://github.com/nextcloud/server/blob/0c758dbe5b014715dd5adde625f5d3b4da3528cd/core/css/apps.scss#L601).

In IE 11 the scenario above causes the iframe to be shown to the right of `app-content` instead of in front of it; it is necessary to explicitly set `left: 0` to force the iframe to be aligned to the left of its positioning context (which in this case is its parent element) and thus in front of `app-content`.

@nextcloud/designers 
