### PR TITLE
Do not load PDF viewer if public share has a download limit

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -31,13 +31,13 @@ use OCA\Files_PDFViewer\Listeners\CSPListener;
 use OCA\Files_PDFViewer\Listeners\LoadPublicViewerListener;
 use OCA\Files_PDFViewer\Listeners\LoadViewerListener;
 
+use OCA\Files_Sharing\Event\BeforeTemplateRenderedEvent;
 use OCA\Viewer\Event\LoadViewer;
 
 use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
 use OCP\AppFramework\Bootstrap\IRegistrationContext;
-use OCP\AppFramework\Http\Events\BeforeTemplateRenderedEvent;
 use OCP\Security\CSP\AddContentSecurityPolicyEvent;
 
 class Application extends App implements IBootstrap {

--- a/lib/Listeners/LoadPublicViewerListener.php
+++ b/lib/Listeners/LoadPublicViewerListener.php
@@ -27,8 +27,7 @@ declare(strict_types=1);
 namespace OCA\Files_PDFViewer\Listeners;
 
 use OCA\Files_PDFViewer\AppInfo\Application;
-use OCP\AppFramework\Http\Events\BeforeTemplateRenderedEvent;
-use OCP\AppFramework\Http\TemplateResponse;
+use OCA\Files_Sharing\Event\BeforeTemplateRenderedEvent;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\Util;
@@ -39,10 +38,12 @@ class LoadPublicViewerListener implements IEventListener {
 			return;
 		}
 
-		// Make sure we are on a public page rendering
-		if ($event->getResponse()->getRenderAs() !== TemplateResponse::RENDER_AS_PUBLIC) {
+		// If the event has a scope it is not the default share page but, for
+		// example, the authentication page
+		if ($event->getScope() !== null) {
 			return;
 		}
+
 		Util::addScript(Application::APP_ID, 'files_pdfviewer-public');
 	}
 }


### PR DESCRIPTION
The PDF viewer needs to download the file in order to render it in the client. Due to this, if a public share has a download limit, loading the PDF viewer automatically reduces the number of available downloads by one, even if the user does not download the file manually. To prevent that now the PDF viewer is not loaded in public shares if the share has a download limit.

In order to accommodate that change, but also to prevent loading the PDF viewer when not needed, the PDF viewer is now loaded only in public share pages instead of in all public pages (which also matches with the existing JavaScript behaviour, as it was initialized only in public shares for PDF files and ignored in the other public pages).

## How to test

- Enable the [files_downloadlimit](https://github.com/nextcloud/files_downloadlimit) app
- Open the Files app
- Create a public share for a PDF file
- Set a download limit to that share
- Close the menu for the share
- Copy the link to the public share
- In a private window, open the link
- In the original window, open again the menu for the share

### Result with this pull request

The number of remaining downloads has not changed; the PDF viewer was not loaded in the public share page.

### Result without this pull request

The number of remaining downloads was reduced by one, because the PDF viewer was loaded in the public share page and therefore the file was implicitly downloaded.
