### PR TITLE
Fix PDF sidebar shown in PDF thumbnails

### DIFF
--- a/css/minmode.css
+++ b/css/minmode.css
@@ -16,3 +16,10 @@ body {
 	border: 1px solid #ddd;
 	border-image: none;
 }
+
+/* Force hide the sidebar in the thumbnail, as whether it is shown or not
+ * depends on whether it was open or not the last time that the main viewer was
+ * used. */
+#sidebarContainer {
+	display: none;
+}


### PR DESCRIPTION
Fixes #112 

The PDF viewer [remembers whether the PDF sidebar was open or closed for each PDF file the last time it was viewed](https://github.com/mozilla/pdf.js/blob/v1.9.426/web/app.js#L963-L974). Thus, when the PDF file is rendered in a thumbnail the sidebar must be explicitly hidden to ensure that it will never be shown.

I miss a _Nextcloud 16_ milestone to set :-)
