### PR TITLE
Prevent download, printing and text selection when download is hidden

### DIFF
--- a/css/viewer.css
+++ b/css/viewer.css
@@ -29,3 +29,16 @@ html .doorHangerRight:before {
 		display: none;
 	}
 }
+
+/* Prevent text selection when the download of a share is hidden. */
+.pdfViewer.disabledTextSelection .textLayer {
+	user-select: none;
+	-moz-user-select: none;
+	-webkit-user-select: none;
+	-ms-user-select: none;
+}
+
+/* Override text cursor in descendants. */
+.pdfViewer.disabledTextSelection .textLayer * {
+	cursor: default;
+}

--- a/css/viewer.css
+++ b/css/viewer.css
@@ -21,3 +21,11 @@ html .doorHangerRight:after {
 html .doorHangerRight:before {
   right: 53px!important;
 }
+
+/* Prevent printing from the browser when the download of a share is hidden. */
+@media print {
+	.pdfViewer.disabledTextSelection {
+		visibility: hidden;
+		display: none;
+	}
+}

--- a/js/previewplugin.js
+++ b/js/previewplugin.js
@@ -83,7 +83,6 @@ var isSecureViewerAvailable = function () {
 				var iframe = $('#pdframe').contents();
 				if ($('#hideDownload').val() === 'true') {
 					iframe.find('.toolbarButton.download').hide()
-					iframe.find('.toolbarButton.print').hide()
 				}
 				if ($('#fileList').length)
 				{

--- a/js/previewplugin.js
+++ b/js/previewplugin.js
@@ -81,9 +81,6 @@ var isSecureViewerAvailable = function () {
 			// if a filelist is present, the PDF viewer can be closed to go back there
 			$('#pdframe').load(function(){
 				var iframe = $('#pdframe').contents();
-				if ($('#hideDownload').val() === 'true') {
-					iframe.find('.toolbarButton.download').hide()
-				}
 				if ($('#fileList').length)
 				{
 					iframe.find('#secondaryToolbarClose').click(function() {

--- a/js/previewplugin.js
+++ b/js/previewplugin.js
@@ -101,6 +101,7 @@ var isSecureViewerAvailable = function () {
 				var hideDownload = $('#hideDownload').val();
 				if (hideDownload === 'true') {
 					iframe.find('.download').addClass('hidden');
+					iframe.find('.pdfViewer').addClass('disabledTextSelection')
 				}
 			});
 

--- a/js/workersrc.js
+++ b/js/workersrc.js
@@ -70,6 +70,15 @@ function initializeCustomPDFViewerApplication() {
 
 		this.downloadManager.downloadUrl(url, getPDFFileNameFromURL(url));
 	};
+
+	var hideDownload = window.parent.document.getElementById('hideDownload').value === 'true';
+	if (hideDownload) {
+		// Disable download function when downloads are hidden, as even if the
+		// buttons in the UI are hidden the download could still be triggered
+		// with Ctrl|Meta+S.
+		PDFViewerApplication.download = function() {
+		}
+	}
 }
 
 document.addEventListener('webviewerloaded', initializeCustomPDFViewerApplication, true);

--- a/js/workersrc.js
+++ b/js/workersrc.js
@@ -78,6 +78,22 @@ function initializeCustomPDFViewerApplication() {
 		// with Ctrl|Meta+S.
 		PDFViewerApplication.download = function() {
 		}
+
+		// Disable printing service when downloads are hidden, as even if the
+		// buttons in the UI are hidden the printing could still be triggered
+		// with Ctrl|Meta+P.
+		// Abuse the "supportsPrinting" parameter, which signals that the
+		// browser does not fully support printing, to make PDFViewer disable
+		// the printing service.
+		// "supportsPrinting" is a getter function, so it needs to be deleted
+		// before replacing it with a simple value.
+		delete PDFViewerApplication.supportsPrinting;
+		PDFViewerApplication.supportsPrinting = false;
+		// When printing is not supported a warning is shown by the default
+		// "beforePrint" function when trying to print. That function needs to
+		// be replaced with an empty one to prevent that warning to be shown.
+		PDFViewerApplication.beforePrint = function() {
+		}
 	}
 }
 


### PR DESCRIPTION
Please refer to the commit messages for details.

## How to test

- Open the files app
- Create a public link share for a PDF file
- Hide the download of the share
- Open the link

### Results with this pull request

It is not possible to download or print the file, and it is not possible to select the text (of course it is possible to do all that if you know how, but not with the "normal" ways).

### Results with this pull request

It is possible to download the file using `Ctrl+S`, it is possible to print the file using `Ctrl+P` or making the window smaller so the Print button appears in the `>>` menu, it is possible to print the file by printing the full page or the frame from the browser, and it is possible to select the text of the PDF.
