### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/pdfjs-get.js
+++ b/pdfjs-get.js
@@ -6,7 +6,7 @@ const cliProgress = require('cli-progress')
 const npmPackage = require('./package.json')
 
 // Fetching pdf.js build release
-const PDFJSversion = npmPackage.dependencies['pdfjs-dist'].substr(1)
+const PDFJSversion = npmPackage.dependencies['pdfjs-dist'].slice(1)
 console.info('Fetching pdfjs', PDFJSversion)
 
 // Init progress


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.