### PR TITLE
Fix viewing PDF files with public share links

### DIFF
--- a/src/views/PDFView.vue
+++ b/src/views/PDFView.vue
@@ -38,26 +38,18 @@ export default {
 		},
 
 		encodedDavPath() {
-			const hasScheme = this.davPath.indexOf('://') !== -1
+			const hasScheme = ~this.davPath.indexOf('://')
+			const url = new URL(hasScheme ? this.davPath : 'https://.' + this.davPath)
+			const pathname = url.pathname
 
-			const pathSections = this.davPath.split('/')
+			url.pathname = pathname
 
-			// Ignore scheme and domain in the loop (note that the scheme
-			// delimiter, "//", creates an empty section when split by "/").
-			const initialSection = hasScheme ? 3 : 0
+			url.searchParams.set('path', this.filename.replace(this.basename, ''))
+			url.searchParams.set('files', this.basename)
 
-			let encodedDavPath = ''
-			for (let i = initialSection; i < pathSections.length; i++) {
-				if (pathSections[i] !== '') {
-					encodedDavPath += '/' + encodeURIComponent(pathSections[i])
-				}
-			}
+			const encodedDavPath = url.toString()
 
-			if (hasScheme) {
-				encodedDavPath = pathSections[0] + '//' + pathSections[2] + encodedDavPath
-			}
-
-			return encodedDavPath
+			return hasScheme ? encodedDavPath : encodedDavPath.split('https://.')[1]
 		},
 	},
 


### PR DESCRIPTION
In nextcloud/files_pdfviewer#286, users have reported that PDF files
are not viewable via public share links. The issue was introduced in
c992b55 when attempting to encode parts of the URL for files that
have special characters.

This patch uses the URL Web API to deal with the parts of the URL
in a more specific way. Also, the path and files searchParams are
set based on `this.filename` and `this.basename` in the same way
it is done in the View module when setting `davPath`.

This has been tested on private and shared public links on files
with and without special characters.