### PR TITLE
Allow downloads in sandboxed iframe

### DIFF
--- a/js/previewplugin.js
+++ b/js/previewplugin.js
@@ -54,7 +54,7 @@ var isSecureViewerAvailable = function () {
 			var shown = true;
 			var $iframe;
 			var viewer = OC.generateUrl('/apps/files_pdfviewer/?file={file}', {file: downloadUrl});
-			$iframe = $('<iframe id="pdframe" style="width:100%;height:100%;display:block;position:absolute;top:0;z-index:1041;left:0;" src="'+viewer+param+'" sandbox="allow-scripts allow-same-origin allow-popups allow-modals allow-top-navigation" allowfullscreen="true"/>');
+			$iframe = $('<iframe id="pdframe" style="width:100%;height:100%;display:block;position:absolute;top:0;z-index:1041;left:0;" src="'+viewer+param+'" sandbox="allow-scripts allow-same-origin allow-popups allow-modals allow-top-navigation allow-downloads" allowfullscreen="true"/>');
 
 			if(isFileList === true) {
 				FileList.setViewerMode(true);


### PR DESCRIPTION
Until now it was possible to initiate a download from an iframe, but the HTML spec has been updated to prevent that unless "allow-downloads" is set in the "sandbox" attribute of the iframe.

As the PDF viewer shows the PDF file in an iframe the "allow-downloads" attribute is needed to be able to download the PDF file by clicking on the "Download" button of the UI in browsers that have implemented the spec change (like [Chromium 83](https://www.chromestatus.com/feature/5706745674465280); other browsers are expected to follow).
