### PR TITLE
Set imageResourcesPath to correct relative path

### DIFF
--- a/src/workersrc.js
+++ b/src/workersrc.js
@@ -53,6 +53,7 @@ function initializeCustomPDFViewerApplication() {
 	PDFViewerApplicationOptions.set('workerSrc', head.getAttribute('data-workersrc'))
 	PDFViewerApplicationOptions.set('cMapUrl', head.getAttribute('data-cmapurl'))
 	PDFViewerApplicationOptions.set('enablePermissions', true)
+	PDFViewerApplicationOptions.set('imageResourcesPath', './js/pdfjs/web/images/')
 
 	if (canDownload === '0') {
 		const pdfViewer = window.document.querySelector('.pdfViewer')


### PR DESCRIPTION
The viewer tries to load images from its default path (`./images/`), with `.` being relative to the app URL this resolves to `/apps/files_pdfviewer/images/annotation-noicon.svg` instead of `/apps/files_pdfviewer/js/pdfjs/web/images/annotation-noicon.svg`.

Resolves #571

Signed-off-by: Hajo Möller <dasjoe@gmail.com>