### PR TITLE
Only call setViewerMode if FileList is available

### DIFF
--- a/js/previewplugin.js
+++ b/js/previewplugin.js
@@ -32,7 +32,9 @@
 				$('footer').removeClass('hidden');
 			}
 
-			FileList.setViewerMode(false);
+			if (typeof FileList !== 'undefined') {
+				FileList.setViewerMode(false);
+			}
 
 			// replace the controls with our own
 			$('#app-content #controls').removeClass('hidden');


### PR DESCRIPTION
This was causing sentry error reports on public shared pdf files, if the viewer was closed.