### PR TITLE
Remove unneeded CSS rule for IE 11

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2,9 +2,6 @@
 #body-public .full-height {
 	height: 100%;
 }
-.ie #body-public .full-height {
-	display: block;
-}
 
 #pdframe {
 	/* The PDF frame uses an absolute position and thus fills the whole padding


### PR DESCRIPTION
This also happens to fix the PDF viewer in public share pages in IE 11 with current _master_ and _stable14_ branches of server. Due to [what looks like a typo the CSS rules of the server](https://github.com/nextcloud/server/blob/0274507cb10b53cfd38bd0ae3810c26cdb172ad1/core/css/ie.scss#L5-L7) the width of `app-content` is forced to the width of the navigation bar; this width is ignored when `content` (its parent element) uses a flex display, but honoured when `content` uses a block display, so removing the rule (that overrode [the default flex display for `content`](https://github.com/nextcloud/server/blob/8f9571bc3b6f2ced6383e2a617583399f7efbbdd/core/css/apps.scss#L589)) makes the `app-content` to fill the width of `content` instead of limiting it to the width of the navigation bar.

In any case this is just a coincidence and [the server will be probably fixed](https://github.com/nextcloud/server/issues/11403) before the next release anyway.
