### PR TITLE
Update previewplugin.js

### DIFF
--- a/js/previewplugin.js
+++ b/js/previewplugin.js
@@ -54,7 +54,7 @@ var isSecureViewerAvailable = function () {
 			var shown = true;
 			var $iframe;
 			var viewer = OC.generateUrl('/apps/files_pdfviewer/?file={file}', {file: downloadUrl});
-			$iframe = $('<iframe id="pdframe" style="width:100%;height:100%;display:block;position:absolute;top:0;z-index:1041;left:0;" src="'+viewer+param+'" sandbox="allow-scripts allow-same-origin allow-popups allow-modals allow-top-navigation" allowfullscreen="true"/>');
+			$iframe = $('<iframe id="pdframe" style="width:100%;height:100%;display:block;position:absolute;top:0;z-index:1041;left:0;" src="'+viewer+param+'" sandbox="allow-scripts allow-popups-to-escape-sandbox allow-same-origin allow-popups allow-modals allow-top-navigation" allowfullscreen="true"/>');
 
 			if(isFileList === true) {
 				FileList.setViewerMode(true);


### PR DESCRIPTION
Adds `allow-popups-to-escape-sandbox` to `sandbox` parameter of iframe
Fixes non working links from pdf to other pdf-files an some pages with forms.
Error only occours if externalLinkTarget is set to BLANK