### PR TITLE
Fix viewing of PDF documents

### DIFF
--- a/js/previewplugin.js
+++ b/js/previewplugin.js
@@ -135,6 +135,9 @@ $(document).ready(function(){
 	if ($('#isPublic').val() && $('#mimetype').val() === 'application/pdf') {
 		$.urlParam = function(name){
 			var results = new RegExp('[\?&]' + name + '=([^&#]*)').exec(window.location.href);
+			if (results == null) {
+				return 0;
+			}
 			return results[1] || 0;
 		};
 		var sharingToken = $('#sharingToken').val();

--- a/js/previewplugin.js
+++ b/js/previewplugin.js
@@ -118,7 +118,7 @@
 				actionHandler: function(fileName, context) {
 					var downloadUrl = context.fileList.getDownloadUrl(fileName, context.dir);
 					if (downloadUrl && downloadUrl !== '#') {
-						self.show(downloadUrl, param, true);
+						self.show(downloadUrl, '', true);
 					}
 				}
 			});


### PR DESCRIPTION
Fixes a regression of https://github.com/nextcloud/files_pdfviewer/pull/106 that prevents documents from being viewed (clicking a file entry does nothing, error logged to console).

@hirschrobert @skjnldsv please review