### PR TITLE
Hide the download button by default

### DIFF
--- a/templates/viewer.php
+++ b/templates/viewer.php
@@ -124,7 +124,7 @@ See https://github.com/adobe-type-tools/cmap-resources
               <span data-l10n-id="print_label">Print</span>
             </button>
 
-            <button id="secondaryDownload" class="secondaryToolbarButton download visibleMediumView" title="Download" tabindex="54" data-l10n-id="download">
+            <button id="secondaryDownload" class="secondaryToolbarButton download visibleMediumView" title="Download" tabindex="54" data-l10n-id="download" hidden="true">
               <span data-l10n-id="download_label">Download</span>
             </button>
 


### PR DESCRIPTION
Fix #246 

We already have the download function handled by the file list or top right header.