### PR TITLE
Fix load of character maps

### DIFF
--- a/js/workersrc.js
+++ b/js/workersrc.js
@@ -31,6 +31,7 @@ function initializeCustomPDFViewerApplication() {
 	PDFJS.openExternalLinksInNewWindow = true;
 	PDFJS.isEvalSupported = false;
 	PDFJS.workerSrc = document.getElementsByTagName('head')[0].getAttribute('data-workersrc');
+	PDFJS.cMapUrl = document.getElementsByTagName('head')[0].getAttribute('data-cmapurl');
 
 	// The download has to be forced to use the URL of the file; by default
 	// "PDFViewerApplication.download" uses a blob, but this causes a CSP error

--- a/templates/viewer.php
+++ b/templates/viewer.php
@@ -27,7 +27,8 @@ Adobe CMap resources are covered by their own copyright but the same license:
 See https://github.com/adobe-type-tools/cmap-resources
 -->
 <html dir="ltr" mozdisallowselectionprint moznomarginboxes>
-  <head data-workersrc="<?php p($urlGenerator->linkTo('files_pdfviewer', 'vendor/pdfjs/build/pdf.worker.js')) ?>?v=<?php p($version) ?>">
+  <head data-workersrc="<?php p($urlGenerator->linkTo('files_pdfviewer', 'vendor/pdfjs/build/pdf.worker.js')) ?>?v=<?php p($version) ?>"
+        data-cmapurl="<?php p($urlGenerator->linkTo('files_pdfviewer', 'vendor/pdfjs/web/cmaps/')) ?>">
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
     <meta name="google" content="notranslate">


### PR DESCRIPTION
This might fix (but without a file to test I do not really know) #136 and #137.

The character maps are used by PDF.JS for font rendering, and are needed to properly show some texts (for example, Japanese text). The PDF.JS package provides the needed character maps, but the URL to get them must be set with the `PDFJS.cMapUrl` property in the same way as the `PDFJs.workerSrc` property is set (as [the default value set in _viewer.js_](https://github.com/nextcloud/files_pdfviewer/blob/c99514c86f20d677fd649afb0d62594356274470/vendor/pdfjs/web/viewer.js#L898) is not right for the PDF viewer app).
