### PR TITLE
Fix download button shown in public share page with hidden downloads

### DIFF
--- a/js/previewplugin.js
+++ b/js/previewplugin.js
@@ -93,6 +93,11 @@
 				} else {
 					iframe.find("#secondaryToolbarClose").addClass('hidden');
 				}
+
+				var hideDownload = $('#hideDownload').val();
+				if (hideDownload === 'true') {
+					iframe.find('.download').addClass('hidden');
+				}
 			});
 
 			if(!$('html').hasClass('ie8')) {


### PR DESCRIPTION
## How to test

- Upload a PDF file
- Add a new link share for that file
- Enable _Hide download_ for that link share
- Open the public share page

### Result with this pull request

The download icon is not shown.

### Result without this pull request

The download icon is shown.
