### PR TITLE
Fix initialization after bump to PDF.js 3.9.179

### DIFF
--- a/templates/viewer.php
+++ b/templates/viewer.php
@@ -289,10 +289,13 @@ See https://github.com/adobe-type-tools/cmap-resources
                 <div class="verticalToolbarSeparator hiddenMediumView"></div>
 
                 <div id="editorModeButtons" class="splitToolbarButton toggled" role="radiogroup" hidden="true">
-                  <button id="editorFreeText" class="toolbarButton" disabled="disabled" title="Text" role="radio" aria-checked="false" aria-controls="editorFreeTextParamsToolbar" tabindex="34" data-l10n-id="editor_free_text2">
+                  <button id="editorStamp" class="toolbarButton hidden" disabled="disabled" title="Image" role="radio" aria-checked="false" tabindex="34" data-l10n-id="editor_stamp">
+                    <span data-l10n-id="editor_stamp_label">Image</span>
+                  </button>
+                  <button id="editorFreeText" class="toolbarButton" disabled="disabled" title="Text" role="radio" aria-checked="false" aria-controls="editorFreeTextParamsToolbar" tabindex="35" data-l10n-id="editor_free_text2">
                     <span data-l10n-id="editor_free_text2_label">Text</span>
                   </button>
-                  <button id="editorInk" class="toolbarButton" disabled="disabled" title="Draw" role="radio" aria-checked="false" aria-controls="editorInkParamsToolbar" tabindex="35" data-l10n-id="editor_ink2">
+                  <button id="editorInk" class="toolbarButton" disabled="disabled" title="Draw" role="radio" aria-checked="false" aria-controls="editorInkParamsToolbar" tabindex="36" data-l10n-id="editor_ink2">
                     <span data-l10n-id="editor_ink2_label">Draw</span>
                   </button>
                 </div>

--- a/templates/viewer.php
+++ b/templates/viewer.php
@@ -289,10 +289,10 @@ See https://github.com/adobe-type-tools/cmap-resources
                 <div class="verticalToolbarSeparator hiddenMediumView"></div>
 
                 <div id="editorModeButtons" class="splitToolbarButton toggled" role="radiogroup" hidden="true">
-                  <button id="editorFreeText" class="toolbarButton" disabled="disabled" title="Text" role="radio" aria-checked="false" tabindex="34" data-l10n-id="editor_free_text2">
+                  <button id="editorFreeText" class="toolbarButton" disabled="disabled" title="Text" role="radio" aria-checked="false" aria-controls="editorFreeTextParamsToolbar" tabindex="34" data-l10n-id="editor_free_text2">
                     <span data-l10n-id="editor_free_text2_label">Text</span>
                   </button>
-                  <button id="editorInk" class="toolbarButton" disabled="disabled" title="Draw" role="radio" aria-checked="false" tabindex="35" data-l10n-id="editor_ink2">
+                  <button id="editorInk" class="toolbarButton" disabled="disabled" title="Draw" role="radio" aria-checked="false" aria-controls="editorInkParamsToolbar" tabindex="35" data-l10n-id="editor_ink2">
                     <span data-l10n-id="editor_ink2_label">Draw</span>
                   </button>
                 </div>


### PR DESCRIPTION
This fixes a regression introduced in https://github.com/nextcloud/files_pdfviewer/pull/792

[PDF.js 3.9.179 added a new toolbar element, `editorStamp`](https://github.com/nextcloud/files_pdfviewer/pull/792/files#diff-b0e73f4391c0f98303bb616d5a1b8d7a085a5924a37edd31a84abbb9940e7cf5R279), which seems to be expected to be in the DOM and thus unconditionally used. Therefore it needs to be added to _templates/viewer.php_, which is the equivalent of _js/pdfjs/web/viewer.html_.

Besides that, _templates/viewer.php_ was also updated to reflect [changes in _js/pdfjs/web/viewer.html_ that were not applied yet](https://github.com/nextcloud/files_pdfviewer/commit/3419664b5f8222c2ee272d588af349f3dbc0c277#diff-b0e73f4391c0f98303bb616d5a1b8d7a085a5924a37edd31a84abbb9940e7cf5).

## How to test

- Open a PDF file

### Result with this pull request

The PDF is opened

### Result without this pull request

The PDF is not open; `Uncaught (in promise) TypeError: element is null` is shown in the browser console
