### PR TITLE
Hide footer in public share page

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -6,6 +6,10 @@
 	display: block;
 }
 
+#body-public footer.hidden {
+	display: none;
+}
+
 #pdframe {
 	/* The PDF frame uses an absolute position and thus fills the whole padding
 	 * box of the content, so the top padding is needed here too to not overlap


### PR DESCRIPTION
The footer in the public share page is hidden by [adding the `hidden` CSS class to the footer](https://github.com/nextcloud/files_pdfviewer/blob/20654090e2ab4e230c416caa3df2070ec501cdc5/js/previewplugin.js#L61). However, [the CSS rules for the footer defined in the server](https://github.com/nextcloud/server/blob/8761856a7156474257f0f17949f1379804b2c627/core/css/public.scss#L65) are more specific than [the general rule for `.hidden` elements](https://github.com/nextcloud/server/blob/0c22a6696703225baabd6a4afaad5759745da8c5/core/css/global.scss#L27-L29), which caused the footer to be shown even if marked as `.hidden`. Now a more specific rule was added to override the ones from the server and ensure that the footer is hidden.

Note that this problem occurs in all browsers; it is not related to IE 11.

Also note that, as the PDF viewer can not be closed in the public share page and thus the footer is never shown, the proper way to fix this would be to change [the TemplateResponse in the DisplayController](https://github.com/nextcloud/files_pdfviewer/blob/b0ea05eb89f81e5c9cef92dc0dadad9758b38014/lib/Controller/DisplayController.php#L49) to a [PublicTemplateResponse which makes possible to completely remove the footer](https://github.com/nextcloud/server/blob/30e76f9f14d901025e245d9900b7ca1d3ff168ad/lib/public/AppFramework/Http/Template/PublicTemplateResponse.php#L136) from [the rendered template](https://github.com/nextcloud/server/blob/ad5093b7a63d8b223c19953dc37cc33c31631be8/core/templates/layout.public.php#L79-L92), and then adjust the JavaScript code as needed.

Despite that I opted for the other approach for easier backport to `stable14`, as this issue appeared in NC 14.0.0 Beta 4 (when the CSS rules for the footer were added in the server).
