### PR TITLE
Fix extraction of PDF.js package

### DIFF
--- a/js/pdfjs/web/locale/fy-NL/viewer.properties
+++ b/js/pdfjs/web/locale/fy-NL/viewer.properties
@@ -1,0 +1,259 @@
+# Copyright 2012 Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Main toolbar buttons (tooltips and alt text for images)
+previous.title=Foarige side
+previous_label=Foarige
+next.title=Folgjende side
+next_label=Folgjende
+
+# LOCALIZATION NOTE (page.title): The tooltip for the pageNumber input.
+page.title=Side
+# LOCALIZATION NOTE (of_pages): "{{pagesCount}}" will be replaced by a number
+# representing the total number of pages in the document.
+of_pages=fan {{pagesCount}}
+# LOCALIZATION NOTE (page_of_pages): "{{pageNumber}}" and "{{pagesCount}}"
+# will be replaced by a number representing the currently visible page,
+# respectively a number representing the total number of pages in the document.
+page_of_pages=({{pageNumber}} fan {{pagesCount}})
+
+zoom_out.title=Utzoome
+zoom_out_label=Utzoome
+zoom_in.title=Ynzoome
+zoom_in_label=Ynzoome
+zoom.title=Zoome
+presentation_mode.title=Wikselje nei presintaasjemodus
+presentation_mode_label=Presintaasjemodus
+open_file.title=Bestân iepenje
+open_file_label=Iepenje
+print.title=Ofdrukke
+print_label=Ofdrukke
+save.title=Bewarje
+save_label=Bewarje
+bookmark1.title=Aktuele side (URL fan aktuele side besjen)
+bookmark1_label=Aktuele side
+# LOCALIZATION NOTE (open_in_app.title): This string is used in Firefox for Android.
+open_in_app.title=Iepenje yn app
+# LOCALIZATION NOTE (open_in_app_label): This string is used in Firefox for Android. Length of the translation matters since we are in a mobile context, with limited screen estate.
+open_in_app_label=Iepenje yn app
+
+# Secondary toolbar and context menu
+tools.title=Ark
+tools_label=Ark
+first_page.title=Gean nei earste side
+first_page_label=Gean nei earste side
+last_page.title=Gean nei lêste side
+last_page_label=Gean nei lêste side
+page_rotate_cw.title=Rjochtsom draaie
+page_rotate_cw_label=Rjochtsom draaie
+page_rotate_ccw.title=Linksom draaie
+page_rotate_ccw_label=Linksom draaie
+
+cursor_text_select_tool.title=Tekstseleksjehelpmiddel ynskeakelje
+cursor_text_select_tool_label=Tekstseleksjehelpmiddel
+cursor_hand_tool.title=Hânhelpmiddel ynskeakelje
+cursor_hand_tool_label=Hânhelpmiddel
+
+scroll_page.title=Sideskowen brûke
+scroll_page_label=Sideskowen
+scroll_vertical.title=Fertikaal skowe brûke
+scroll_vertical_label=Fertikaal skowe
+scroll_horizontal.title=Horizontaal skowe brûke
+scroll_horizontal_label=Horizontaal skowe
+scroll_wrapped.title=Skowe mei oersjoch brûke
+scroll_wrapped_label=Skowe mei oersjoch
+
+spread_none.title=Sidesprieding net gearfetsje
+spread_none_label=Gjin sprieding
+spread_odd.title=Sidesprieding gearfetsje te starten mei ûneven nûmers
+spread_odd_label=Uneven sprieding
+spread_even.title=Sidesprieding gearfetsje te starten mei even nûmers
+spread_even_label=Even sprieding
+
+# Document properties dialog box
+document_properties.title=Dokuminteigenskippen…
+document_properties_label=Dokuminteigenskippen…
+document_properties_file_name=Bestânsnamme:
+document_properties_file_size=Bestânsgrutte:
+# LOCALIZATION NOTE (document_properties_kb): "{{size_kb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in kilobytes, respectively in bytes.
+document_properties_kb={{size_kb}} KB ({{size_b}} bytes)
+# LOCALIZATION NOTE (document_properties_mb): "{{size_mb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in megabytes, respectively in bytes.
+document_properties_mb={{size_mb}} MB ({{size_b}} bytes)
+document_properties_title=Titel:
+document_properties_author=Auteur:
+document_properties_subject=Underwerp:
+document_properties_keywords=Kaaiwurden:
+document_properties_creation_date=Oanmaakdatum:
+document_properties_modification_date=Bewurkingsdatum:
+# LOCALIZATION NOTE (document_properties_date_string): "{{date}}" and "{{time}}"
+# will be replaced by the creation/modification date, and time, of the PDF file.
+document_properties_date_string={{date}}, {{time}}
+document_properties_creator=Makker:
+document_properties_producer=PDF-makker:
+document_properties_version=PDF-ferzje:
+document_properties_page_count=Siden:
+document_properties_page_size=Sideformaat:
+document_properties_page_size_unit_inches=yn
+document_properties_page_size_unit_millimeters=mm
+document_properties_page_size_orientation_portrait=steand
+document_properties_page_size_orientation_landscape=lizzend
+document_properties_page_size_name_a3=A3
+document_properties_page_size_name_a4=A4
+document_properties_page_size_name_letter=Letter
+document_properties_page_size_name_legal=Juridysk
+# LOCALIZATION NOTE (document_properties_page_size_dimension_string):
+# "{{width}}", "{{height}}", {{unit}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement and orientation, of the (current) page.
+document_properties_page_size_dimension_string={{width}} × {{height}} {{unit}} ({{orientation}})
+# LOCALIZATION NOTE (document_properties_page_size_dimension_name_string):
+# "{{width}}", "{{height}}", {{unit}}, {{name}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement, name, and orientation, of the (current) page.
+document_properties_page_size_dimension_name_string={{width}} × {{height}} {{unit}} ({{name}}, {{orientation}})
+# LOCALIZATION NOTE (document_properties_linearized): The linearization status of
+# the document; usually called "Fast Web View" in English locales of Adobe software.
+document_properties_linearized=Flugge webwerjefte:
+document_properties_linearized_yes=Ja
+document_properties_linearized_no=Nee
+document_properties_close=Slute
+
+print_progress_message=Dokumint tariede oar ôfdrukken…
+# LOCALIZATION NOTE (print_progress_percent): "{{progress}}" will be replaced by
+# a numerical per cent value.
+print_progress_percent={{progress}}%
+print_progress_close=Annulearje
+
+# Tooltips and alt text for side panel toolbar buttons
+# (the _label strings are alt text for the buttons, the .title strings are
+# tooltips)
+toggle_sidebar.title=Sidebalke yn-/útskeakelje
+toggle_sidebar_notification2.title=Sidebalke yn-/útskeakelje (dokumint befettet oersjoch/bylagen/lagen)
+toggle_sidebar_label=Sidebalke yn-/útskeakelje
+document_outline.title=Dokumintoersjoch toane (dûbelklik om alle items út/yn te klappen)
+document_outline_label=Dokumintoersjoch
+attachments.title=Bylagen toane
+attachments_label=Bylagen
+layers.title=Lagen toane (dûbelklik om alle lagen nei de standertsteat werom te setten)
+layers_label=Lagen
+thumbs.title=Foarbylden toane
+thumbs_label=Foarbylden
+current_outline_item.title=Aktueel item yn ynhâldsopjefte sykje
+current_outline_item_label=Aktueel item yn ynhâldsopjefte
+findbar.title=Sykje yn dokumint
+findbar_label=Sykje
+
+additional_layers=Oanfoljende lagen
+# LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
+page_landmark=Side {{page}}
+# Thumbnails panel item (tooltip and alt text for images)
+# LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
+# number.
+thumb_page_title=Side {{page}}
+# LOCALIZATION NOTE (thumb_page_canvas): "{{page}}" will be replaced by the page
+# number.
+thumb_page_canvas=Foarbyld fan side {{page}}
+
+# Find panel button title and messages
+find_input.title=Sykje
+find_input.placeholder=Sykje yn dokumint…
+find_previous.title=It foarige foarkommen fan de tekst sykje
+find_previous_label=Foarige
+find_next.title=It folgjende foarkommen fan de tekst sykje
+find_next_label=Folgjende
+find_highlight=Alles markearje
+find_match_case_label=Haadlettergefoelich
+find_match_diacritics_label=Diakrityske tekens brûke
+find_entire_word_label=Hiele wurden
+find_reached_top=Boppekant fan dokumint berikt, trochgien fan ûnder ôf
+find_reached_bottom=Ein fan dokumint berikt, trochgien fan boppe ôf
+# LOCALIZATION NOTE (find_match_count): The supported plural forms are
+# [one|two|few|many|other], with [other] as the default value.
+# "{{current}}" and "{{total}}" will be replaced by a number representing the
+# index of the currently active find result, respectively a number representing
+# the total number of matches in the document.
+find_match_count={[ plural(total) ]}
+find_match_count[one]={{current}} fan {{total}} oerienkomst
+find_match_count[two]={{current}} fan {{total}} oerienkomsten
+find_match_count[few]={{current}} fan {{total}} oerienkomsten
+find_match_count[many]={{current}} fan {{total}} oerienkomsten
+find_match_count[other]={{current}} fan {{total}} oerienkomsten
+# LOCALIZATION NOTE (find_match_count_limit): The supported plural forms are
+# [zero|one|two|few|many|other], with [other] as the default value.
+# "{{limit}}" will be replaced by a numerical value.
+find_match_count_limit={[ plural(limit) ]}
+find_match_count_limit[zero]=Mear as {{limit}} oerienkomsten
+find_match_count_limit[one]=Mear as {{limit}} oerienkomst
+find_match_count_limit[two]=Mear as {{limit}} oerienkomsten
+find_match_count_limit[few]=Mear as {{limit}} oerienkomsten
+find_match_count_limit[many]=Mear as {{limit}} oerienkomsten
+find_match_count_limit[other]=Mear as {{limit}} oerienkomsten
+find_not_found=Tekst net fûn
+
+# Predefined zoom values
+page_scale_width=Sidebreedte
+page_scale_fit=Hiele side
+page_scale_auto=Automatysk zoome
+page_scale_actual=Werklike grutte
+# LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
+# numerical scale value.
+page_scale_percent={{scale}}%
+
+# Loading indicator messages
+loading_error=Der is in flater bard by it laden fan de PDF.
+invalid_file_error=Ynfalide of korruptearre PDF-bestân.
+missing_file_error=PDF-bestân ûntbrekt.
+unexpected_response_error=Unferwacht serverantwurd.
+rendering_error=Der is in flater bard by it renderjen fan de side.
+
+# LOCALIZATION NOTE (annotation_date_string): "{{date}}" and "{{time}}" will be
+# replaced by the modification date, and time, of the annotation.
+annotation_date_string={{date}}, {{time}}
+
+# LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
+# "{{type}}" will be replaced with an annotation type from a list defined in
+# the PDF spec (32000-1:2008 Table 169 – Annotation types).
+# Some common types are e.g.: "Check", "Text", "Comment", "Note"
+text_annotation_type.alt=[{{type}}-annotaasje]
+password_label=Jou it wachtwurd om dit PDF-bestân te iepenjen.
+password_invalid=Ferkeard wachtwurd. Probearje opnij.
+password_ok=OK
+password_cancel=Annulearje
+
+printing_not_supported=Warning: Printen is net folslein stipe troch dizze browser.
+printing_not_ready=Warning: PDF is net folslein laden om ôf te drukken.
+web_fonts_disabled=Weblettertypen binne útskeakele: gebrûk fan ynsluten PDF-lettertypen is net mooglik.
+
+# Editor
+editor_free_text2.title=Tekst
+editor_free_text2_label=Tekst
+editor_ink2.title=Tekenje
+editor_ink2_label=Tekenje
+
+editor_stamp.title=Ofbylding tafoegje
+editor_stamp_label=Ofbylding tafoegje
+
+free_text2_default_content=Begjin mei typen…
+
+# Editor Parameters
+editor_free_text_color=Kleur
+editor_free_text_size=Grutte
+editor_ink_color=Kleur
+editor_ink_thickness=Tsjokte
+editor_ink_opacity=Transparânsje
+
+# Editor aria
+editor_free_text2_aria_label=Tekstbewurker
+editor_ink2_aria_label=Tekeningbewurker
+editor_ink_canvas_aria_label=Troch brûker makke ôfbylding

--- a/js/pdfjs/web/locale/ga-IE/viewer.properties
+++ b/js/pdfjs/web/locale/ga-IE/viewer.properties
@@ -1,0 +1,181 @@
+# Copyright 2012 Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Main toolbar buttons (tooltips and alt text for images)
+previous.title=An Leathanach Roimhe Seo
+previous_label=Roimhe Seo
+next.title=An Chéad Leathanach Eile
+next_label=Ar Aghaidh
+
+# LOCALIZATION NOTE (page.title): The tooltip for the pageNumber input.
+page.title=Leathanach
+# LOCALIZATION NOTE (of_pages): "{{pagesCount}}" will be replaced by a number
+# representing the total number of pages in the document.
+of_pages=as {{pagesCount}}
+# LOCALIZATION NOTE (page_of_pages): "{{pageNumber}}" and "{{pagesCount}}"
+# will be replaced by a number representing the currently visible page,
+# respectively a number representing the total number of pages in the document.
+page_of_pages=({{pageNumber}} as {{pagesCount}})
+
+zoom_out.title=Súmáil Amach
+zoom_out_label=Súmáil Amach
+zoom_in.title=Súmáil Isteach
+zoom_in_label=Súmáil Isteach
+zoom.title=Súmáil
+presentation_mode.title=Úsáid an Mód Láithreoireachta
+presentation_mode_label=Mód Láithreoireachta
+open_file.title=Oscail Comhad
+open_file_label=Oscail
+print.title=Priontáil
+print_label=Priontáil
+
+# Secondary toolbar and context menu
+tools.title=Uirlisí
+tools_label=Uirlisí
+first_page.title=Go dtí an chéad leathanach
+first_page_label=Go dtí an chéad leathanach
+last_page.title=Go dtí an leathanach deiridh
+last_page_label=Go dtí an leathanach deiridh
+page_rotate_cw.title=Rothlaigh ar deiseal
+page_rotate_cw_label=Rothlaigh ar deiseal
+page_rotate_ccw.title=Rothlaigh ar tuathal
+page_rotate_ccw_label=Rothlaigh ar tuathal
+
+cursor_text_select_tool.title=Cumasaigh an Uirlis Roghnaithe Téacs
+cursor_text_select_tool_label=Uirlis Roghnaithe Téacs
+cursor_hand_tool.title=Cumasaigh an Uirlis Láimhe
+cursor_hand_tool_label=Uirlis Láimhe
+
+
+
+# Document properties dialog box
+document_properties.title=Airíonna na Cáipéise…
+document_properties_label=Airíonna na Cáipéise…
+document_properties_file_name=Ainm an chomhaid:
+document_properties_file_size=Méid an chomhaid:
+# LOCALIZATION NOTE (document_properties_kb): "{{size_kb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in kilobytes, respectively in bytes.
+document_properties_kb={{size_kb}} kB ({{size_b}} beart)
+# LOCALIZATION NOTE (document_properties_mb): "{{size_mb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in megabytes, respectively in bytes.
+document_properties_mb={{size_mb}} MB ({{size_b}} beart)
+document_properties_title=Teideal:
+document_properties_author=Údar:
+document_properties_subject=Ábhar:
+document_properties_keywords=Eochairfhocail:
+document_properties_creation_date=Dáta Cruthaithe:
+document_properties_modification_date=Dáta Athraithe:
+# LOCALIZATION NOTE (document_properties_date_string): "{{date}}" and "{{time}}"
+# will be replaced by the creation/modification date, and time, of the PDF file.
+document_properties_date_string={{date}}, {{time}}
+document_properties_creator=Cruthaitheoir:
+document_properties_producer=Cruthaitheoir an PDF:
+document_properties_version=Leagan PDF:
+document_properties_page_count=Líon Leathanach:
+# LOCALIZATION NOTE (document_properties_page_size_dimension_string):
+# "{{width}}", "{{height}}", {{unit}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement and orientation, of the (current) page.
+# LOCALIZATION NOTE (document_properties_page_size_dimension_name_string):
+# "{{width}}", "{{height}}", {{unit}}, {{name}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement, name, and orientation, of the (current) page.
+# LOCALIZATION NOTE (document_properties_linearized): The linearization status of
+# the document; usually called "Fast Web View" in English locales of Adobe software.
+document_properties_close=Dún
+
+print_progress_message=Cáipéis á hullmhú le priontáil…
+# LOCALIZATION NOTE (print_progress_percent): "{{progress}}" will be replaced by
+# a numerical per cent value.
+print_progress_percent={{progress}}%
+print_progress_close=Cealaigh
+
+# Tooltips and alt text for side panel toolbar buttons
+# (the _label strings are alt text for the buttons, the .title strings are
+# tooltips)
+toggle_sidebar.title=Scoránaigh an Barra Taoibh
+toggle_sidebar_label=Scoránaigh an Barra Taoibh
+document_outline.title=Taispeáin Imlíne na Cáipéise (déchliceáil chun chuile rud a leathnú nó a laghdú)
+document_outline_label=Creatlach na Cáipéise
+attachments.title=Taispeáin Iatáin
+attachments_label=Iatáin
+thumbs.title=Taispeáin Mionsamhlacha
+thumbs_label=Mionsamhlacha
+findbar.title=Aimsigh sa Cháipéis
+findbar_label=Aimsigh
+
+# LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
+# Thumbnails panel item (tooltip and alt text for images)
+# LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
+# number.
+thumb_page_title=Leathanach {{page}}
+# LOCALIZATION NOTE (thumb_page_canvas): "{{page}}" will be replaced by the page
+# number.
+thumb_page_canvas=Mionsamhail Leathanaigh {{page}}
+
+# Find panel button title and messages
+find_input.title=Aimsigh
+find_input.placeholder=Aimsigh sa cháipéis…
+find_previous.title=Aimsigh an sampla roimhe seo den nath seo
+find_previous_label=Roimhe seo
+find_next.title=Aimsigh an chéad sampla eile den nath sin
+find_next_label=Ar aghaidh
+find_highlight=Aibhsigh uile
+find_match_case_label=Cásíogair
+find_entire_word_label=Focail iomlána
+find_reached_top=Ag barr na cáipéise, ag leanúint ón mbun
+find_reached_bottom=Ag bun na cáipéise, ag leanúint ón mbarr
+# LOCALIZATION NOTE (find_match_count): The supported plural forms are
+# [one|two|few|many|other], with [other] as the default value.
+# "{{current}}" and "{{total}}" will be replaced by a number representing the
+# index of the currently active find result, respectively a number representing
+# the total number of matches in the document.
+find_match_count={[ plural(total) ]}
+# LOCALIZATION NOTE (find_match_count_limit): The supported plural forms are
+# [zero|one|two|few|many|other], with [other] as the default value.
+# "{{limit}}" will be replaced by a numerical value.
+find_not_found=Frása gan aimsiú
+
+# Predefined zoom values
+page_scale_width=Leithead Leathanaigh
+page_scale_fit=Laghdaigh go dtí an Leathanach
+page_scale_auto=Súmáil Uathoibríoch
+page_scale_actual=Fíormhéid
+# LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
+# numerical scale value.
+page_scale_percent={{scale}}%
+
+# Loading indicator messages
+loading_error=Tharla earráid agus an cháipéis PDF á lódáil.
+invalid_file_error=Comhad neamhbhailí nó truaillithe PDF.
+missing_file_error=Comhad PDF ar iarraidh.
+unexpected_response_error=Freagra ón bhfreastalaí nach rabhthas ag súil leis.
+
+# LOCALIZATION NOTE (annotation_date_string): "{{date}}" and "{{time}}" will be
+# replaced by the modification date, and time, of the annotation.
+
+rendering_error=Tharla earráid agus an leathanach á leagan amach.
+
+# LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
+# "{{type}}" will be replaced with an annotation type from a list defined in
+# the PDF spec (32000-1:2008 Table 169 – Annotation types).
+# Some common types are e.g.: "Check", "Text", "Comment", "Note"
+text_annotation_type.alt=[Anótáil {{type}}]
+password_label=Cuir an focal faire isteach chun an comhad PDF seo a oscailt.
+password_invalid=Focal faire mícheart. Déan iarracht eile.
+password_ok=OK
+password_cancel=Cealaigh
+
+printing_not_supported=Rabhadh: Ní thacaíonn an brabhsálaí le priontáil go hiomlán.
+printing_not_ready=Rabhadh: Ní féidir an PDF a phriontáil go dtí go mbeidh an cháipéis iomlán lódáilte.
+web_fonts_disabled=Tá clófhoirne Gréasáin díchumasaithe: ní féidir clófhoirne leabaithe PDF a úsáid.
+

--- a/js/pdfjs/web/locale/gd/viewer.properties
+++ b/js/pdfjs/web/locale/gd/viewer.properties
@@ -1,0 +1,257 @@
+# Copyright 2012 Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Main toolbar buttons (tooltips and alt text for images)
+previous.title=An duilleag roimhe
+previous_label=Air ais
+next.title=An ath-dhuilleag
+next_label=Air adhart
+
+# LOCALIZATION NOTE (page.title): The tooltip for the pageNumber input.
+page.title=Duilleag
+# LOCALIZATION NOTE (of_pages): "{{pagesCount}}" will be replaced by a number
+# representing the total number of pages in the document.
+of_pages=à {{pagesCount}}
+# LOCALIZATION NOTE (page_of_pages): "{{pageNumber}}" and "{{pagesCount}}"
+# will be replaced by a number representing the currently visible page,
+# respectively a number representing the total number of pages in the document.
+page_of_pages=({{pageNumber}} à {{pagesCount}})
+
+zoom_out.title=Sùm a-mach
+zoom_out_label=Sùm a-mach
+zoom_in.title=Sùm a-steach
+zoom_in_label=Sùm a-steach
+zoom.title=Sùm
+presentation_mode.title=Gearr leum dhan mhodh taisbeanaidh
+presentation_mode_label=Am modh taisbeanaidh
+open_file.title=Fosgail faidhle
+open_file_label=Fosgail
+print.title=Clò-bhuail
+print_label=Clò-bhuail
+
+save.title=Sàbhail
+save_label=Sàbhail
+bookmark1.title=An duilleag làithreach (Seall an URL on duilleag làithreach)
+bookmark1_label=An duilleag làithreach
+
+open_in_app.title=Fosgail san aplacaid
+open_in_app_label=Fosgail san aplacaid
+
+# Secondary toolbar and context menu
+tools.title=Innealan
+tools_label=Innealan
+first_page.title=Rach gun chiad duilleag
+first_page_label=Rach gun chiad duilleag
+last_page.title=Rach gun duilleag mu dheireadh
+last_page_label=Rach gun duilleag mu dheireadh
+page_rotate_cw.title=Cuairtich gu deiseil
+page_rotate_cw_label=Cuairtich gu deiseil
+page_rotate_ccw.title=Cuairtich gu tuathail
+page_rotate_ccw_label=Cuairtich gu tuathail
+
+cursor_text_select_tool.title=Cuir an comas inneal taghadh an teacsa
+cursor_text_select_tool_label=Inneal taghadh an teacsa
+cursor_hand_tool.title=Cuir inneal na làimhe an comas
+cursor_hand_tool_label=Inneal na làimhe
+
+scroll_page.title=Cleachd sgroladh duilleige
+scroll_page_label=Sgroladh duilleige
+scroll_vertical.title=Cleachd sgroladh inghearach
+scroll_vertical_label=Sgroladh inghearach
+scroll_horizontal.title=Cleachd sgroladh còmhnard
+scroll_horizontal_label=Sgroladh còmhnard
+scroll_wrapped.title=Cleachd sgroladh paisgte
+scroll_wrapped_label=Sgroladh paisgte
+
+spread_none.title=Na cuir còmhla sgoileadh dhuilleagan
+spread_none_label=Gun sgaoileadh dhuilleagan
+spread_odd.title=Cuir còmhla duilleagan sgaoilte a thòisicheas le duilleagan aig a bheil àireamh chorr
+spread_odd_label=Sgaoileadh dhuilleagan corra
+spread_even.title=Cuir còmhla duilleagan sgaoilte a thòisicheas le duilleagan aig a bheil àireamh chothrom
+spread_even_label=Sgaoileadh dhuilleagan cothrom
+
+# Document properties dialog box
+document_properties.title=Roghainnean na sgrìobhainne…
+document_properties_label=Roghainnean na sgrìobhainne…
+document_properties_file_name=Ainm an fhaidhle:
+document_properties_file_size=Meud an fhaidhle:
+# LOCALIZATION NOTE (document_properties_kb): "{{size_kb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in kilobytes, respectively in bytes.
+document_properties_kb={{size_kb}} KB ({{size_b}} bytes)
+# LOCALIZATION NOTE (document_properties_mb): "{{size_mb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in megabytes, respectively in bytes.
+document_properties_mb={{size_mb}} MB ({{size_b}} bytes)
+document_properties_title=Tiotal:
+document_properties_author=Ùghdar:
+document_properties_subject=Cuspair:
+document_properties_keywords=Faclan-luirg:
+document_properties_creation_date=Latha a chruthachaidh:
+document_properties_modification_date=Latha atharrachaidh:
+# LOCALIZATION NOTE (document_properties_date_string): "{{date}}" and "{{time}}"
+# will be replaced by the creation/modification date, and time, of the PDF file.
+document_properties_date_string={{date}}, {{time}}
+document_properties_creator=Cruthadair:
+document_properties_producer=Saothraiche a' PDF:
+document_properties_version=Tionndadh a' PDF:
+document_properties_page_count=Àireamh de dhuilleagan:
+document_properties_page_size=Meud na duilleige:
+document_properties_page_size_unit_inches=ann an
+document_properties_page_size_unit_millimeters=mm
+document_properties_page_size_orientation_portrait=portraid
+document_properties_page_size_orientation_landscape=dreach-tìre
+document_properties_page_size_name_a3=A3
+document_properties_page_size_name_a4=A4
+document_properties_page_size_name_letter=Litir
+document_properties_page_size_name_legal=Laghail
+# LOCALIZATION NOTE (document_properties_page_size_dimension_string):
+# "{{width}}", "{{height}}", {{unit}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement and orientation, of the (current) page.
+document_properties_page_size_dimension_string={{width}} × {{height}} {{unit}} ({{orientation}})
+# LOCALIZATION NOTE (document_properties_page_size_dimension_name_string):
+# "{{width}}", "{{height}}", {{unit}}, {{name}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement, name, and orientation, of the (current) page.
+document_properties_page_size_dimension_name_string={{width}} × {{height}} {{unit}} ({{name}}, {{orientation}})
+# LOCALIZATION NOTE (document_properties_linearized): The linearization status of
+# the document; usually called "Fast Web View" in English locales of Adobe software.
+document_properties_linearized=Grad shealladh-lìn:
+document_properties_linearized_yes=Tha
+document_properties_linearized_no=Chan eil
+document_properties_close=Dùin
+
+print_progress_message=Ag ullachadh na sgrìobhainn airson clò-bhualadh…
+# LOCALIZATION NOTE (print_progress_percent): "{{progress}}" will be replaced by
+# a numerical per cent value.
+print_progress_percent={{progress}}%
+print_progress_close=Sguir dheth
+
+# Tooltips and alt text for side panel toolbar buttons
+# (the _label strings are alt text for the buttons, the .title strings are
+# tooltips)
+toggle_sidebar.title=Toglaich am bàr-taoibh
+toggle_sidebar_notification2.title=Toglaich am bàr-taoibh (tha oir-loidhne/ceanglachain/breathan aig an sgrìobhainn)
+toggle_sidebar_label=Toglaich am bàr-taoibh
+document_outline.title=Seall oir-loidhne na sgrìobhainn (dèan briogadh dùbailte airson a h-uile nì a leudachadh/a cho-theannadh)
+document_outline_label=Oir-loidhne na sgrìobhainne
+attachments.title=Seall na ceanglachain
+attachments_label=Ceanglachain
+layers.title=Seall na breathan (dèan briogadh dùbailte airson a h-uile breath ath-shuidheachadh dhan staid bhunaiteach)
+layers_label=Breathan
+thumbs.title=Seall na dealbhagan
+thumbs_label=Dealbhagan
+current_outline_item.title=Lorg nì làithreach na h-oir-loidhne
+current_outline_item_label=Nì làithreach na h-oir-loidhne
+findbar.title=Lorg san sgrìobhainn
+findbar_label=Lorg
+
+additional_layers=Barrachd breathan
+# LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
+page_landmark=Duilleag {{page}}
+# Thumbnails panel item (tooltip and alt text for images)
+# LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
+# number.
+thumb_page_title=Duilleag a {{page}}
+# LOCALIZATION NOTE (thumb_page_canvas): "{{page}}" will be replaced by the page
+# number.
+thumb_page_canvas=Dealbhag duilleag a {{page}}
+
+# Find panel button title and messages
+find_input.title=Lorg
+find_input.placeholder=Lorg san sgrìobhainn...
+find_previous.title=Lorg làthair roimhe na h-abairt seo
+find_previous_label=Air ais
+find_next.title=Lorg ath-làthair na h-abairt seo
+find_next_label=Air adhart
+find_highlight=Soillsich a h-uile
+find_match_case_label=Aire do litrichean mòra is beaga
+find_match_diacritics_label=Aire do stràcan
+find_entire_word_label=Faclan-slàna
+find_reached_top=Ràinig sinn barr na duilleige, a' leantainn air adhart o bhonn na duilleige
+find_reached_bottom=Ràinig sinn bonn na duilleige, a' leantainn air adhart o bharr na duilleige
+# LOCALIZATION NOTE (find_match_count): The supported plural forms are
+# [one|two|few|many|other], with [other] as the default value.
+# "{{current}}" and "{{total}}" will be replaced by a number representing the
+# index of the currently active find result, respectively a number representing
+# the total number of matches in the document.
+find_match_count={[ plural(total) ]}
+find_match_count[one]={{current}} à {{total}} mhaids
+find_match_count[two]={{current}} à {{total}} mhaids
+find_match_count[few]={{current}} à {{total}} maidsichean
+find_match_count[many]={{current}} à {{total}} maids
+find_match_count[other]={{current}} à {{total}} maids
+# LOCALIZATION NOTE (find_match_count_limit): The supported plural forms are
+# [zero|one|two|few|many|other], with [other] as the default value.
+# "{{limit}}" will be replaced by a numerical value.
+find_match_count_limit={[ plural(limit) ]}
+find_match_count_limit[zero]=Barrachd air {{limit}} maids
+find_match_count_limit[one]=Barrachd air {{limit}} mhaids
+find_match_count_limit[two]=Barrachd air {{limit}} mhaids
+find_match_count_limit[few]=Barrachd air {{limit}} maidsichean
+find_match_count_limit[many]=Barrachd air {{limit}} maids
+find_match_count_limit[other]=Barrachd air {{limit}} maids
+find_not_found=Cha deach an abairt a lorg
+
+# Predefined zoom values
+page_scale_width=Leud na duilleige
+page_scale_fit=Freagair ri meud na duilleige
+page_scale_auto=Sùm fèin-obrachail
+page_scale_actual=Am fìor-mheud
+# LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
+# numerical scale value.
+page_scale_percent={{scale}}%
+
+# Loading indicator messages
+loading_error=Thachair mearachd rè luchdadh a' PDF.
+invalid_file_error=Faidhle PDF a tha mì-dhligheach no coirbte.
+missing_file_error=Faidhle PDF a tha a dhìth.
+unexpected_response_error=Freagairt on fhrithealaiche ris nach robh dùil.
+
+rendering_error=Thachair mearachd rè reandaradh na duilleige.
+
+# LOCALIZATION NOTE (annotation_date_string): "{{date}}" and "{{time}}" will be
+# replaced by the modification date, and time, of the annotation.
+annotation_date_string={{date}}, {{time}}
+
+# LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
+# "{{type}}" will be replaced with an annotation type from a list defined in
+# the PDF spec (32000-1:2008 Table 169 – Annotation types).
+# Some common types are e.g.: "Check", "Text", "Comment", "Note"
+text_annotation_type.alt=[Nòtachadh {{type}}]
+password_label=Cuir a-steach am facal-faire gus am faidhle PDF seo fhosgladh.
+password_invalid=Tha am facal-faire cearr. Nach fheuch thu ris a-rithist?
+password_ok=Ceart ma-thà
+password_cancel=Sguir dheth
+
+printing_not_supported=Rabhadh: Chan eil am brabhsair seo a' cur làn-taic ri clò-bhualadh.
+printing_not_ready=Rabhadh: Cha deach am PDF a luchdadh gu tur airson clò-bhualadh.
+web_fonts_disabled=Tha cruthan-clò lìn à comas: Chan urrainn dhuinn cruthan-clò PDF leabaichte a chleachdadh.
+
+# Editor
+editor_free_text2.title=Teacsa
+editor_free_text2_label=Teacsa
+editor_ink2.title=Tarraing
+editor_ink2_label=Tarraing
+
+free_text2_default_content=Tòisich air sgrìobhadh…
+
+# Editor Parameters
+editor_free_text_color=Dath
+editor_free_text_size=Meud
+editor_ink_color=Dath
+editor_ink_thickness=Tighead
+editor_ink_opacity=Trìd-dhoilleireachd
+
+# Editor aria
+editor_free_text2_aria_label=An deasaiche teacsa
+editor_ink2_aria_label=An deasaiche tharraingean
+editor_ink_canvas_aria_label=Dealbh a chruthaich cleachdaiche

--- a/js/pdfjs/web/locale/gl/viewer.properties
+++ b/js/pdfjs/web/locale/gl/viewer.properties
@@ -1,0 +1,259 @@
+# Copyright 2012 Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Main toolbar buttons (tooltips and alt text for images)
+previous.title=Páxina anterior
+previous_label=Anterior
+next.title=Seguinte páxina
+next_label=Seguinte
+
+# LOCALIZATION NOTE (page.title): The tooltip for the pageNumber input.
+page.title=Páxina
+# LOCALIZATION NOTE (of_pages): "{{pagesCount}}" will be replaced by a number
+# representing the total number of pages in the document.
+of_pages=de {{pagesCount}}
+# LOCALIZATION NOTE (page_of_pages): "{{pageNumber}}" and "{{pagesCount}}"
+# will be replaced by a number representing the currently visible page,
+# respectively a number representing the total number of pages in the document.
+page_of_pages=({{pageNumber}} de {{pagesCount}})
+
+zoom_out.title=Reducir
+zoom_out_label=Reducir
+zoom_in.title=Ampliar
+zoom_in_label=Ampliar
+zoom.title=Zoom
+presentation_mode.title=Cambiar ao modo presentación
+presentation_mode_label=Modo presentación
+open_file.title=Abrir ficheiro
+open_file_label=Abrir
+print.title=Imprimir
+print_label=Imprimir
+save.title=Gardar
+save_label=Gardar
+bookmark1.title=Páxina actual (ver o URL da páxina actual)
+bookmark1_label=Páxina actual
+# LOCALIZATION NOTE (open_in_app.title): This string is used in Firefox for Android.
+open_in_app.title=Abrir cunha aplicación
+# LOCALIZATION NOTE (open_in_app_label): This string is used in Firefox for Android. Length of the translation matters since we are in a mobile context, with limited screen estate.
+open_in_app_label=Abrir cunha aplicación
+
+# Secondary toolbar and context menu
+tools.title=Ferramentas
+tools_label=Ferramentas
+first_page.title=Ir á primeira páxina
+first_page_label=Ir á primeira páxina
+last_page.title=Ir á última páxina
+last_page_label=Ir á última páxina
+page_rotate_cw.title=Rotar no sentido das agullas do reloxo
+page_rotate_cw_label=Rotar no sentido das agullas do reloxo
+page_rotate_ccw.title=Rotar no sentido contrario ás agullas do reloxo
+page_rotate_ccw_label=Rotar no sentido contrario ás agullas do reloxo
+
+cursor_text_select_tool.title=Activar a ferramenta de selección de texto
+cursor_text_select_tool_label=Ferramenta de selección de texto
+cursor_hand_tool.title=Activar a ferramenta de man
+cursor_hand_tool_label=Ferramenta de man
+
+scroll_page.title=Usar o desprazamento da páxina
+scroll_page_label=Desprazamento da páxina
+scroll_vertical.title=Usar o desprazamento vertical
+scroll_vertical_label=Desprazamento vertical
+scroll_horizontal.title=Usar o desprazamento horizontal
+scroll_horizontal_label=Desprazamento horizontal
+scroll_wrapped.title=Usar o desprazamento en bloque
+scroll_wrapped_label=Desprazamento por bloque
+
+spread_none.title=Non agrupar páxinas
+spread_none_label=Ningún agrupamento
+spread_odd.title=Crea grupo de páxinas que comezan con números de páxina impares
+spread_odd_label=Agrupamento impar
+spread_even.title=Crea grupo de páxinas que comezan con números de páxina pares
+spread_even_label=Agrupamento par
+
+# Document properties dialog box
+document_properties.title=Propiedades do documento…
+document_properties_label=Propiedades do documento…
+document_properties_file_name=Nome do ficheiro:
+document_properties_file_size=Tamaño do ficheiro:
+# LOCALIZATION NOTE (document_properties_kb): "{{size_kb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in kilobytes, respectively in bytes.
+document_properties_kb={{size_kb}} KB ({{size_b}} bytes)
+# LOCALIZATION NOTE (document_properties_mb): "{{size_mb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in megabytes, respectively in bytes.
+document_properties_mb={{size_mb}} MB ({{size_b}} bytes)
+document_properties_title=Título:
+document_properties_author=Autor:
+document_properties_subject=Asunto:
+document_properties_keywords=Palabras clave:
+document_properties_creation_date=Data de creación:
+document_properties_modification_date=Data de modificación:
+# LOCALIZATION NOTE (document_properties_date_string): "{{date}}" and "{{time}}"
+# will be replaced by the creation/modification date, and time, of the PDF file.
+document_properties_date_string={{date}}, {{time}}
+document_properties_creator=Creado por:
+document_properties_producer=Xenerador do PDF:
+document_properties_version=Versión de PDF:
+document_properties_page_count=Número de páxinas:
+document_properties_page_size=Tamaño da páxina:
+document_properties_page_size_unit_inches=pol
+document_properties_page_size_unit_millimeters=mm
+document_properties_page_size_orientation_portrait=vertical
+document_properties_page_size_orientation_landscape=horizontal
+document_properties_page_size_name_a3=A3
+document_properties_page_size_name_a4=A4
+document_properties_page_size_name_letter=Carta
+document_properties_page_size_name_legal=Legal
+# LOCALIZATION NOTE (document_properties_page_size_dimension_string):
+# "{{width}}", "{{height}}", {{unit}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement and orientation, of the (current) page.
+document_properties_page_size_dimension_string={{width}} × {{height}} {{unit}} ({{orientation}})
+# LOCALIZATION NOTE (document_properties_page_size_dimension_name_string):
+# "{{width}}", "{{height}}", {{unit}}, {{name}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement, name, and orientation, of the (current) page.
+document_properties_page_size_dimension_name_string={{width}} × {{height}} {{unit}} ({{name}}, {{orientation}})
+# LOCALIZATION NOTE (document_properties_linearized): The linearization status of
+# the document; usually called "Fast Web View" in English locales of Adobe software.
+document_properties_linearized=Visualización rápida das páxinas web:
+document_properties_linearized_yes=Si
+document_properties_linearized_no=Non
+document_properties_close=Pechar
+
+print_progress_message=Preparando o documento para imprimir…
+# LOCALIZATION NOTE (print_progress_percent): "{{progress}}" will be replaced by
+# a numerical per cent value.
+print_progress_percent={{progress}}%
+print_progress_close=Cancelar
+
+# Tooltips and alt text for side panel toolbar buttons
+# (the _label strings are alt text for the buttons, the .title strings are
+# tooltips)
+toggle_sidebar.title=Amosar/agochar a barra lateral
+toggle_sidebar_notification2.title=Alternar barra lateral (o documento contén esquema/anexos/capas)
+toggle_sidebar_label=Amosar/agochar a barra lateral
+document_outline.title=Amosar a estrutura do documento (dobre clic para expandir/contraer todos os elementos)
+document_outline_label=Estrutura do documento
+attachments.title=Amosar anexos
+attachments_label=Anexos
+layers.title=Mostrar capas (prema dúas veces para restaurar todas as capas o estado predeterminado)
+layers_label=Capas
+thumbs.title=Amosar miniaturas
+thumbs_label=Miniaturas
+current_outline_item.title=Atopar o elemento delimitado actualmente
+current_outline_item_label=Elemento delimitado actualmente
+findbar.title=Atopar no documento
+findbar_label=Atopar
+
+additional_layers=Capas adicionais
+# LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
+page_landmark=Páxina {{page}}
+# Thumbnails panel item (tooltip and alt text for images)
+# LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
+# number.
+thumb_page_title=Páxina {{page}}
+# LOCALIZATION NOTE (thumb_page_canvas): "{{page}}" will be replaced by the page
+# number.
+thumb_page_canvas=Miniatura da páxina {{page}}
+
+# Find panel button title and messages
+find_input.title=Atopar
+find_input.placeholder=Atopar no documento…
+find_previous.title=Atopar a anterior aparición da frase
+find_previous_label=Anterior
+find_next.title=Atopar a seguinte aparición da frase
+find_next_label=Seguinte
+find_highlight=Realzar todo
+find_match_case_label=Diferenciar maiúsculas de minúsculas
+find_match_diacritics_label=Distinguir os diacríticos
+find_entire_word_label=Palabras completas
+find_reached_top=Chegouse ao inicio do documento, continuar desde o final
+find_reached_bottom=Chegouse ao final do documento, continuar desde o inicio
+# LOCALIZATION NOTE (find_match_count): The supported plural forms are
+# [one|two|few|many|other], with [other] as the default value.
+# "{{current}}" and "{{total}}" will be replaced by a number representing the
+# index of the currently active find result, respectively a number representing
+# the total number of matches in the document.
+find_match_count={[ plural(total) ]}
+find_match_count[one]={{current}} de {{total}} coincidencia
+find_match_count[two]={{current}} de {{total}} coincidencias
+find_match_count[few]={{current}} de {{total}} coincidencias
+find_match_count[many]={{current}} de {{total}} coincidencias
+find_match_count[other]={{current}} de {{total}} coincidencias
+# LOCALIZATION NOTE (find_match_count_limit): The supported plural forms are
+# [zero|one|two|few|many|other], with [other] as the default value.
+# "{{limit}}" will be replaced by a numerical value.
+find_match_count_limit={[ plural(limit) ]}
+find_match_count_limit[zero]=Máis de {{limit}} coincidencias
+find_match_count_limit[one]=Máis de {{limit}} coincidencia
+find_match_count_limit[two]=Máis de {{limit}} coincidencias
+find_match_count_limit[few]=Máis de {{limit}} coincidencias
+find_match_count_limit[many]=Máis de {{limit}} coincidencias
+find_match_count_limit[other]=Máis de {{limit}} coincidencias
+find_not_found=Non se atopou a frase
+
+# Predefined zoom values
+page_scale_width=Largura da páxina
+page_scale_fit=Axuste de páxina
+page_scale_auto=Zoom automático
+page_scale_actual=Tamaño actual
+# LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
+# numerical scale value.
+page_scale_percent={{scale}}%
+
+# Loading indicator messages
+loading_error=Produciuse un erro ao cargar o PDF.
+invalid_file_error=Ficheiro PDF danado ou non válido.
+missing_file_error=Falta o ficheiro PDF.
+unexpected_response_error=Resposta inesperada do servidor.
+rendering_error=Produciuse un erro ao representar a páxina.
+
+# LOCALIZATION NOTE (annotation_date_string): "{{date}}" and "{{time}}" will be
+# replaced by the modification date, and time, of the annotation.
+annotation_date_string={{date}}, {{time}}
+
+# LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
+# "{{type}}" will be replaced with an annotation type from a list defined in
+# the PDF spec (32000-1:2008 Table 169 – Annotation types).
+# Some common types are e.g.: "Check", "Text", "Comment", "Note"
+text_annotation_type.alt=[Anotación {{type}}]
+password_label=Escriba o contrasinal para abrir este ficheiro PDF.
+password_invalid=Contrasinal incorrecto. Tente de novo.
+password_ok=Aceptar
+password_cancel=Cancelar
+
+printing_not_supported=Aviso: A impresión non é compatíbel de todo con este navegador.
+printing_not_ready=Aviso: O PDF non se cargou completamente para imprimirse.
+web_fonts_disabled=Desactiváronse as fontes web:  foi imposíbel usar as fontes incrustadas no PDF.
+
+# Editor
+editor_free_text2.title=Texto
+editor_free_text2_label=Texto
+editor_ink2.title=Debuxo
+editor_ink2_label=Debuxo
+
+editor_stamp.title=Engadir unha imaxe
+editor_stamp_label=Engadir unha imaxe
+
+free_text2_default_content=Comezar a teclear…
+
+# Editor Parameters
+editor_free_text_color=Cor
+editor_free_text_size=Tamaño
+editor_ink_color=Cor
+editor_ink_thickness=Grosor
+editor_ink_opacity=Opacidade
+
+# Editor aria
+editor_free_text2_aria_label=Editor de texto
+editor_ink2_aria_label=Editor de debuxos
+editor_ink_canvas_aria_label=Imaxe creada por unha usuaria

--- a/js/pdfjs/web/locale/gn/viewer.properties
+++ b/js/pdfjs/web/locale/gn/viewer.properties
@@ -1,0 +1,259 @@
+# Copyright 2012 Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Main toolbar buttons (tooltips and alt text for images)
+previous.title=Kuatiarogue mboyvegua
+previous_label=Mboyvegua
+next.title=Kuatiarogue upeigua
+next_label=Upeigua
+
+# LOCALIZATION NOTE (page.title): The tooltip for the pageNumber input.
+page.title=Kuatiarogue
+# LOCALIZATION NOTE (of_pages): "{{pagesCount}}" will be replaced by a number
+# representing the total number of pages in the document.
+of_pages={{pagesCount}} gui
+# LOCALIZATION NOTE (page_of_pages): "{{pageNumber}}" and "{{pagesCount}}"
+# will be replaced by a number representing the currently visible page,
+# respectively a number representing the total number of pages in the document.
+page_of_pages=({{pageNumber}} of {{pagesCount}})
+
+zoom_out.title=Momichĩ
+zoom_out_label=Momichĩ
+zoom_in.title=Mbotuicha
+zoom_in_label=Mbotuicha
+zoom.title=Tuichakue
+presentation_mode.title=Jehechauka reko moambue
+presentation_mode_label=Jehechauka reko
+open_file.title=Marandurendápe jeike
+open_file_label=Jeike
+print.title=Monguatia
+print_label=Monguatia
+save.title=Ñongatu
+save_label=Ñongatu
+bookmark1.title=Kuatiarogue ag̃agua (Ehecha URL kuatiarogue ag̃agua)
+bookmark1_label=Kuatiarogue Ag̃agua
+# LOCALIZATION NOTE (open_in_app.title): This string is used in Firefox for Android.
+open_in_app.title=Embojuruja tembipuru’ípe
+# LOCALIZATION NOTE (open_in_app_label): This string is used in Firefox for Android. Length of the translation matters since we are in a mobile context, with limited screen estate.
+open_in_app_label=Embojuruja tembipuru’ípe
+
+# Secondary toolbar and context menu
+tools.title=Tembipuru
+tools_label=Tembipuru
+first_page.title=Kuatiarogue ñepyrũme jeho
+first_page_label=Kuatiarogue ñepyrũme jeho
+last_page.title=Kuatiarogue pahápe jeho
+last_page_label=Kuatiarogue pahápe jeho
+page_rotate_cw.title=Aravóicha mbojere
+page_rotate_cw_label=Aravóicha mbojere
+page_rotate_ccw.title=Aravo rapykue gotyo mbojere
+page_rotate_ccw_label=Aravo rapykue gotyo mbojere
+
+cursor_text_select_tool.title=Emyandy moñe’ẽrã jeporavo rembipuru
+cursor_text_select_tool_label=Moñe’ẽrã jeporavo rembipuru
+cursor_hand_tool.title=Tembipuru po pegua myandy
+cursor_hand_tool_label=Tembipuru po pegua
+
+scroll_page.title=Eipuru kuatiarogue jeku’e
+scroll_page_label=Kuatiarogue jeku’e
+scroll_vertical.title=Eipuru jeku’e ykeguáva
+scroll_vertical_label=Jeku’e ykeguáva
+scroll_horizontal.title=Eipuru jeku’e yvate gotyo
+scroll_horizontal_label=Jeku’e yvate gotyo
+scroll_wrapped.title=Eipuru jeku’e mbohyrupyre
+scroll_wrapped_label=Jeku’e mbohyrupyre
+
+spread_none.title=Ani ejuaju spreads kuatiarogue ndive
+spread_none_label=Spreads ỹre
+spread_odd.title=Embojuaju kuatiarogue jepysokue eñepyrũvo kuatiarogue impar-vagui
+spread_odd_label=Spreads impar
+spread_even.title=Embojuaju kuatiarogue jepysokue eñepyrũvo kuatiarogue par-vagui
+spread_even_label=Ipukuve uvei
+
+# Document properties dialog box
+document_properties.title=Kuatia mba’etee…
+document_properties_label=Kuatia mba’etee…
+document_properties_file_name=Marandurenda réra:
+document_properties_file_size=Marandurenda tuichakue:
+# LOCALIZATION NOTE (document_properties_kb): "{{size_kb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in kilobytes, respectively in bytes.
+document_properties_kb={{size_kb}} KB ({{size_b}} bytes)
+# LOCALIZATION NOTE (document_properties_mb): "{{size_mb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in megabytes, respectively in bytes.
+document_properties_mb={{size_mb}} MB ({{size_b}} bytes)
+document_properties_title=Teratee:
+document_properties_author=Apohára:
+document_properties_subject=Mba’egua:
+document_properties_keywords=Jehero:
+document_properties_creation_date=Teñoihague arange:
+document_properties_modification_date=Iñambue hague arange:
+# LOCALIZATION NOTE (document_properties_date_string): "{{date}}" and "{{time}}"
+# will be replaced by the creation/modification date, and time, of the PDF file.
+document_properties_date_string={{date}}, {{time}}
+document_properties_creator=Apo’ypyha:
+document_properties_producer=PDF mbosako’iha:
+document_properties_version=PDF mbojuehegua:
+document_properties_page_count=Kuatiarogue papapy:
+document_properties_page_size=Kuatiarogue tuichakue:
+document_properties_page_size_unit_inches=Amo
+document_properties_page_size_unit_millimeters=mm
+document_properties_page_size_orientation_portrait=Oĩháicha
+document_properties_page_size_orientation_landscape=apaisado
+document_properties_page_size_name_a3=A3
+document_properties_page_size_name_a4=A4
+document_properties_page_size_name_letter=Kuatiañe’ẽ
+document_properties_page_size_name_legal=Tee
+# LOCALIZATION NOTE (document_properties_page_size_dimension_string):
+# "{{width}}", "{{height}}", {{unit}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement and orientation, of the (current) page.
+document_properties_page_size_dimension_string={{width}} × {{height}} {{unit}} ({{orientation}})
+# LOCALIZATION NOTE (document_properties_page_size_dimension_name_string):
+# "{{width}}", "{{height}}", {{unit}}, {{name}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement, name, and orientation, of the (current) page.
+document_properties_page_size_dimension_name_string={{width}} × {{height}} {{unit}} ({{name}}, {{orientation}})
+# LOCALIZATION NOTE (document_properties_linearized): The linearization status of
+# the document; usually called "Fast Web View" in English locales of Adobe software.
+document_properties_linearized=Ñanduti jahecha pya’e:
+document_properties_linearized_yes=Añete
+document_properties_linearized_no=Ahániri
+document_properties_close=Mboty
+
+print_progress_message=Embosako’i kuatia emonguatia hag̃ua…
+# LOCALIZATION NOTE (print_progress_percent): "{{progress}}" will be replaced by
+# a numerical per cent value.
+print_progress_percent={{progress}}%
+print_progress_close=Heja
+
+# Tooltips and alt text for side panel toolbar buttons
+# (the _label strings are alt text for the buttons, the .title strings are
+# tooltips)
+toggle_sidebar.title=Tenda yke moambue
+toggle_sidebar_notification2.title=Embojopyru tenda ykegua (kuatia oguereko kuaakaha/moirũha/ñuãha)
+toggle_sidebar_label=Tenda yke moambue
+document_outline.title=Ehechauka kuatia rape (eikutu mokõi jey embotuicha/emomichĩ hag̃ua opavavete mba’epuru)
+document_outline_label=Kuatia apopyre
+attachments.title=Moirũha jehechauka
+attachments_label=Moirũha
+layers.title=Ehechauka ñuãha (eikutu jo’a emomba’apo hag̃ua opaite ñuãha tekoypýpe)
+layers_label=Ñuãha
+thumbs.title=Mba’emirĩ jehechauka
+thumbs_label=Mba’emirĩ
+current_outline_item.title=Eheka mba’epuru ag̃aguaitéva
+current_outline_item_label=Mba’epuru ag̃aguaitéva
+findbar.title=Kuatiápe jeheka
+findbar_label=Juhu
+
+additional_layers=Ñuãha moirũguáva
+# LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
+page_landmark=Kuatiarogue {{page}}
+# Thumbnails panel item (tooltip and alt text for images)
+# LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
+# number.
+thumb_page_title=Kuatiarogue {{page}}
+# LOCALIZATION NOTE (thumb_page_canvas): "{{page}}" will be replaced by the page
+# number.
+thumb_page_canvas=Kuatiarogue mba’emirĩ {{page}}
+
+# Find panel button title and messages
+find_input.title=Juhu
+find_input.placeholder=Kuatiápe jejuhu…
+find_previous.title=Ejuhu ñe’ẽrysýi osẽ’ypy hague
+find_previous_label=Mboyvegua
+find_next.title=Eho ñe’ẽ juhupyre upeiguávape
+find_next_label=Upeigua
+find_highlight=Embojekuaavepa
+find_match_case_label=Ejesareko taiguasu/taimichĩre
+find_match_diacritics_label=Diacrítico moñondive
+find_entire_word_label=Ñe’ẽ oĩmbáva 
+find_reached_top=Ojehupyty kuatia ñepyrũ, oku’ejeýta kuatia paha guive
+find_reached_bottom=Ojehupyty kuatia paha, oku’ejeýta kuatia ñepyrũ guive
+# LOCALIZATION NOTE (find_match_count): The supported plural forms are
+# [one|two|few|many|other], with [other] as the default value.
+# "{{current}}" and "{{total}}" will be replaced by a number representing the
+# index of the currently active find result, respectively a number representing
+# the total number of matches in the document.
+find_match_count={[ plural(total) ]}
+find_match_count[one]={{current}} {{total}} ojojoguáva
+find_match_count[two]={{current}} {{total}} ojojoguáva
+find_match_count[few]={{current}} {{total}} ojojoguáva
+find_match_count[many]={{current}} {{total}} ojojoguáva
+find_match_count[other]={{current}} {{total}} ojojoguáva
+# LOCALIZATION NOTE (find_match_count_limit): The supported plural forms are
+# [zero|one|two|few|many|other], with [other] as the default value.
+# "{{limit}}" will be replaced by a numerical value.
+find_match_count_limit={[ plural(limit) ]}
+find_match_count_limit[zero]=Hetave {{limit}} ojojoguáva
+find_match_count_limit[one]=Hetave {{limit}} ojojogua
+find_match_count_limit[two]=Hetave {{limit}} ojojoguáva
+find_match_count_limit[few]=Hetave {{limit}} ojojoguáva
+find_match_count_limit[many]=Hetave {{limit}} ojojoguáva
+find_match_count_limit[other]=Hetave {{limit}} ojojoguáva
+find_not_found=Ñe’ẽrysýi ojejuhu’ỹva
+
+# Predefined zoom values
+page_scale_width=Kuatiarogue pekue
+page_scale_fit=Kuatiarogue ñemoĩporã
+page_scale_auto=Tuichakue ijeheguíva
+page_scale_actual=Tuichakue ag̃agua
+# LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
+# numerical scale value.
+page_scale_percent={{scale}}%
+
+# Loading indicator messages
+loading_error=Oiko jejavy PDF oñemyeñyhẽnguévo.
+invalid_file_error=PDF marandurenda ndoikóiva térã ivaipyréva.
+missing_file_error=Ndaipóri PDF marandurenda
+unexpected_response_error=Mohendahavusu mbohovái ñeha’arõ’ỹva.
+rendering_error=Oiko jejavy ehechaukasévo kuatiarogue.
+
+# LOCALIZATION NOTE (annotation_date_string): "{{date}}" and "{{time}}" will be
+# replaced by the modification date, and time, of the annotation.
+annotation_date_string={{date}}, {{time}}
+
+# LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
+# "{{type}}" will be replaced with an annotation type from a list defined in
+# the PDF spec (32000-1:2008 Table 169 – Annotation types).
+# Some common types are e.g.: "Check", "Text", "Comment", "Note"
+text_annotation_type.alt=[Jehaipy {{type}}]
+password_label=Emoinge ñe’ẽñemi eipe’a hag̃ua ko marandurenda PDF.
+password_invalid=Ñe’ẽñemi ndoikóiva. Eha’ã jey.
+password_ok=MONEĨ
+password_cancel=Heja
+
+printing_not_supported=Kyhyjerã: Ñembokuatia ndojokupytypái ko kundahára ndive.
+printing_not_ready=Kyhyjerã: Ko PDF nahenyhẽmbái oñembokuatia hag̃uáicha.
+web_fonts_disabled=Ñanduti taity oñemongéma: ndaikatumo’ãi eipuru PDF jehai’íva taity.
+
+# Editor
+editor_free_text2.title=Moñe’ẽrã
+editor_free_text2_label=Moñe’ẽrã
+editor_ink2.title=Moha’ãnga
+editor_ink2_label=Moha’ãnga
+
+editor_stamp.title=Embojuaju ta’ãnga
+editor_stamp_label=Embojuaju ta’ãnga
+
+free_text2_default_content=Ehai ñepyrũ…
+
+# Editor Parameters
+editor_free_text_color=Sa’y
+editor_free_text_size=Tuichakue
+editor_ink_color=Sa’y
+editor_ink_thickness=Anambusu
+editor_ink_opacity=Pytũngy
+
+# Editor aria
+editor_free_text2_aria_label=Moñe’ẽrã moheñoiha
+editor_ink2_aria_label=Ta’ãnga moheñoiha
+editor_ink_canvas_aria_label=Ta’ãnga omoheñóiva puruhára

--- a/js/pdfjs/web/locale/gu-IN/viewer.properties
+++ b/js/pdfjs/web/locale/gu-IN/viewer.properties
@@ -1,0 +1,214 @@
+# Copyright 2012 Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Main toolbar buttons (tooltips and alt text for images)
+previous.title=પહેલાનુ પાનું
+previous_label=પહેલાનુ
+next.title=આગળનુ પાનું
+next_label=આગળનું
+
+# LOCALIZATION NOTE (page.title): The tooltip for the pageNumber input.
+page.title=પાનું
+# LOCALIZATION NOTE (of_pages): "{{pagesCount}}" will be replaced by a number
+# representing the total number of pages in the document.
+of_pages=નો {{pagesCount}}
+# LOCALIZATION NOTE (page_of_pages): "{{pageNumber}}" and "{{pagesCount}}"
+# will be replaced by a number representing the currently visible page,
+# respectively a number representing the total number of pages in the document.
+page_of_pages=({{pageNumber}} નો {{pagesCount}})
+
+zoom_out.title=મોટુ કરો
+zoom_out_label=મોટુ કરો
+zoom_in.title=નાનું કરો
+zoom_in_label=નાનું કરો
+zoom.title=નાનું મોટુ કરો
+presentation_mode.title=રજૂઆત સ્થિતિમાં જાવ
+presentation_mode_label=રજૂઆત સ્થિતિ
+open_file.title=ફાઇલ ખોલો
+open_file_label=ખોલો
+print.title=છાપો
+print_label=છારો
+
+# Secondary toolbar and context menu
+tools.title=સાધનો
+tools_label=સાધનો
+first_page.title=પહેલાં પાનામાં જાવ
+first_page_label=પ્રથમ પાનાં પર જાવ
+last_page.title=છેલ્લા પાનાં પર જાવ
+last_page_label=છેલ્લા પાનાં પર જાવ
+page_rotate_cw.title=ઘડિયાળનાં કાંટા તરફ ફેરવો
+page_rotate_cw_label=ઘડિયાળનાં કાંટા તરફ ફેરવો
+page_rotate_ccw.title=ઘડિયાળનાં કાંટાની ઉલટી દિશામાં ફેરવો
+page_rotate_ccw_label=ઘડિયાળનાં કાંટાની વિરુદ્દ ફેરવો
+
+cursor_text_select_tool.title=ટેક્સ્ટ પસંદગી ટૂલ સક્ષમ કરો
+cursor_text_select_tool_label=ટેક્સ્ટ પસંદગી ટૂલ
+cursor_hand_tool.title=હાથનાં સાધનને સક્રિય કરો
+cursor_hand_tool_label=હેન્ડ ટૂલ
+
+scroll_vertical.title=ઊભી સ્ક્રોલિંગનો ઉપયોગ કરો
+scroll_vertical_label=ઊભી સ્ક્રોલિંગ
+scroll_horizontal.title=આડી સ્ક્રોલિંગનો ઉપયોગ કરો
+scroll_horizontal_label=આડી સ્ક્રોલિંગ
+scroll_wrapped.title=આવરિત સ્ક્રોલિંગનો ઉપયોગ કરો
+scroll_wrapped_label=આવરિત સ્ક્રોલિંગ
+
+spread_none.title=પૃષ્ઠ સ્પ્રેડમાં જોડાવશો નહીં
+spread_none_label=કોઈ સ્પ્રેડ નથી
+spread_odd.title=એકી-ક્રમાંકિત પૃષ્ઠો સાથે પ્રારંભ થતાં પૃષ્ઠ સ્પ્રેડમાં જોડાઓ
+spread_odd_label=એકી સ્પ્રેડ્સ
+spread_even.title=નંબર-ક્રમાંકિત પૃષ્ઠોથી શરૂ થતાં પૃષ્ઠ સ્પ્રેડમાં જોડાઓ
+spread_even_label=સરખું ફેલાવવું
+
+# Document properties dialog box
+document_properties.title=દસ્તાવેજ ગુણધર્મો…
+document_properties_label=દસ્તાવેજ ગુણધર્મો…
+document_properties_file_name=ફાઇલ નામ:
+document_properties_file_size=ફાઇલ માપ:
+# LOCALIZATION NOTE (document_properties_kb): "{{size_kb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in kilobytes, respectively in bytes.
+document_properties_kb={{size_kb}} KB ({{size_b}} બાઇટ)
+# LOCALIZATION NOTE (document_properties_mb): "{{size_mb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in megabytes, respectively in bytes.
+document_properties_mb={{size_mb}} MB ({{size_b}} બાઇટ)
+document_properties_title=શીર્ષક:
+document_properties_author=લેખક:
+document_properties_subject=વિષય:
+document_properties_keywords=કિવર્ડ:
+document_properties_creation_date=નિર્માણ તારીખ:
+document_properties_modification_date=ફેરફાર તારીખ:
+# LOCALIZATION NOTE (document_properties_date_string): "{{date}}" and "{{time}}"
+# will be replaced by the creation/modification date, and time, of the PDF file.
+document_properties_date_string={{date}}, {{time}}
+document_properties_creator=નિર્માતા:
+document_properties_producer=PDF નિર્માતા:
+document_properties_version=PDF આવૃત્તિ:
+document_properties_page_count=પાનાં ગણતરી:
+document_properties_page_size=પૃષ્ઠનું કદ:
+document_properties_page_size_unit_inches=ઇંચ
+document_properties_page_size_unit_millimeters=મીમી
+document_properties_page_size_orientation_portrait=ઉભું
+document_properties_page_size_orientation_landscape=આડુ
+document_properties_page_size_name_a3=A3
+document_properties_page_size_name_a4=A4
+document_properties_page_size_name_letter=પત્ર
+document_properties_page_size_name_legal=કાયદાકીય
+# LOCALIZATION NOTE (document_properties_page_size_dimension_string):
+# "{{width}}", "{{height}}", {{unit}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement and orientation, of the (current) page.
+document_properties_page_size_dimension_string={{width}} × {{height}} {{unit}} ({{orientation}})
+# LOCALIZATION NOTE (document_properties_page_size_dimension_name_string):
+# "{{width}}", "{{height}}", {{unit}}, {{name}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement, name, and orientation, of the (current) page.
+document_properties_page_size_dimension_name_string={{width}} × {{height}} {{unit}} ({{name}}, {{orientation}})
+# LOCALIZATION NOTE (document_properties_linearized): The linearization status of
+# the document; usually called "Fast Web View" in English locales of Adobe software.
+document_properties_linearized=ઝડપી વૅબ દૃશ્ય:
+document_properties_linearized_yes=હા
+document_properties_linearized_no=ના
+document_properties_close=બંધ કરો
+
+print_progress_message=છાપકામ માટે દસ્તાવેજ તૈયાર કરી રહ્યા છે…
+# LOCALIZATION NOTE (print_progress_percent): "{{progress}}" will be replaced by
+# a numerical per cent value.
+print_progress_percent={{progress}}%
+print_progress_close=રદ કરો
+
+# Tooltips and alt text for side panel toolbar buttons
+# (the _label strings are alt text for the buttons, the .title strings are
+# tooltips)
+toggle_sidebar.title=ટૉગલ બાજુપટ્ટી
+toggle_sidebar_label=ટૉગલ બાજુપટ્ટી
+document_outline.title=દસ્તાવેજની રૂપરેખા બતાવો(બધી આઇટમ્સને વિસ્તૃત/સંકુચિત કરવા માટે ડબલ-ક્લિક કરો)
+document_outline_label=દસ્તાવેજ રૂપરેખા
+attachments.title=જોડાણોને બતાવો
+attachments_label=જોડાણો
+thumbs.title=થંબનેલ્સ બતાવો
+thumbs_label=થંબનેલ્સ
+findbar.title=દસ્તાવેજમાં શોધો
+findbar_label=શોધો
+
+# Thumbnails panel item (tooltip and alt text for images)
+# LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
+# number.
+thumb_page_title=પાનું {{page}}
+# LOCALIZATION NOTE (thumb_page_canvas): "{{page}}" will be replaced by the page
+# number.
+thumb_page_canvas=પાનાં {{page}} નું થંબનેલ્સ
+
+# Find panel button title and messages
+find_input.title=શોધો
+find_input.placeholder=દસ્તાવેજમાં શોધો…
+find_previous.title=શબ્દસમૂહની પાછલી ઘટનાને શોધો
+find_previous_label=પહેલાંનુ
+find_next.title=શબ્દસમૂહની આગળની ઘટનાને શોધો
+find_next_label=આગળનું
+find_highlight=બધુ પ્રકાશિત કરો
+find_match_case_label=કેસ બંધબેસાડો
+find_entire_word_label=સંપૂર્ણ શબ્દો
+find_reached_top=દસ્તાવેજનાં ટોચે પહોંચી ગયા, તળિયેથી ચાલુ કરેલ હતુ
+find_reached_bottom=દસ્તાવેજનાં અંતે પહોંચી ગયા, ઉપરથી ચાલુ કરેલ હતુ
+# LOCALIZATION NOTE (find_match_count): The supported plural forms are
+# [one|two|few|many|other], with [other] as the default value.
+# "{{current}}" and "{{total}}" will be replaced by a number representing the
+# index of the currently active find result, respectively a number representing
+# the total number of matches in the document.
+find_match_count={[ plural(total) ]}
+find_match_count[one]={{total}} માંથી {{current}} સરખું મળ્યું
+find_match_count[two]={{total}} માંથી {{current}} સરખા મળ્યાં
+find_match_count[few]={{total}} માંથી {{current}} સરખા મળ્યાં
+find_match_count[many]={{total}} માંથી {{current}} સરખા મળ્યાં
+find_match_count[other]={{total}} માંથી {{current}} સરખા મળ્યાં
+# LOCALIZATION NOTE (find_match_count_limit): The supported plural forms are
+# [zero|one|two|few|many|other], with [other] as the default value.
+# "{{limit}}" will be replaced by a numerical value.
+find_match_count_limit={[ plural(limit) ]}
+find_match_count_limit[zero]={{limit}} કરતાં વધુ સરખા મળ્યાં
+find_match_count_limit[one]={{limit}} કરતાં વધુ સરખું મળ્યું
+find_match_count_limit[two]={{limit}} કરતાં વધુ સરખા મળ્યાં
+find_match_count_limit[few]={{limit}} કરતાં વધુ સરખા મળ્યાં
+find_match_count_limit[many]={{limit}} કરતાં વધુ સરખા મળ્યાં
+find_match_count_limit[other]={{limit}} કરતાં વધુ સરખા મળ્યાં
+find_not_found=શબ્દસમૂહ મળ્યુ નથી
+
+# Predefined zoom values
+page_scale_width=પાનાની પહોળાઇ
+page_scale_fit=પાનું બંધબેસતુ
+page_scale_auto=આપમેળે નાનુંમોટુ કરો
+page_scale_actual=ચોક્કસ માપ
+# LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
+# numerical scale value.
+page_scale_percent={{scale}}%
+
+loading_error=ભૂલ ઉદ્ભવી જ્યારે PDF ને લાવી રહ્યા હોય.
+invalid_file_error=અયોગ્ય અથવા ભાંગેલ PDF ફાઇલ.
+missing_file_error=ગુમ થયેલ PDF ફાઇલ.
+unexpected_response_error=અનપેક્ષિત સર્વર પ્રતિસાદ.
+
+rendering_error=ભૂલ ઉદ્ભવી જ્યારે પાનાંનુ રેન્ડ કરી રહ્યા હોય.
+
+# LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
+# "{{type}}" will be replaced with an annotation type from a list defined in
+# the PDF spec (32000-1:2008 Table 169 – Annotation types).
+# Some common types are e.g.: "Check", "Text", "Comment", "Note"
+text_annotation_type.alt=[{{type}} Annotation]
+password_label=આ PDF ફાઇલને ખોલવા પાસવર્ડને દાખલ કરો.
+password_invalid=અયોગ્ય પાસવર્ડ. મહેરબાની કરીને ફરી પ્રયત્ન કરો.
+password_ok=બરાબર
+password_cancel=રદ કરો
+
+printing_not_supported=ચેતવણી: છાપવાનું આ બ્રાઉઝર દ્દારા સંપૂર્ણપણે આધારભૂત નથી.
+printing_not_ready=Warning: PDF એ છાપવા માટે સંપૂર્ણપણે લાવેલ છે.
+web_fonts_disabled=વેબ ફોન્ટ નિષ્ક્રિય થયેલ છે: ઍમ્બેડ થયેલ PDF ફોન્ટને વાપરવાનું અસમર્થ.
+

--- a/js/pdfjs/web/locale/he/viewer.properties
+++ b/js/pdfjs/web/locale/he/viewer.properties
@@ -1,0 +1,258 @@
+# Copyright 2012 Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Main toolbar buttons (tooltips and alt text for images)
+previous.title=דף קודם
+previous_label=קודם
+next.title=דף הבא
+next_label=הבא
+
+# LOCALIZATION NOTE (page.title): The tooltip for the pageNumber input.
+page.title=דף
+# LOCALIZATION NOTE (of_pages): "{{pagesCount}}" will be replaced by a number
+# representing the total number of pages in the document.
+of_pages=מתוך {{pagesCount}}
+# LOCALIZATION NOTE (page_of_pages): "{{pageNumber}}" and "{{pagesCount}}"
+# will be replaced by a number representing the currently visible page,
+# respectively a number representing the total number of pages in the document.
+page_of_pages=({{pageNumber}} מתוך {{pagesCount}})
+
+zoom_out.title=התרחקות
+zoom_out_label=התרחקות
+zoom_in.title=התקרבות
+zoom_in_label=התקרבות
+zoom.title=מרחק מתצוגה
+presentation_mode.title=מעבר למצב מצגת
+presentation_mode_label=מצב מצגת
+open_file.title=פתיחת קובץ
+open_file_label=פתיחה
+print.title=הדפסה
+print_label=הדפסה
+save.title=שמירה
+save_label=שמירה
+bookmark1_label=עמוד נוכחי
+# LOCALIZATION NOTE (open_in_app.title): This string is used in Firefox for Android.
+open_in_app.title=פתיחה ביישום
+# LOCALIZATION NOTE (open_in_app_label): This string is used in Firefox for Android. Length of the translation matters since we are in a mobile context, with limited screen estate.
+open_in_app_label=פתיחה ביישום
+
+# Secondary toolbar and context menu
+tools.title=כלים
+tools_label=כלים
+first_page.title=מעבר לעמוד הראשון
+first_page_label=מעבר לעמוד הראשון
+last_page.title=מעבר לעמוד האחרון
+last_page_label=מעבר לעמוד האחרון
+page_rotate_cw.title=הטיה עם כיוון השעון
+page_rotate_cw_label=הטיה עם כיוון השעון
+page_rotate_ccw.title=הטיה כנגד כיוון השעון
+page_rotate_ccw_label=הטיה כנגד כיוון השעון
+
+cursor_text_select_tool.title=הפעלת כלי בחירת טקסט
+cursor_text_select_tool_label=כלי בחירת טקסט
+cursor_hand_tool.title=הפעלת כלי היד
+cursor_hand_tool_label=כלי יד
+
+scroll_page.title=שימוש בגלילת עמוד
+scroll_page_label=גלילת עמוד
+scroll_vertical.title=שימוש בגלילה אנכית
+scroll_vertical_label=גלילה אנכית
+scroll_horizontal.title=שימוש בגלילה אופקית
+scroll_horizontal_label=גלילה אופקית
+scroll_wrapped.title=שימוש בגלילה רציפה
+scroll_wrapped_label=גלילה רציפה
+
+spread_none.title=לא לצרף מפתחי עמודים
+spread_none_label=ללא מפתחים
+spread_odd.title=צירוף מפתחי עמודים שמתחילים בדפים עם מספרים אי־זוגיים
+spread_odd_label=מפתחים אי־זוגיים
+spread_even.title=צירוף מפתחי עמודים שמתחילים בדפים עם מספרים זוגיים
+spread_even_label=מפתחים זוגיים
+
+# Document properties dialog box
+document_properties.title=מאפייני מסמך…
+document_properties_label=מאפייני מסמך…
+document_properties_file_name=שם קובץ:
+document_properties_file_size=גודל הקובץ:
+# LOCALIZATION NOTE (document_properties_kb): "{{size_kb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in kilobytes, respectively in bytes.
+document_properties_kb={{size_kb}} ק״ב ({{size_b}} בתים)
+# LOCALIZATION NOTE (document_properties_mb): "{{size_mb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in megabytes, respectively in bytes.
+document_properties_mb={{size_mb}} מ״ב ({{size_b}} בתים)
+document_properties_title=כותרת:
+document_properties_author=מחבר:
+document_properties_subject=נושא:
+document_properties_keywords=מילות מפתח:
+document_properties_creation_date=תאריך יצירה:
+document_properties_modification_date=תאריך שינוי:
+# LOCALIZATION NOTE (document_properties_date_string): "{{date}}" and "{{time}}"
+# will be replaced by the creation/modification date, and time, of the PDF file.
+document_properties_date_string={{date}}, {{time}}
+document_properties_creator=יוצר:
+document_properties_producer=יצרן PDF:
+document_properties_version=גרסת PDF:
+document_properties_page_count=מספר דפים:
+document_properties_page_size=גודל העמוד:
+document_properties_page_size_unit_inches=אינ׳
+document_properties_page_size_unit_millimeters=מ״מ
+document_properties_page_size_orientation_portrait=לאורך
+document_properties_page_size_orientation_landscape=לרוחב
+document_properties_page_size_name_a3=A3
+document_properties_page_size_name_a4=A4
+document_properties_page_size_name_letter=מכתב
+document_properties_page_size_name_legal=דף משפטי
+# LOCALIZATION NOTE (document_properties_page_size_dimension_string):
+# "{{width}}", "{{height}}", {{unit}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement and orientation, of the (current) page.
+document_properties_page_size_dimension_string={{width}} × {{height}} {{unit}} ({{orientation}})
+# LOCALIZATION NOTE (document_properties_page_size_dimension_name_string):
+# "{{width}}", "{{height}}", {{unit}}, {{name}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement, name, and orientation, of the (current) page.
+document_properties_page_size_dimension_name_string={{width}} × {{height}} {{unit}} ({{name}}, {{orientation}})
+# LOCALIZATION NOTE (document_properties_linearized): The linearization status of
+# the document; usually called "Fast Web View" in English locales of Adobe software.
+document_properties_linearized=תצוגת דף מהירה:
+document_properties_linearized_yes=כן
+document_properties_linearized_no=לא
+document_properties_close=סגירה
+
+print_progress_message=מסמך בהכנה להדפסה…
+# LOCALIZATION NOTE (print_progress_percent): "{{progress}}" will be replaced by
+# a numerical per cent value.
+print_progress_percent={{progress}}%
+print_progress_close=ביטול
+
+# Tooltips and alt text for side panel toolbar buttons
+# (the _label strings are alt text for the buttons, the .title strings are
+# tooltips)
+toggle_sidebar.title=הצגה/הסתרה של סרגל הצד
+toggle_sidebar_notification2.title=החלפת תצוגת סרגל צד (מסמך שמכיל תוכן עניינים/קבצים מצורפים/שכבות)
+toggle_sidebar_label=הצגה/הסתרה של סרגל הצד
+document_outline.title=הצגת תוכן העניינים של המסמך (לחיצה כפולה כדי להרחיב או לצמצם את כל הפריטים)
+document_outline_label=תוכן העניינים של המסמך
+attachments.title=הצגת צרופות
+attachments_label=צרופות
+layers.title=הצגת שכבות (יש ללחוץ לחיצה כפולה כדי לאפס את כל השכבות למצב ברירת המחדל)
+layers_label=שכבות
+thumbs.title=הצגת תצוגה מקדימה
+thumbs_label=תצוגה מקדימה
+current_outline_item.title=מציאת פריט תוכן העניינים הנוכחי
+current_outline_item_label=פריט תוכן העניינים הנוכחי
+findbar.title=חיפוש במסמך
+findbar_label=חיפוש
+
+additional_layers=שכבות נוספות
+# LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
+page_landmark=עמוד {{page}}
+# Thumbnails panel item (tooltip and alt text for images)
+# LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
+# number.
+thumb_page_title=עמוד {{page}}
+# LOCALIZATION NOTE (thumb_page_canvas): "{{page}}" will be replaced by the page
+# number.
+thumb_page_canvas=תצוגה מקדימה של עמוד {{page}}
+
+# Find panel button title and messages
+find_input.title=חיפוש
+find_input.placeholder=חיפוש במסמך…
+find_previous.title=מציאת המופע הקודם של הביטוי
+find_previous_label=קודם
+find_next.title=מציאת המופע הבא של הביטוי
+find_next_label=הבא
+find_highlight=הדגשת הכול
+find_match_case_label=התאמת אותיות
+find_match_diacritics_label=התאמה דיאקריטית
+find_entire_word_label=מילים שלמות
+find_reached_top=הגיע לראש הדף, ממשיך מלמטה
+find_reached_bottom=הגיע לסוף הדף, ממשיך מלמעלה
+# LOCALIZATION NOTE (find_match_count): The supported plural forms are
+# [one|two|few|many|other], with [other] as the default value.
+# "{{current}}" and "{{total}}" will be replaced by a number representing the
+# index of the currently active find result, respectively a number representing
+# the total number of matches in the document.
+find_match_count={[ plural(total) ]}
+find_match_count[one]=תוצאה {{current}} מתוך {{total}}
+find_match_count[two]={{current}} מתוך {{total}} תוצאות
+find_match_count[few]={{current}} מתוך {{total}} תוצאות
+find_match_count[many]={{current}} מתוך {{total}} תוצאות
+find_match_count[other]={{current}} מתוך {{total}} תוצאות
+# LOCALIZATION NOTE (find_match_count_limit): The supported plural forms are
+# [zero|one|two|few|many|other], with [other] as the default value.
+# "{{limit}}" will be replaced by a numerical value.
+find_match_count_limit={[ plural(limit) ]}
+find_match_count_limit[zero]=יותר מ־{{limit}} תוצאות
+find_match_count_limit[one]=יותר מתוצאה אחת
+find_match_count_limit[two]=יותר מ־{{limit}} תוצאות
+find_match_count_limit[few]=יותר מ־{{limit}} תוצאות
+find_match_count_limit[many]=יותר מ־{{limit}} תוצאות
+find_match_count_limit[other]=יותר מ־{{limit}} תוצאות
+find_not_found=הביטוי לא נמצא
+
+# Predefined zoom values
+page_scale_width=רוחב העמוד
+page_scale_fit=התאמה לעמוד
+page_scale_auto=מרחק מתצוגה אוטומטי
+page_scale_actual=גודל אמיתי
+# LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
+# numerical scale value.
+page_scale_percent={{scale}}%
+
+# Loading indicator messages
+loading_error=אירעה שגיאה בעת טעינת ה־PDF.
+invalid_file_error=קובץ PDF פגום או לא תקין.
+missing_file_error=קובץ PDF חסר.
+unexpected_response_error=תגובת שרת לא צפויה.
+rendering_error=אירעה שגיאה בעת עיבוד הדף.
+
+# LOCALIZATION NOTE (annotation_date_string): "{{date}}" and "{{time}}" will be
+# replaced by the modification date, and time, of the annotation.
+annotation_date_string={{date}}, {{time}}
+
+# LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
+# "{{type}}" will be replaced with an annotation type from a list defined in
+# the PDF spec (32000-1:2008 Table 169 – Annotation types).
+# Some common types are e.g.: "Check", "Text", "Comment", "Note"
+text_annotation_type.alt=[הערת {{type}}]
+password_label=נא להכניס את הססמה לפתיחת קובץ PDF זה.
+password_invalid=ססמה שגויה. נא לנסות שנית.
+password_ok=אישור
+password_cancel=ביטול
+
+printing_not_supported=אזהרה: הדפסה אינה נתמכת במלואה בדפדפן זה.
+printing_not_ready=אזהרה: מסמך ה־PDF לא נטען לחלוטין עד מצב שמאפשר הדפסה.
+web_fonts_disabled=גופני רשת מנוטרלים: לא ניתן להשתמש בגופני PDF מוטבעים.
+
+# Editor
+editor_free_text2.title=טקסט
+editor_free_text2_label=טקסט
+editor_ink2.title=ציור
+editor_ink2_label=ציור
+
+editor_stamp.title=הוספת תמונה
+editor_stamp_label=הוספת תמונה
+
+free_text2_default_content=להתחיל להקליד…
+
+# Editor Parameters
+editor_free_text_color=צבע
+editor_free_text_size=גודל
+editor_ink_color=צבע
+editor_ink_thickness=עובי
+editor_ink_opacity=אטימות
+
+# Editor aria
+editor_free_text2_aria_label=עורך טקסט
+editor_ink2_aria_label=עורך ציור
+editor_ink_canvas_aria_label=תמונה שנוצרה על־ידי משתמש

--- a/js/pdfjs/web/locale/hi-IN/viewer.properties
+++ b/js/pdfjs/web/locale/hi-IN/viewer.properties
@@ -1,0 +1,214 @@
+# Copyright 2012 Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Main toolbar buttons (tooltips and alt text for images)
+previous.title=पिछला पृष्ठ
+previous_label=पिछला
+next.title=अगला पृष्ठ
+next_label=आगे
+
+# LOCALIZATION NOTE (page.title): The tooltip for the pageNumber input.
+page.title=पृष्ठ:
+# LOCALIZATION NOTE (of_pages): "{{pagesCount}}" will be replaced by a number
+# representing the total number of pages in the document.
+of_pages={{pagesCount}} का
+# LOCALIZATION NOTE (page_of_pages): "{{pageNumber}}" and "{{pagesCount}}"
+# will be replaced by a number representing the currently visible page,
+# respectively a number representing the total number of pages in the document.
+page_of_pages=({{pageNumber}} of {{pagesCount}})
+
+zoom_out.title=\u0020छोटा करें
+zoom_out_label=\u0020छोटा करें
+zoom_in.title=बड़ा करें
+zoom_in_label=बड़ा करें
+zoom.title=बड़ा-छोटा करें
+presentation_mode.title=प्रस्तुति अवस्था में जाएँ
+presentation_mode_label=\u0020प्रस्तुति अवस्था
+open_file.title=फ़ाइल खोलें
+open_file_label=\u0020खोलें
+print.title=छापें
+print_label=\u0020छापें
+
+# Secondary toolbar and context menu
+tools.title=औज़ार
+tools_label=औज़ार
+first_page.title=प्रथम पृष्ठ पर जाएँ
+first_page_label=प्रथम पृष्ठ पर जाएँ
+last_page.title=अंतिम पृष्ठ पर जाएँ
+last_page_label=\u0020अंतिम पृष्ठ पर जाएँ
+page_rotate_cw.title=घड़ी की दिशा में घुमाएँ
+page_rotate_cw_label=घड़ी की दिशा में घुमाएँ
+page_rotate_ccw.title=घड़ी की दिशा से उल्टा घुमाएँ
+page_rotate_ccw_label=\u0020घड़ी की दिशा से उल्टा घुमाएँ
+
+cursor_text_select_tool.title=पाठ चयन उपकरण सक्षम करें
+cursor_text_select_tool_label=पाठ चयन उपकरण
+cursor_hand_tool.title=हस्त उपकरण सक्षम करें
+cursor_hand_tool_label=हस्त उपकरण
+
+scroll_vertical.title=लंबवत स्क्रॉलिंग का उपयोग करें
+scroll_vertical_label=लंबवत स्क्रॉलिंग
+scroll_horizontal.title=क्षितिजिय स्क्रॉलिंग का उपयोग करें
+scroll_horizontal_label=क्षितिजिय स्क्रॉलिंग
+scroll_wrapped.title=व्राप्पेड स्क्रॉलिंग का उपयोग करें
+
+spread_none_label=कोई स्प्रेड उपलब्ध नहीं
+spread_odd.title=विषम-क्रमांकित पृष्ठों से प्रारंभ होने वाले पृष्ठ स्प्रेड में शामिल हों
+spread_odd_label=विषम फैलाव
+
+# Document properties dialog box
+document_properties.title=दस्तावेज़ विशेषता...
+document_properties_label=दस्तावेज़ विशेषता...
+document_properties_file_name=फ़ाइल नाम:
+document_properties_file_size=फाइल आकारः
+# LOCALIZATION NOTE (document_properties_kb): "{{size_kb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in kilobytes, respectively in bytes.
+document_properties_kb={{size_kb}} KB ({{size_b}} bytes)
+# LOCALIZATION NOTE (document_properties_mb): "{{size_mb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in megabytes, respectively in bytes.
+document_properties_mb={{size_mb}} MB ({{size_b}} bytes)
+document_properties_title=शीर्षक:
+document_properties_author=लेखकः
+document_properties_subject=विषय:
+document_properties_keywords=कुंजी-शब्द:
+document_properties_creation_date=निर्माण दिनांक:
+document_properties_modification_date=संशोधन दिनांक:
+# LOCALIZATION NOTE (document_properties_date_string): "{{date}}" and "{{time}}"
+# will be replaced by the creation/modification date, and time, of the PDF file.
+document_properties_date_string={{date}}, {{time}}
+document_properties_creator=निर्माता:
+document_properties_producer=PDF उत्पादक:
+document_properties_version=PDF संस्करण:
+document_properties_page_count=पृष्ठ गिनती:
+document_properties_page_size=पृष्ठ आकार:
+document_properties_page_size_unit_inches=इंच
+document_properties_page_size_unit_millimeters=मिमी
+document_properties_page_size_orientation_portrait=पोर्ट्रेट
+document_properties_page_size_orientation_landscape=लैंडस्केप
+document_properties_page_size_name_a3=A3
+document_properties_page_size_name_a4=A4
+document_properties_page_size_name_letter=पत्र
+document_properties_page_size_name_legal=क़ानूनी
+# LOCALIZATION NOTE (document_properties_page_size_dimension_string):
+# "{{width}}", "{{height}}", {{unit}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement and orientation, of the (current) page.
+document_properties_page_size_dimension_string={{width}} × {{height}} {{unit}} ({{orientation}})
+# LOCALIZATION NOTE (document_properties_page_size_dimension_name_string):
+# "{{width}}", "{{height}}", {{unit}}, {{name}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement, name, and orientation, of the (current) page.
+document_properties_page_size_dimension_name_string={{width}} × {{height}} {{unit}} ({{name}}, {{orientation}})
+# LOCALIZATION NOTE (document_properties_linearized): The linearization status of
+# the document; usually called "Fast Web View" in English locales of Adobe software.
+document_properties_linearized=तीव्र वेब व्यू:
+document_properties_linearized_yes=हाँ
+document_properties_linearized_no=नहीं
+document_properties_close=बंद करें
+
+print_progress_message=छपाई के लिए दस्तावेज़ को तैयार किया जा रहा है...
+# LOCALIZATION NOTE (print_progress_percent): "{{progress}}" will be replaced by
+# a numerical per cent value.
+print_progress_percent={{progress}}%
+print_progress_close=रद्द करें
+
+# Tooltips and alt text for side panel toolbar buttons
+# (the _label strings are alt text for the buttons, the .title strings are
+# tooltips)
+toggle_sidebar.title=\u0020स्लाइडर टॉगल करें
+toggle_sidebar_label=स्लाइडर टॉगल करें
+document_outline.title=दस्तावेज़ की रूपरेखा दिखाइए (सारी वस्तुओं को फलने अथवा समेटने के लिए दो बार क्लिक करें)
+document_outline_label=दस्तावेज़ आउटलाइन
+attachments.title=संलग्नक दिखायें
+attachments_label=संलग्नक
+thumbs.title=लघुछवियाँ दिखाएँ
+thumbs_label=लघु छवि
+findbar.title=\u0020दस्तावेज़ में ढूँढ़ें
+findbar_label=ढूँढें
+
+# Thumbnails panel item (tooltip and alt text for images)
+# LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
+# number.
+thumb_page_title=पृष्ठ {{page}}
+# LOCALIZATION NOTE (thumb_page_canvas): "{{page}}" will be replaced by the page
+# number.
+thumb_page_canvas=पृष्ठ {{page}} की लघु-छवि
+
+# Find panel button title and messages
+find_input.title=ढूँढें
+find_input.placeholder=दस्तावेज़ में खोजें...
+find_previous.title=वाक्यांश की पिछली उपस्थिति ढूँढ़ें
+find_previous_label=पिछला
+find_next.title=वाक्यांश की अगली उपस्थिति ढूँढ़ें
+find_next_label=अगला
+find_highlight=\u0020सभी आलोकित करें
+find_match_case_label=मिलान स्थिति
+find_entire_word_label=संपूर्ण शब्द
+find_reached_top=पृष्ठ के ऊपर पहुंच गया, नीचे से जारी रखें
+find_reached_bottom=पृष्ठ के नीचे में जा पहुँचा, ऊपर से जारी
+# LOCALIZATION NOTE (find_match_count): The supported plural forms are
+# [one|two|few|many|other], with [other] as the default value.
+# "{{current}}" and "{{total}}" will be replaced by a number representing the
+# index of the currently active find result, respectively a number representing
+# the total number of matches in the document.
+find_match_count={[ plural(total) ]}
+find_match_count[one]={{total}} में {{current}} मेल
+find_match_count[two]={{total}} में {{current}} मेल
+find_match_count[few]={{total}} में {{current}} मेल
+find_match_count[many]={{total}} में {{current}} मेल
+find_match_count[other]={{total}} में {{current}} मेल
+# LOCALIZATION NOTE (find_match_count_limit): The supported plural forms are
+# [zero|one|two|few|many|other], with [other] as the default value.
+# "{{limit}}" will be replaced by a numerical value.
+find_match_count_limit={[ plural(limit) ]}
+find_match_count_limit[zero]={{limit}} से अधिक मेल
+find_match_count_limit[one]={{limit}} से अधिक मेल
+find_match_count_limit[two]={{limit}} से अधिक मेल
+find_match_count_limit[few]={{limit}} से अधिक मेल
+find_match_count_limit[many]={{limit}} से अधिक मेल
+find_match_count_limit[other]={{limit}} से अधिक मेल
+find_not_found=वाक्यांश नहीं मिला
+
+# Predefined zoom values
+page_scale_width=\u0020पृष्ठ चौड़ाई
+page_scale_fit=पृष्ठ फिट
+page_scale_auto=स्वचालित जूम
+page_scale_actual=वास्तविक आकार
+# LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
+# numerical scale value.
+page_scale_percent={{scale}}%
+
+loading_error=PDF लोड करते समय एक त्रुटि हुई.
+invalid_file_error=अमान्य या भ्रष्ट PDF फ़ाइल.
+missing_file_error=\u0020अनुपस्थित PDF फ़ाइल.
+unexpected_response_error=अप्रत्याशित सर्वर प्रतिक्रिया.
+
+rendering_error=पृष्ठ रेंडरिंग के दौरान त्रुटि आई.
+
+# LOCALIZATION NOTE (annotation_date_string): "{{date}}" and "{{time}}" will be
+# replaced by the modification date, and time, of the annotation.
+annotation_date_string={{date}}, {{time}}
+
+# LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
+# "{{type}}" will be replaced with an annotation type from a list defined in
+# the PDF spec (32000-1:2008 Table 169 – Annotation types).
+# Some common types are e.g.: "Check", "Text", "Comment", "Note"
+text_annotation_type.alt=\u0020[{{type}} Annotation]
+password_label=इस PDF फ़ाइल को खोलने के लिए कृपया कूटशब्द भरें.
+password_invalid=अवैध कूटशब्द, कृपया फिर कोशिश करें.
+password_ok=OK
+password_cancel=रद्द करें
+
+printing_not_supported=चेतावनी: इस ब्राउज़र पर छपाई पूरी तरह से समर्थित नहीं है.
+printing_not_ready=चेतावनी: PDF छपाई के लिए पूरी तरह से लोड नहीं है.
+web_fonts_disabled=वेब फॉन्ट्स निष्क्रिय हैं: अंतःस्थापित PDF फॉन्टस के उपयोग में असमर्थ.
+

--- a/js/pdfjs/web/locale/hr/viewer.properties
+++ b/js/pdfjs/web/locale/hr/viewer.properties
@@ -1,0 +1,243 @@
+# Copyright 2012 Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Main toolbar buttons (tooltips and alt text for images)
+previous.title=Prethodna stranica
+previous_label=Prethodna
+next.title=Sljedeća stranica
+next_label=Sljedeća
+
+# LOCALIZATION NOTE (page.title): The tooltip for the pageNumber input.
+page.title=Stranica
+# LOCALIZATION NOTE (of_pages): "{{pagesCount}}" will be replaced by a number
+# representing the total number of pages in the document.
+of_pages=od {{pagesCount}}
+# LOCALIZATION NOTE (page_of_pages): "{{pageNumber}}" and "{{pagesCount}}"
+# will be replaced by a number representing the currently visible page,
+# respectively a number representing the total number of pages in the document.
+page_of_pages=({{pageNumber}} od {{pagesCount}})
+
+zoom_out.title=Umanji
+zoom_out_label=Umanji
+zoom_in.title=Uvećaj
+zoom_in_label=Uvećaj
+zoom.title=Zumiranje
+presentation_mode.title=Prebaci u prezentacijski način rada
+presentation_mode_label=Prezentacijski način rada
+open_file.title=Otvori datoteku
+open_file_label=Otvori
+print.title=Ispiši
+print_label=Ispiši
+save.title=Spremi
+save_label=Spremi
+
+# Secondary toolbar and context menu
+tools.title=Alati
+tools_label=Alati
+first_page.title=Idi na prvu stranicu
+first_page_label=Idi na prvu stranicu
+last_page.title=Idi na posljednju stranicu
+last_page_label=Idi na posljednju stranicu
+page_rotate_cw.title=Rotiraj u smjeru kazaljke na satu
+page_rotate_cw_label=Rotiraj u smjeru kazaljke na satu
+page_rotate_ccw.title=Rotiraj obrnutno od smjera kazaljke na satu
+page_rotate_ccw_label=Rotiraj obrnutno od smjera kazaljke na satu
+
+cursor_text_select_tool.title=Omogući alat za označavanje teksta
+cursor_text_select_tool_label=Alat za označavanje teksta
+cursor_hand_tool.title=Omogući ručni alat
+cursor_hand_tool_label=Ručni alat
+
+scroll_vertical.title=Koristi okomito pomicanje
+scroll_vertical_label=Okomito pomicanje
+scroll_horizontal.title=Koristi vodoravno pomicanje
+scroll_horizontal_label=Vodoravno pomicanje
+scroll_wrapped.title=Koristi kontinuirani raspored stranica
+scroll_wrapped_label=Kontinuirani raspored stranica
+
+spread_none.title=Ne izrađuj duplerice
+spread_none_label=Pojedinačne stranice
+spread_odd.title=Izradi duplerice koje počinju s neparnim stranicama
+spread_odd_label=Neparne duplerice
+spread_even.title=Izradi duplerice koje počinju s parnim stranicama
+spread_even_label=Parne duplerice
+
+# Document properties dialog box
+document_properties.title=Svojstva dokumenta …
+document_properties_label=Svojstva dokumenta …
+document_properties_file_name=Naziv datoteke:
+document_properties_file_size=Veličina datoteke:
+# LOCALIZATION NOTE (document_properties_kb): "{{size_kb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in kilobytes, respectively in bytes.
+document_properties_kb={{size_kb}} KB ({{size_b}} bajtova)
+# LOCALIZATION NOTE (document_properties_mb): "{{size_mb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in megabytes, respectively in bytes.
+document_properties_mb={{size_mb}} MB ({{size_b}} bajtova)
+document_properties_title=Naslov:
+document_properties_author=Autor:
+document_properties_subject=Predmet:
+document_properties_keywords=Ključne riječi:
+document_properties_creation_date=Datum stvaranja:
+document_properties_modification_date=Datum promjene:
+# LOCALIZATION NOTE (document_properties_date_string): "{{date}}" and "{{time}}"
+# will be replaced by the creation/modification date, and time, of the PDF file.
+document_properties_date_string={{date}}, {{time}}
+document_properties_creator=Stvaratelj:
+document_properties_producer=PDF stvaratelj:
+document_properties_version=PDF verzija:
+document_properties_page_count=Broj stranica:
+document_properties_page_size=Dimenzije stranice:
+document_properties_page_size_unit_inches=in
+document_properties_page_size_unit_millimeters=mm
+document_properties_page_size_orientation_portrait=uspravno
+document_properties_page_size_orientation_landscape=položeno
+document_properties_page_size_name_a3=A3
+document_properties_page_size_name_a4=A4
+document_properties_page_size_name_letter=Letter
+document_properties_page_size_name_legal=Legal
+# LOCALIZATION NOTE (document_properties_page_size_dimension_string):
+# "{{width}}", "{{height}}", {{unit}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement and orientation, of the (current) page.
+document_properties_page_size_dimension_string={{width}} × {{height}} {{unit}} ({{orientation}})
+# LOCALIZATION NOTE (document_properties_page_size_dimension_name_string):
+# "{{width}}", "{{height}}", {{unit}}, {{name}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement, name, and orientation, of the (current) page.
+document_properties_page_size_dimension_name_string={{width}} × {{height}} {{unit}} ({{name}}, {{orientation}})
+# LOCALIZATION NOTE (document_properties_linearized): The linearization status of
+# the document; usually called "Fast Web View" in English locales of Adobe software.
+document_properties_linearized=Brzi web pregled:
+document_properties_linearized_yes=Da
+document_properties_linearized_no=Ne
+document_properties_close=Zatvori
+
+print_progress_message=Pripremanje dokumenta za ispis…
+# LOCALIZATION NOTE (print_progress_percent): "{{progress}}" will be replaced by
+# a numerical per cent value.
+print_progress_percent={{progress}}%
+print_progress_close=Odustani
+
+# Tooltips and alt text for side panel toolbar buttons
+# (the _label strings are alt text for the buttons, the .title strings are
+# tooltips)
+toggle_sidebar.title=Prikaži/sakrij bočnu traku
+toggle_sidebar_notification2.title=Prikazivanje i sklanjanje bočne trake (dokument sadrži strukturu/privitke/slojeve)
+toggle_sidebar_label=Prikaži/sakrij bočnu traku
+document_outline.title=Prikaži strukturu dokumenta (dvostruki klik za rasklapanje/sklapanje svih stavki)
+document_outline_label=Struktura dokumenta
+attachments.title=Prikaži privitke
+attachments_label=Privitci
+layers.title=Prikaži slojeve (dvoklik za vraćanje svih slojeva u zadano stanje)
+layers_label=Slojevi
+thumbs.title=Prikaži minijature
+thumbs_label=Minijature
+current_outline_item.title=Pronađi trenutačni element strukture
+current_outline_item_label=Trenutačni element strukture
+findbar.title=Pronađi u dokumentu
+findbar_label=Pronađi
+
+additional_layers=Dodatni slojevi
+# LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
+page_landmark=Stranica {{page}}
+# Thumbnails panel item (tooltip and alt text for images)
+# LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
+# number.
+thumb_page_title=Stranica {{page}}
+# LOCALIZATION NOTE (thumb_page_canvas): "{{page}}" will be replaced by the page
+# number.
+thumb_page_canvas=Minijatura stranice {{page}}
+
+# Find panel button title and messages
+find_input.title=Pronađi
+find_input.placeholder=Pronađi u dokumentu …
+find_previous.title=Pronađi prethodno pojavljivanje ovog izraza
+find_previous_label=Prethodno
+find_next.title=Pronađi sljedeće pojavljivanje ovog izraza
+find_next_label=Sljedeće
+find_highlight=Istankni sve
+find_match_case_label=Razlikovanje velikih i malih slova
+find_entire_word_label=Cijele riječi
+find_reached_top=Dosegnut početak dokumenta, nastavak s kraja
+find_reached_bottom=Dosegnut kraj dokumenta, nastavak s početka
+# LOCALIZATION NOTE (find_match_count): The supported plural forms are
+# [one|two|few|many|other], with [other] as the default value.
+# "{{current}}" and "{{total}}" will be replaced by a number representing the
+# index of the currently active find result, respectively a number representing
+# the total number of matches in the document.
+find_match_count={[ plural(total) ]}
+find_match_count[one]={{current}} od {{total}} se podudara
+find_match_count[two]={{current}} od {{total}} se podudara
+find_match_count[few]={{current}} od {{total}} se podudara
+find_match_count[many]={{current}} od {{total}} se podudara
+find_match_count[other]={{current}} od {{total}} se podudara
+# LOCALIZATION NOTE (find_match_count_limit): The supported plural forms are
+# [zero|one|two|few|many|other], with [other] as the default value.
+# "{{limit}}" will be replaced by a numerical value.
+find_match_count_limit={[ plural(limit) ]}
+find_match_count_limit[zero]=Više od {{limit}} podudaranja
+find_match_count_limit[one]=Više od {{limit}} podudaranja
+find_match_count_limit[two]=Više od {{limit}} podudaranja
+find_match_count_limit[few]=Više od {{limit}} podudaranja
+find_match_count_limit[many]=Više od {{limit}} podudaranja
+find_match_count_limit[other]=Više od {{limit}} podudaranja
+find_not_found=Izraz nije pronađen
+
+# Predefined zoom values
+page_scale_width=Prilagodi širini prozora
+page_scale_fit=Prilagodi veličini prozora
+page_scale_auto=Automatsko zumiranje
+page_scale_actual=Stvarna veličina
+# LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
+# numerical scale value.
+page_scale_percent={{scale}} %
+
+loading_error=Došlo je do greške pri učitavanju PDF-a.
+invalid_file_error=Neispravna ili oštećena PDF datoteka.
+missing_file_error=Nedostaje PDF datoteka.
+unexpected_response_error=Neočekivani odgovor poslužitelja.
+
+rendering_error=Došlo je do greške prilikom iscrtavanja stranice.
+
+# LOCALIZATION NOTE (annotation_date_string): "{{date}}" and "{{time}}" will be
+# replaced by the modification date, and time, of the annotation.
+annotation_date_string={{date}}, {{time}}
+
+# LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
+# "{{type}}" will be replaced with an annotation type from a list defined in
+# the PDF spec (32000-1:2008 Table 169 – Annotation types).
+# Some common types are e.g.: "Check", "Text", "Comment", "Note"
+text_annotation_type.alt=[{{type}} Bilješka]
+password_label=Za otvoranje ove PDF datoteku upiši lozinku.
+password_invalid=Neispravna lozinka. Pokušaj ponovo.
+password_ok=U redu
+password_cancel=Odustani
+
+printing_not_supported=Upozorenje: Ovaj preglednik ne podržava u potpunosti ispisivanje.
+printing_not_ready=Upozorenje: PDF nije u potpunosti učitan za ispis.
+web_fonts_disabled=Web fontovi su deaktivirani: nije moguće koristiti ugrađene PDF fontove.
+
+# Editor
+editor_free_text2.title=Tekst
+editor_free_text2_label=Tekst
+
+free_text2_default_content=Počni tipkati …
+
+# Editor Parameters
+editor_free_text_color=Boja
+editor_free_text_size=Veličina
+editor_ink_color=Boja
+editor_ink_thickness=Debljina
+editor_ink_opacity=Neprozirnost
+
+# Editor aria
+editor_free_text2_aria_label=Uređivač teksta

--- a/js/pdfjs/web/locale/hsb/viewer.properties
+++ b/js/pdfjs/web/locale/hsb/viewer.properties
@@ -1,0 +1,259 @@
+# Copyright 2012 Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Main toolbar buttons (tooltips and alt text for images)
+previous.title=Předchadna strona
+previous_label=Wróćo
+next.title=Přichodna strona
+next_label=Dale
+
+# LOCALIZATION NOTE (page.title): The tooltip for the pageNumber input.
+page.title=Strona
+# LOCALIZATION NOTE (of_pages): "{{pagesCount}}" will be replaced by a number
+# representing the total number of pages in the document.
+of_pages=z {{pagesCount}}
+# LOCALIZATION NOTE (page_of_pages): "{{pageNumber}}" and "{{pagesCount}}"
+# will be replaced by a number representing the currently visible page,
+# respectively a number representing the total number of pages in the document.
+page_of_pages=({{pageNumber}} z {{pagesCount}})
+
+zoom_out.title=Pomjeńšić
+zoom_out_label=Pomjeńšić
+zoom_in.title=Powjetšić
+zoom_in_label=Powjetšić
+zoom.title=Skalowanje
+presentation_mode.title=Do prezentaciskeho modusa přeńć
+presentation_mode_label=Prezentaciski modus
+open_file.title=Dataju wočinić
+open_file_label=Wočinić
+print.title=Ćišćeć
+print_label=Ćišćeć
+save.title=Składować
+save_label=Składować
+bookmark1.title=Aktualna strona (URL z aktualneje strony pokazać)
+bookmark1_label=Aktualna strona
+# LOCALIZATION NOTE (open_in_app.title): This string is used in Firefox for Android.
+open_in_app.title=W nałoženju wočinić
+# LOCALIZATION NOTE (open_in_app_label): This string is used in Firefox for Android. Length of the translation matters since we are in a mobile context, with limited screen estate.
+open_in_app_label=W nałoženju wočinić
+
+# Secondary toolbar and context menu
+tools.title=Nastroje
+tools_label=Nastroje
+first_page.title=K prěnjej stronje
+first_page_label=K prěnjej stronje
+last_page.title=K poslednjej stronje
+last_page_label=K poslednjej stronje
+page_rotate_cw.title=K směrej časnika wjerćeć
+page_rotate_cw_label=K směrej časnika wjerćeć
+page_rotate_ccw.title=Přećiwo směrej časnika wjerćeć
+page_rotate_ccw_label=Přećiwo směrej časnika wjerćeć
+
+cursor_text_select_tool.title=Nastroj za wuběranje teksta zmóžnić
+cursor_text_select_tool_label=Nastroj za wuběranje teksta
+cursor_hand_tool.title=Ručny nastroj zmóžnić
+cursor_hand_tool_label=Ručny nastroj
+
+scroll_page.title=Kulenje strony wužiwać
+scroll_page_label=Kulenje strony
+scroll_vertical.title=Wertikalne suwanje wužiwać
+scroll_vertical_label=Wertikalne suwanje
+scroll_horizontal.title=Horicontalne suwanje wužiwać
+scroll_horizontal_label=Horicontalne suwanje
+scroll_wrapped.title=Postupne suwanje wužiwać
+scroll_wrapped_label=Postupne suwanje
+
+spread_none.title=Strony njezwjazać
+spread_none_label=Žana dwójna strona
+spread_odd.title=Strony započinajo z njerunymi stronami zwjazać
+spread_odd_label=Njerune strony
+spread_even.title=Strony započinajo z runymi stronami zwjazać
+spread_even_label=Rune strony
+
+# Document properties dialog box
+document_properties.title=Dokumentowe kajkosće…
+document_properties_label=Dokumentowe kajkosće…
+document_properties_file_name=Mjeno dataje:
+document_properties_file_size=Wulkosć dataje:
+# LOCALIZATION NOTE (document_properties_kb): "{{size_kb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in kilobytes, respectively in bytes.
+document_properties_kb={{size_kb}} KB ({{size_b}} bajtow)
+# LOCALIZATION NOTE (document_properties_mb): "{{size_mb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in megabytes, respectively in bytes.
+document_properties_mb={{size_mb}} MB ({{size_b}} bajtow)
+document_properties_title=Titul:
+document_properties_author=Awtor:
+document_properties_subject=Předmjet:
+document_properties_keywords=Klučowe słowa:
+document_properties_creation_date=Datum wutworjenja:
+document_properties_modification_date=Datum změny:
+# LOCALIZATION NOTE (document_properties_date_string): "{{date}}" and "{{time}}"
+# will be replaced by the creation/modification date, and time, of the PDF file.
+document_properties_date_string={{date}}, {{time}}
+document_properties_creator=Awtor:
+document_properties_producer=PDF-zhotowjer:
+document_properties_version=PDF-wersija:
+document_properties_page_count=Ličba stronow:
+document_properties_page_size=Wulkosć strony:
+document_properties_page_size_unit_inches=cól
+document_properties_page_size_unit_millimeters=mm
+document_properties_page_size_orientation_portrait=wysoki format
+document_properties_page_size_orientation_landscape=prěčny format
+document_properties_page_size_name_a3=A3
+document_properties_page_size_name_a4=A4
+document_properties_page_size_name_letter=Letter
+document_properties_page_size_name_legal=Legal
+# LOCALIZATION NOTE (document_properties_page_size_dimension_string):
+# "{{width}}", "{{height}}", {{unit}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement and orientation, of the (current) page.
+document_properties_page_size_dimension_string={{width}} × {{height}} {{unit}} ({{orientation}})
+# LOCALIZATION NOTE (document_properties_page_size_dimension_name_string):
+# "{{width}}", "{{height}}", {{unit}}, {{name}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement, name, and orientation, of the (current) page.
+document_properties_page_size_dimension_name_string={{width}} × {{height}} {{unit}} ({{name}}, {{orientation}})
+# LOCALIZATION NOTE (document_properties_linearized): The linearization status of
+# the document; usually called "Fast Web View" in English locales of Adobe software.
+document_properties_linearized=Fast Web View:
+document_properties_linearized_yes=Haj
+document_properties_linearized_no=Ně
+document_properties_close=Začinić
+
+print_progress_message=Dokument so za ćišćenje přihotuje…
+# LOCALIZATION NOTE (print_progress_percent): "{{progress}}" will be replaced by
+# a numerical per cent value.
+print_progress_percent={{progress}}%
+print_progress_close=Přetorhnyć
+
+# Tooltips and alt text for side panel toolbar buttons
+# (the _label strings are alt text for the buttons, the .title strings are
+# tooltips)
+toggle_sidebar.title=Bóčnicu pokazać/schować
+toggle_sidebar_notification2.title=Bóčnicu přepinać (dokument rozrjad/přiwěški/woršty wobsahuje)
+toggle_sidebar_label=Bóčnicu pokazać/schować
+document_outline.title=Dokumentowy naćisk pokazać (dwójne kliknjenje, zo bychu so wšě zapiski pokazali/schowali)
+document_outline_label=Dokumentowa struktura
+attachments.title=Přiwěški pokazać
+attachments_label=Přiwěški
+layers.title=Woršty pokazać (klikńće dwójce, zo byšće wšě woršty na standardny staw wróćo stajił)
+layers_label=Woršty
+thumbs.title=Miniatury pokazać
+thumbs_label=Miniatury
+current_outline_item.title=Aktualny rozrjadowy zapisk pytać
+current_outline_item_label=Aktualny rozrjadowy zapisk
+findbar.title=W dokumenće pytać
+findbar_label=Pytać
+
+additional_layers=Dalše woršty
+# LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
+page_landmark=Strona {{page}}
+# Thumbnails panel item (tooltip and alt text for images)
+# LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
+# number.
+thumb_page_title=Strona {{page}}
+# LOCALIZATION NOTE (thumb_page_canvas): "{{page}}" will be replaced by the page
+# number.
+thumb_page_canvas=Miniatura strony {{page}}
+
+# Find panel button title and messages
+find_input.title=Pytać
+find_input.placeholder=W dokumenće pytać…
+find_previous.title=Předchadne wustupowanje pytanskeho wuraza pytać
+find_previous_label=Wróćo
+find_next.title=Přichodne wustupowanje pytanskeho wuraza pytać
+find_next_label=Dale
+find_highlight=Wšě wuzběhnyć
+find_match_case_label=Wulkopisanje wobkedźbować
+find_match_diacritics_label=Diakritiske znamješka wužiwać
+find_entire_word_label=Cyłe słowa
+find_reached_top=Spočatk dokumenta docpěty, pokročuje so z kóncom
+find_reached_bottom=Kónc dokument docpěty, pokročuje so ze spočatkom
+# LOCALIZATION NOTE (find_match_count): The supported plural forms are
+# [one|two|few|many|other], with [other] as the default value.
+# "{{current}}" and "{{total}}" will be replaced by a number representing the
+# index of the currently active find result, respectively a number representing
+# the total number of matches in the document.
+find_match_count={[ plural(total) ]}
+find_match_count[one]={{current}} z {{total}} wotpowědnika
+find_match_count[two]={{current}} z {{total}} wotpowědnikow
+find_match_count[few]={{current}} z {{total}} wotpowědnikow
+find_match_count[many]={{current}} z {{total}} wotpowědnikow
+find_match_count[other]={{current}} z {{total}} wotpowědnikow
+# LOCALIZATION NOTE (find_match_count_limit): The supported plural forms are
+# [zero|one|two|few|many|other], with [other] as the default value.
+# "{{limit}}" will be replaced by a numerical value.
+find_match_count_limit={[ plural(limit) ]}
+find_match_count_limit[zero]=Wjace hač {{limit}} wotpowědnikow
+find_match_count_limit[one]=Wjace hač {{limit}} wotpowědnik
+find_match_count_limit[two]=Wjace hač {{limit}} wotpowědnikaj
+find_match_count_limit[few]=Wjace hač {{limit}} wotpowědniki
+find_match_count_limit[many]=Wjace hač {{limit}} wotpowědnikow
+find_match_count_limit[other]=Wjace hač {{limit}} wotpowědnikow
+find_not_found=Pytanski wuraz njeje so namakał
+
+# Predefined zoom values
+page_scale_width=Šěrokosć strony
+page_scale_fit=Wulkosć strony
+page_scale_auto=Awtomatiske skalowanje
+page_scale_actual=Aktualna wulkosć
+# LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
+# numerical scale value.
+page_scale_percent={{scale}}%
+
+# Loading indicator messages
+loading_error=Při začitowanju PDF je zmylk wustupił.
+invalid_file_error=Njepłaćiwa abo wobškodźena PDF-dataja.
+missing_file_error=Falowaca PDF-dataja.
+unexpected_response_error=Njewočakowana serwerowa wotmołwa.
+rendering_error=Při zwobraznjenju strony je zmylk wustupił.
+
+# LOCALIZATION NOTE (annotation_date_string): "{{date}}" and "{{time}}" will be
+# replaced by the modification date, and time, of the annotation.
+annotation_date_string={{date}}, {{time}}
+
+# LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
+# "{{type}}" will be replaced with an annotation type from a list defined in
+# the PDF spec (32000-1:2008 Table 169 – Annotation types).
+# Some common types are e.g.: "Check", "Text", "Comment", "Note"
+text_annotation_type.alt=[Typ přispomnjenki: {{type}}]
+password_label=Zapodajće hesło, zo byšće PDF-dataju wočinił.
+password_invalid=Njepłaćiwe hesło. Prošu spytajće hišće raz.
+password_ok=W porjadku
+password_cancel=Přetorhnyć
+
+printing_not_supported=Warnowanje: Ćišćenje so přez tutón wobhladowak połnje njepodpěruje.
+printing_not_ready=Warnowanje: PDF njeje so za ćišćenje dospołnje začitał.
+web_fonts_disabled=Webpisma su znjemóžnjene: njeje móžno, zasadźene PDF-pisma wužiwać.
+
+# Editor
+editor_free_text2.title=Tekst
+editor_free_text2_label=Tekst
+editor_ink2.title=Rysować
+editor_ink2_label=Rysować
+
+editor_stamp.title=Wobraz přidać
+editor_stamp_label=Wobraz přidać
+
+free_text2_default_content=Započńće pisać…
+
+# Editor Parameters
+editor_free_text_color=Barba
+editor_free_text_size=Wulkosć
+editor_ink_color=Barba
+editor_ink_thickness=Tołstosć
+editor_ink_opacity=Opacita
+
+# Editor aria
+editor_free_text2_aria_label=Tekstowy editor
+editor_ink2_aria_label=Rysowanski editor
+editor_ink_canvas_aria_label=Wobraz wutworjeny wot wužiwarja

--- a/js/pdfjs/web/locale/hu/viewer.properties
+++ b/js/pdfjs/web/locale/hu/viewer.properties
@@ -1,0 +1,257 @@
+# Copyright 2012 Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Main toolbar buttons (tooltips and alt text for images)
+previous.title=Előző oldal
+previous_label=Előző
+next.title=Következő oldal
+next_label=Tovább
+
+# LOCALIZATION NOTE (page.title): The tooltip for the pageNumber input.
+page.title=Oldal
+# LOCALIZATION NOTE (of_pages): "{{pagesCount}}" will be replaced by a number
+# representing the total number of pages in the document.
+of_pages=összesen: {{pagesCount}}
+# LOCALIZATION NOTE (page_of_pages): "{{pageNumber}}" and "{{pagesCount}}"
+# will be replaced by a number representing the currently visible page,
+# respectively a number representing the total number of pages in the document.
+page_of_pages=({{pageNumber}} / {{pagesCount}})
+
+zoom_out.title=Kicsinyítés
+zoom_out_label=Kicsinyítés
+zoom_in.title=Nagyítás
+zoom_in_label=Nagyítás
+zoom.title=Nagyítás
+presentation_mode.title=Váltás bemutató módba
+presentation_mode_label=Bemutató mód
+open_file.title=Fájl megnyitása
+open_file_label=Megnyitás
+print.title=Nyomtatás
+print_label=Nyomtatás
+
+save.title=Mentés
+save_label=Mentés
+bookmark1.title=Jelenlegi oldal (webcím megtekintése a jelenlegi oldalról)
+bookmark1_label=Jelenlegi oldal
+
+open_in_app.title=Megnyitás alkalmazásban
+open_in_app_label=Megnyitás alkalmazásban
+
+# Secondary toolbar and context menu
+tools.title=Eszközök
+tools_label=Eszközök
+first_page.title=Ugrás az első oldalra
+first_page_label=Ugrás az első oldalra
+last_page.title=Ugrás az utolsó oldalra
+last_page_label=Ugrás az utolsó oldalra
+page_rotate_cw.title=Forgatás az óramutató járásával egyezően
+page_rotate_cw_label=Forgatás az óramutató járásával egyezően
+page_rotate_ccw.title=Forgatás az óramutató járásával ellentétesen
+page_rotate_ccw_label=Forgatás az óramutató járásával ellentétesen
+
+cursor_text_select_tool.title=Szövegkijelölő eszköz bekapcsolása
+cursor_text_select_tool_label=Szövegkijelölő eszköz
+cursor_hand_tool.title=Kéz eszköz bekapcsolása
+cursor_hand_tool_label=Kéz eszköz
+
+scroll_page.title=Oldalgörgetés használata
+scroll_page_label=Oldalgörgetés
+scroll_vertical.title=Függőleges görgetés használata
+scroll_vertical_label=Függőleges görgetés
+scroll_horizontal.title=Vízszintes görgetés használata
+scroll_horizontal_label=Vízszintes görgetés
+scroll_wrapped.title=Rácsos elrendezés használata
+scroll_wrapped_label=Rácsos elrendezés
+
+spread_none.title=Ne tapassza össze az oldalakat
+spread_none_label=Nincs összetapasztás
+spread_odd.title=Lapok összetapasztása, a páratlan számú oldalakkal kezdve
+spread_odd_label=Összetapasztás: páratlan
+spread_even.title=Lapok összetapasztása, a páros számú oldalakkal kezdve
+spread_even_label=Összetapasztás: páros
+
+# Document properties dialog box
+document_properties.title=Dokumentum tulajdonságai…
+document_properties_label=Dokumentum tulajdonságai…
+document_properties_file_name=Fájlnév:
+document_properties_file_size=Fájlméret:
+# LOCALIZATION NOTE (document_properties_kb): "{{size_kb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in kilobytes, respectively in bytes.
+document_properties_kb={{size_kb}} KB ({{size_b}} bájt)
+# LOCALIZATION NOTE (document_properties_mb): "{{size_mb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in megabytes, respectively in bytes.
+document_properties_mb={{size_mb}} MB ({{size_b}} bájt)
+document_properties_title=Cím:
+document_properties_author=Szerző:
+document_properties_subject=Tárgy:
+document_properties_keywords=Kulcsszavak:
+document_properties_creation_date=Létrehozás dátuma:
+document_properties_modification_date=Módosítás dátuma:
+# LOCALIZATION NOTE (document_properties_date_string): "{{date}}" and "{{time}}"
+# will be replaced by the creation/modification date, and time, of the PDF file.
+document_properties_date_string={{date}}, {{time}}
+document_properties_creator=Létrehozta:
+document_properties_producer=PDF előállító:
+document_properties_version=PDF verzió:
+document_properties_page_count=Oldalszám:
+document_properties_page_size=Lapméret:
+document_properties_page_size_unit_inches=in
+document_properties_page_size_unit_millimeters=mm
+document_properties_page_size_orientation_portrait=álló
+document_properties_page_size_orientation_landscape=fekvő
+document_properties_page_size_name_a3=A3
+document_properties_page_size_name_a4=A4
+document_properties_page_size_name_letter=Letter
+document_properties_page_size_name_legal=Jogi információk
+# LOCALIZATION NOTE (document_properties_page_size_dimension_string):
+# "{{width}}", "{{height}}", {{unit}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement and orientation, of the (current) page.
+document_properties_page_size_dimension_string={{width}} × {{height}} {{unit}} ({{orientation}})
+# LOCALIZATION NOTE (document_properties_page_size_dimension_name_string):
+# "{{width}}", "{{height}}", {{unit}}, {{name}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement, name, and orientation, of the (current) page.
+document_properties_page_size_dimension_name_string={{width}} × {{height}} {{unit}} ({{name}}, {{orientation}})
+# LOCALIZATION NOTE (document_properties_linearized): The linearization status of
+# the document; usually called "Fast Web View" in English locales of Adobe software.
+document_properties_linearized=Gyors webes nézet:
+document_properties_linearized_yes=Igen
+document_properties_linearized_no=Nem
+document_properties_close=Bezárás
+
+print_progress_message=Dokumentum előkészítése nyomtatáshoz…
+# LOCALIZATION NOTE (print_progress_percent): "{{progress}}" will be replaced by
+# a numerical per cent value.
+print_progress_percent={{progress}}%
+print_progress_close=Mégse
+
+# Tooltips and alt text for side panel toolbar buttons
+# (the _label strings are alt text for the buttons, the .title strings are
+# tooltips)
+toggle_sidebar.title=Oldalsáv be/ki
+toggle_sidebar_notification2.title=Oldalsáv be/ki (a dokumentum vázlatot/mellékleteket/rétegeket tartalmaz)
+toggle_sidebar_label=Oldalsáv be/ki
+document_outline.title=Dokumentum megjelenítése online (dupla kattintás minden elem kinyitásához/összecsukásához)
+document_outline_label=Dokumentumvázlat
+attachments.title=Mellékletek megjelenítése
+attachments_label=Van melléklet
+layers.title=Rétegek megjelenítése (dupla kattintás az összes réteg alapértelmezett állapotra visszaállításához)
+layers_label=Rétegek
+thumbs.title=Bélyegképek megjelenítése
+thumbs_label=Bélyegképek
+current_outline_item.title=Jelenlegi vázlatelem megkeresése
+current_outline_item_label=Jelenlegi vázlatelem
+findbar.title=Keresés a dokumentumban
+findbar_label=Keresés
+
+additional_layers=További rétegek
+# LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
+page_landmark={{page}}. oldal
+# Thumbnails panel item (tooltip and alt text for images)
+# LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
+# number.
+thumb_page_title={{page}}. oldal
+# LOCALIZATION NOTE (thumb_page_canvas): "{{page}}" will be replaced by the page
+# number.
+thumb_page_canvas={{page}}. oldal bélyegképe
+
+# Find panel button title and messages
+find_input.title=Keresés
+find_input.placeholder=Keresés a dokumentumban…
+find_previous.title=A kifejezés előző előfordulásának keresése
+find_previous_label=Előző
+find_next.title=A kifejezés következő előfordulásának keresése
+find_next_label=Tovább
+find_highlight=Összes kiemelése
+find_match_case_label=Kis- és nagybetűk megkülönböztetése
+find_match_diacritics_label=Diakritikus jelek
+find_entire_word_label=Teljes szavak
+find_reached_top=A dokumentum eleje elérve, folytatás a végétől
+find_reached_bottom=A dokumentum vége elérve, folytatás az elejétől
+# LOCALIZATION NOTE (find_match_count): The supported plural forms are
+# [one|two|few|many|other], with [other] as the default value.
+# "{{current}}" and "{{total}}" will be replaced by a number representing the
+# index of the currently active find result, respectively a number representing
+# the total number of matches in the document.
+find_match_count={[ plural(total) ]}
+find_match_count[one]={{current}} / {{total}} találat
+find_match_count[two]={{current}} / {{total}} találat
+find_match_count[few]={{current}} / {{total}} találat
+find_match_count[many]={{current}} / {{total}} találat
+find_match_count[other]={{current}} / {{total}} találat
+# LOCALIZATION NOTE (find_match_count_limit): The supported plural forms are
+# [zero|one|two|few|many|other], with [other] as the default value.
+# "{{limit}}" will be replaced by a numerical value.
+find_match_count_limit={[ plural(limit) ]}
+find_match_count_limit[zero]=Több mint {{limit}} találat
+find_match_count_limit[one]=Több mint {{limit}} találat
+find_match_count_limit[two]=Több mint {{limit}} találat
+find_match_count_limit[few]=Több mint {{limit}} találat
+find_match_count_limit[many]=Több mint {{limit}} találat
+find_match_count_limit[other]=Több mint {{limit}} találat
+find_not_found=A kifejezés nem található
+
+# Predefined zoom values
+page_scale_width=Oldalszélesség
+page_scale_fit=Teljes oldal
+page_scale_auto=Automatikus nagyítás
+page_scale_actual=Valódi méret
+# LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
+# numerical scale value.
+page_scale_percent={{scale}}%
+
+# Loading indicator messages
+loading_error=Hiba történt a PDF betöltésekor.
+invalid_file_error=Érvénytelen vagy sérült PDF fájl.
+missing_file_error=Hiányzó PDF fájl.
+unexpected_response_error=Váratlan kiszolgálóválasz.
+
+rendering_error=Hiba történt az oldal feldolgozása közben.
+
+# LOCALIZATION NOTE (annotation_date_string): "{{date}}" and "{{time}}" will be
+# replaced by the modification date, and time, of the annotation.
+annotation_date_string={{date}}, {{time}}
+
+# LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
+# "{{type}}" will be replaced with an annotation type from a list defined in
+# the PDF spec (32000-1:2008 Table 169 – Annotation types).
+# Some common types are e.g.: "Check", "Text", "Comment", "Note"
+text_annotation_type.alt=[{{type}} megjegyzés]
+password_label=Adja meg a jelszót a PDF fájl megnyitásához.
+password_invalid=Helytelen jelszó. Próbálja újra.
+password_ok=OK
+password_cancel=Mégse
+
+printing_not_supported=Figyelmeztetés: Ez a böngésző nem teljesen támogatja a nyomtatást.
+printing_not_ready=Figyelmeztetés: A PDF nincs teljesen betöltve a nyomtatáshoz.
+web_fonts_disabled=Webes betűkészletek letiltva: nem használhatók a beágyazott PDF betűkészletek.
+
+# Editor
+editor_free_text2.title=Szöveg
+editor_free_text2_label=Szöveg
+editor_ink2.title=Rajzolás
+editor_ink2_label=Rajzolás
+
+free_text2_default_content=Kezdjen el gépelni…
+
+# Editor Parameters
+editor_free_text_color=Szín
+editor_free_text_size=Méret
+editor_ink_color=Szín
+editor_ink_thickness=Vastagság
+editor_ink_opacity=Átlátszatlanság
+
+# Editor aria
+editor_free_text2_aria_label=Szövegszerkesztő
+editor_ink2_aria_label=Rajzszerkesztő
+editor_ink_canvas_aria_label=Felhasználó által készített kép

--- a/js/pdfjs/web/locale/hy-AM/viewer.properties
+++ b/js/pdfjs/web/locale/hy-AM/viewer.properties
@@ -1,0 +1,232 @@
+# Copyright 2012 Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Main toolbar buttons (tooltips and alt text for images)
+previous.title=Նախորդ էջը
+previous_label=Նախորդը
+next.title=Հաջորդ էջը
+next_label=Հաջորդը
+
+# LOCALIZATION NOTE (page.title): The tooltip for the pageNumber input.
+page.title=Էջ.
+# LOCALIZATION NOTE (of_pages): "{{pagesCount}}" will be replaced by a number
+# representing the total number of pages in the document.
+of_pages=-ը՝ {{pagesCount}}-ից
+# LOCALIZATION NOTE (page_of_pages): "{{pageNumber}}" and "{{pagesCount}}"
+# will be replaced by a number representing the currently visible page,
+# respectively a number representing the total number of pages in the document.
+page_of_pages=({{pageNumber}}-ը {{pagesCount}})-ից
+
+zoom_out.title=Փոքրացնել
+zoom_out_label=Փոքրացնել
+zoom_in.title=Խոշորացնել
+zoom_in_label=Խոշորացնել
+zoom.title=Մասշտաբ
+presentation_mode.title=Անցնել Ներկայացման եղանակին
+presentation_mode_label=Ներկայացման եղանակ
+open_file.title=Բացել նիշք
+open_file_label=Բացել
+print.title=Տպել
+print_label=Տպել
+
+# LOCALIZATION NOTE (open_in_app.title): This string is used in Firefox for Android.
+# LOCALIZATION NOTE (open_in_app_label): This string is used in Firefox for Android. Length of the translation matters since we are in a mobile context, with limited screen estate.
+
+# Secondary toolbar and context menu
+tools.title=Գործիքներ
+tools_label=Գործիքներ
+first_page.title=Անցնել առաջին էջին
+first_page_label=Անցնել առաջին էջին
+last_page.title=Անցնել վերջին էջին
+last_page_label=Անցնել վերջին էջին
+page_rotate_cw.title=Պտտել ըստ ժամացույցի սլաքի
+page_rotate_cw_label=Պտտել ըստ ժամացույցի սլաքի
+page_rotate_ccw.title=Պտտել հակառակ ժամացույցի սլաքի
+page_rotate_ccw_label=Պտտել հակառակ ժամացույցի սլաքի
+
+cursor_text_select_tool.title=Միացնել գրույթ ընտրելու գործիքը
+cursor_text_select_tool_label=Գրույթը ընտրելու գործիք
+cursor_hand_tool.title=Միացնել Ձեռքի գործիքը
+cursor_hand_tool_label=Ձեռքի գործիք
+
+scroll_vertical.title=Օգտագործել ուղղահայաց ոլորում
+scroll_vertical_label=Ուղղահայաց ոլորում
+scroll_horizontal.title=Օգտագործել հորիզոնական ոլորում
+scroll_horizontal_label=Հորիզոնական ոլորում
+scroll_wrapped.title=Օգտագործել փաթաթված ոլորում
+scroll_wrapped_label=Փաթաթված ոլորում
+
+spread_none.title=Մի միացեք էջի վերածածկերին
+spread_none_label=Չկա վերածածկեր
+spread_odd.title=Միացեք էջի վերածածկերին սկսելով՝ կենտ համարակալված էջերով
+spread_odd_label=Կենտ վերածածկեր
+spread_even.title=Միացեք էջի վերածածկերին սկսելով՝ զույգ համարակալված էջերով
+spread_even_label=Զույգ վերածածկեր
+
+# Document properties dialog box
+document_properties.title=Փաստաթղթի հատկությունները…
+document_properties_label=Փաստաթղթի հատկությունները…
+document_properties_file_name=Նիշքի անունը.
+document_properties_file_size=Նիշք չափը.
+# LOCALIZATION NOTE (document_properties_kb): "{{size_kb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in kilobytes, respectively in bytes.
+document_properties_kb={{size_kb}} ԿԲ ({{size_b}} բայթ)
+# LOCALIZATION NOTE (document_properties_mb): "{{size_mb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in megabytes, respectively in bytes.
+document_properties_mb={{size_mb}} ՄԲ ({{size_b}} բայթ)
+document_properties_title=Վերնագիր.
+document_properties_author=Հեղինակ․
+document_properties_subject=Վերնագիր.
+document_properties_keywords=Հիմնաբառ.
+document_properties_creation_date=Ստեղծելու ամսաթիվը.
+document_properties_modification_date=Փոփոխելու ամսաթիվը.
+# LOCALIZATION NOTE (document_properties_date_string): "{{date}}" and "{{time}}"
+# will be replaced by the creation/modification date, and time, of the PDF file.
+document_properties_date_string={{date}}, {{time}}
+document_properties_creator=Ստեղծող.
+document_properties_producer=PDF-ի հեղինակը.
+document_properties_version=PDF-ի տարբերակը.
+document_properties_page_count=Էջերի քանակը.
+document_properties_page_size=Էջի չափը.
+document_properties_page_size_unit_inches=ում
+document_properties_page_size_unit_millimeters=մմ
+document_properties_page_size_orientation_portrait=ուղղաձիգ
+document_properties_page_size_orientation_landscape=հորիզոնական
+document_properties_page_size_name_a3=A3
+document_properties_page_size_name_a4=A4
+document_properties_page_size_name_letter=Նամակ
+document_properties_page_size_name_legal=Օրինական
+# LOCALIZATION NOTE (document_properties_page_size_dimension_string):
+# "{{width}}", "{{height}}", {{unit}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement and orientation, of the (current) page.
+document_properties_page_size_dimension_string={{width}} × {{height}} {{unit}} ({{orientation}})
+# LOCALIZATION NOTE (document_properties_page_size_dimension_name_string):
+# "{{width}}", "{{height}}", {{unit}}, {{name}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement, name, and orientation, of the (current) page.
+document_properties_page_size_dimension_name_string={{width}} × {{height}} {{unit}} ({{name}}, {{orientation}})
+# LOCALIZATION NOTE (document_properties_linearized): The linearization status of
+# the document; usually called "Fast Web View" in English locales of Adobe software.
+document_properties_linearized=Արագ վեբ դիտում․
+document_properties_linearized_yes=Այո
+document_properties_linearized_no=Ոչ
+document_properties_close=Փակել
+
+print_progress_message=Նախապատրաստում է փաստաթուղթը տպելուն...
+# LOCALIZATION NOTE (print_progress_percent): "{{progress}}" will be replaced by
+# a numerical per cent value.
+print_progress_percent={{progress}}%
+print_progress_close=Չեղարկել
+
+# Tooltips and alt text for side panel toolbar buttons
+# (the _label strings are alt text for the buttons, the .title strings are
+# tooltips)
+toggle_sidebar.title=Բացել/Փակել Կողային վահանակը
+toggle_sidebar_label=Բացել/Փակել Կողային վահանակը
+document_outline.title=Ցուցադրել փաստաթղթի ուրվագիծը (կրկնակի սեղմեք՝ միավորները ընդարձակելու/կոծկելու համար)
+document_outline_label=Փաստաթղթի բովանդակությունը
+attachments.title=Ցուցադրել կցորդները
+attachments_label=Կցորդներ
+thumbs.title=Ցուցադրել Մանրապատկերը
+thumbs_label=Մանրապատկերը
+findbar.title=Գտնել փաստաթղթում
+findbar_label=Որոնում
+
+# LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
+# Thumbnails panel item (tooltip and alt text for images)
+# LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
+# number.
+thumb_page_title=Էջը {{page}}
+# LOCALIZATION NOTE (thumb_page_canvas): "{{page}}" will be replaced by the page
+# number.
+thumb_page_canvas=Էջի մանրապատկերը {{page}}
+
+# Find panel button title and messages
+find_input.title=Որոնում
+find_input.placeholder=Գտնել փաստաթղթում...
+find_previous.title=Գտնել անրահայտության նախորդ հանդիպումը
+find_previous_label=Նախորդը
+find_next.title=Գտիր արտահայտության հաջորդ հանդիպումը
+find_next_label=Հաջորդը
+find_highlight=Գունանշել բոլորը
+find_match_case_label=Մեծ(փոքր)ատառ հաշվի առնել
+find_entire_word_label=Ամբողջ բառերը
+find_reached_top=Հասել եք փաստաթղթի վերևին, կշարունակվի ներքևից
+find_reached_bottom=Հասել եք փաստաթղթի վերջին, կշարունակվի վերևից
+# LOCALIZATION NOTE (find_match_count): The supported plural forms are
+# [one|two|few|many|other], with [other] as the default value.
+# "{{current}}" and "{{total}}" will be replaced by a number representing the
+# index of the currently active find result, respectively a number representing
+# the total number of matches in the document.
+find_match_count={[ հոգնակի(ընդհանուր) ]}
+find_match_count[one]={{current}} {{total}}-ի համընկնումից
+find_match_count[two]={{current}} {{total}}-ի համընկնումներից
+find_match_count[few]={{current}} {{total}}-ի համընկնումներից
+find_match_count[many]={{current}} {{total}}-ի համընկնումներից
+find_match_count[other]={{current}} {{total}}-ի համընկնումներից
+# LOCALIZATION NOTE (find_match_count_limit): The supported plural forms are
+# [zero|one|two|few|many|other], with [other] as the default value.
+# "{{limit}}" will be replaced by a numerical value.
+find_match_count_limit={[ հոգնակի (սահմանը) ]}
+find_match_count_limit[zero]=Ավելին քան {{limit}} համընկնումները
+find_match_count_limit[one]=Ավելին քան {{limit}} համընկնումը
+find_match_count_limit[two]=Ավելին քան {{limit}} համընկնումներներ
+find_match_count_limit[few]=Ավելին քան {{limit}} համընկնումներներ
+find_match_count_limit[many]=Ավելին քան {{limit}} համընկնումներներ
+find_match_count_limit[other]=Ավելին քան {{limit}} համընկնումներներ
+find_not_found=Արտահայտությունը չգտնվեց
+
+# Predefined zoom values
+page_scale_width=Էջի լայնքը
+page_scale_fit=Ձգել էջը
+page_scale_auto=Ինքնաշխատ
+page_scale_actual=Իրական չափը
+# LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
+# numerical scale value.
+page_scale_percent={{scale}}%
+
+# Loading indicator messages
+
+# Loading indicator messages
+loading_error=Սխալ՝ PDF ֆայլը բացելիս։
+invalid_file_error=Սխալ կամ վնասված PDF ֆայլ:
+missing_file_error=PDF ֆայլը բացակայում է:
+unexpected_response_error=Սպասարկիչի անսպասելի պատասխան:
+
+rendering_error=Սխալ՝ էջը ստեղծելիս:
+
+# LOCALIZATION NOTE (annotation_date_string): "{{date}}" and "{{time}}" will be
+# replaced by the modification date, and time, of the annotation.
+annotation_date_string={{date}}, {{time}}
+
+# LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
+# "{{type}}" will be replaced with an annotation type from a list defined in
+# the PDF spec (32000-1:2008 Table 169 – Annotation types).
+# Some common types are e.g.: "Check", "Text", "Comment", "Note"
+text_annotation_type.alt=[{{type}} Ծանոթություն]
+password_label=Մուտքագրեք PDF-ի գաղտնաբառը:
+password_invalid=Գաղտնաբառը սխալ է: Կրկին փորձեք:
+password_ok=Լավ
+password_cancel=Չեղարկել
+
+printing_not_supported=Զգուշացում. Տպելը ամբողջությամբ չի աջակցվում դիտարկիչի կողմից։
+printing_not_ready=Զգուշացում. PDF-ը ամբողջությամբ չի բեռնավորվել տպելու համար:
+web_fonts_disabled=Վեբ-տառատեսակները անջատված են. հնարավոր չէ օգտագործել ներկառուցված PDF տառատեսակները:
+
+# Editor
+
+
+# Editor Parameters
+
+# Editor aria
+

--- a/js/pdfjs/web/locale/hye/viewer.properties
+++ b/js/pdfjs/web/locale/hye/viewer.properties
@@ -1,0 +1,229 @@
+# Copyright 2012 Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Main toolbar buttons (tooltips and alt text for images)
+previous.title=Նախորդ էջ
+previous_label=Նախորդը
+next.title=Յաջորդ էջ
+next_label=Յաջորդը
+
+# LOCALIZATION NOTE (page.title): The tooltip for the pageNumber input.
+page.title=էջ
+# LOCALIZATION NOTE (of_pages): "{{pagesCount}}" will be replaced by a number
+# representing the total number of pages in the document.
+of_pages={{pagesCount}}-ից\u0020
+# LOCALIZATION NOTE (page_of_pages): "{{pageNumber}}" and "{{pagesCount}}"
+# will be replaced by a number representing the currently visible page,
+# respectively a number representing the total number of pages in the document.
+page_of_pages=({{pageNumber}}-ը {{pagesCount}})-ից
+
+zoom_out.title=Փոքրացնել
+zoom_out_label=Փոքրացնել
+zoom_in.title=Խոշորացնել
+zoom_in_label=Խոշորացնել
+zoom.title=Խոշորացում
+presentation_mode.title=Անցնել ներկայացման եղանակին
+presentation_mode_label=Ներկայացման եղանակ
+open_file.title=Բացել նիշքը
+open_file_label=Բացել
+print.title=Տպել
+print_label=Տպել
+
+# Secondary toolbar and context menu
+tools.title=Գործիքներ
+tools_label=Գործիքներ
+first_page.title=Գնալ դէպի առաջին էջ
+first_page_label=Գնալ դէպի առաջին էջ
+last_page.title=Գնալ դէպի վերջին էջ
+last_page_label=Գնալ դէպի վերջին էջ
+page_rotate_cw.title=Պտտել ժամացոյցի սլաքի ուղղութեամբ
+page_rotate_cw_label=Պտտել ժամացոյցի սլաքի ուղղութեամբ
+page_rotate_ccw.title=Պտտել ժամացոյցի սլաքի հակառակ ուղղութեամբ
+page_rotate_ccw_label=Պտտել ժամացոյցի սլաքի հակառակ ուղղութեամբ
+
+cursor_text_select_tool.title=Միացնել գրոյթ ընտրելու գործիքը
+cursor_text_select_tool_label=Գրուածք ընտրելու գործիք
+cursor_hand_tool.title=Միացնել ձեռքի գործիքը
+cursor_hand_tool_label=Ձեռքի գործիք
+
+scroll_page.title=Աւգտագործել էջի ոլորում
+scroll_page_label=Էջի ոլորում
+scroll_vertical.title=Աւգտագործել ուղղահայեաց ոլորում
+scroll_vertical_label=Ուղղահայեաց ոլորում
+scroll_horizontal.title=Աւգտագործել հորիզոնական ոլորում
+scroll_horizontal_label=Հորիզոնական ոլորում
+scroll_wrapped.title=Աւգտագործել փաթաթուած ոլորում
+scroll_wrapped_label=Փաթաթուած ոլորում
+
+spread_none.title=Մի միացէք էջի կոնտեքստում
+spread_none_label=Չկայ կոնտեքստ
+spread_odd.title=Միացէք էջի կոնտեքստին սկսելով՝ կենտ համարակալուած էջերով
+spread_odd_label=Տարաւրինակ կոնտեքստ
+spread_even.title=Միացէք էջի կոնտեքստին սկսելով՝ զոյգ համարակալուած էջերով
+spread_even_label=Հաւասար վերածածկեր
+
+# Document properties dialog box
+document_properties.title=Փաստաթղթի հատկութիւնները…
+document_properties_label=Փաստաթղթի յատկութիւնները…
+document_properties_file_name=Նիշքի անունը․
+document_properties_file_size=Նիշք չափը.
+# LOCALIZATION NOTE (document_properties_kb): "{{size_kb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in kilobytes, respectively in bytes.
+document_properties_kb={{size_kb}} ԿԲ ({{size_b}} բայթ)
+# LOCALIZATION NOTE (document_properties_mb): "{{size_mb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in megabytes, respectively in bytes.
+document_properties_mb={{size_mb}} ՄԲ ({{size_b}} բայթ)
+document_properties_title=Վերնագիր
+document_properties_author=Հեղինակ․
+document_properties_subject=առարկայ
+document_properties_keywords=Հիմնաբառեր
+document_properties_creation_date=Ստեղծման ամսաթիւ
+document_properties_modification_date=Փոփոխութեան ամսաթիւ.
+# LOCALIZATION NOTE (document_properties_date_string): "{{date}}" and "{{time}}"
+# will be replaced by the creation/modification date, and time, of the PDF file.
+document_properties_date_string={{date}}, {{time}}
+document_properties_creator=Ստեղծող
+document_properties_producer=PDF-ի Արտադրողը.
+document_properties_version=PDF-ի տարբերակը.
+document_properties_page_count=Էջերի քանակը.
+document_properties_page_size=Էջի չափը.
+document_properties_page_size_unit_inches=ում
+document_properties_page_size_unit_millimeters=mm
+document_properties_page_size_orientation_portrait=ուղղաձիգ
+document_properties_page_size_orientation_landscape=հորիզոնական
+document_properties_page_size_name_a3=A3
+document_properties_page_size_name_a4=A4
+document_properties_page_size_name_letter=Նամակ
+document_properties_page_size_name_legal=Աւրինական
+# LOCALIZATION NOTE (document_properties_page_size_dimension_string):
+# "{{width}}", "{{height}}", {{unit}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement and orientation, of the (current) page.
+document_properties_page_size_dimension_string={{width}} × {{height}} {{unit}} ({{orientation}})
+# LOCALIZATION NOTE (document_properties_page_size_dimension_name_string):
+# "{{width}}", "{{height}}", {{unit}}, {{name}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement, name, and orientation, of the (current) page.
+document_properties_page_size_dimension_name_string={{width}} × {{height}} {{unit}} ({{name}}, {{orientation}})
+# LOCALIZATION NOTE (document_properties_linearized): The linearization status of
+# the document; usually called "Fast Web View" in English locales of Adobe software.
+document_properties_linearized=Արագ վեբ դիտում․
+document_properties_linearized_yes=Այո
+document_properties_linearized_no=Ոչ
+document_properties_close=Փակել
+
+print_progress_message=Նախապատրաստում է փաստաթուղթը տպելուն…
+# LOCALIZATION NOTE (print_progress_percent): "{{progress}}" will be replaced by
+# a numerical per cent value.
+print_progress_percent={{progress}}%
+print_progress_close=Չեղարկել
+
+# Tooltips and alt text for side panel toolbar buttons
+# (the _label strings are alt text for the buttons, the .title strings are
+# tooltips)
+toggle_sidebar.title=Փոխարկել կողային վահանակը
+toggle_sidebar_notification2.title=Փոխանջատել կողմնասիւնը (փաստաթուղթը պարունակում է ուրուագիծ/կցորդներ/շերտեր)
+toggle_sidebar_label=Փոխարկել կողային վահանակը
+document_outline.title=Ցուցադրել փաստաթղթի ուրուագիծը (կրկնակի սեղմէք՝ միաւորները ընդարձակելու/կոծկելու համար)
+document_outline_label=Փաստաթղթի ուրուագիծ
+attachments.title=Ցուցադրել կցորդները
+attachments_label=Կցորդներ
+layers.title=Ցուցադրել շերտերը (կրկնահպել վերակայելու բոլոր շերտերը սկզբնադիր վիճակի)
+layers_label=Շերտեր
+thumbs.title=Ցուցադրել մանրապատկերը
+thumbs_label=Մանրապատկեր
+current_outline_item.title=Գտէք ընթացիկ գծագրման տարրը
+current_outline_item_label=Ընթացիկ գծագրման տարր
+findbar.title=Գտնել փաստաթղթում
+findbar_label=Որոնում
+
+additional_layers=Լրացուցիչ շերտեր
+# LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
+page_landmark=Էջ {{page}}
+# Thumbnails panel item (tooltip and alt text for images)
+# LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
+# number.
+thumb_page_title=Էջը {{page}}
+# LOCALIZATION NOTE (thumb_page_canvas): "{{page}}" will be replaced by the page
+# number.
+thumb_page_canvas=Էջի մանրապատկերը {{page}}
+
+# Find panel button title and messages
+find_input.title=Որոնում
+find_input.placeholder=Գտնել փաստաթղթում…
+find_previous.title=Գտնել արտայայտութեան նախորդ արտայայտութիւնը
+find_previous_label=Նախորդը
+find_next.title=Գտիր արտայայտութեան յաջորդ արտայայտութիւնը
+find_next_label=Հաջորդը
+find_highlight=Գունանշել բոլորը
+find_match_case_label=Հաշուի առնել հանգամանքը
+find_match_diacritics_label=Հնչիւնատարբերիչ նշանների համապատասխանեցում
+find_entire_word_label=Ամբողջ բառերը
+find_reached_top=Հասել եք փաստաթղթի վերեւին,շարունակել ներքեւից
+find_reached_bottom=Հասել էք փաստաթղթի վերջին, շարունակել վերեւից
+# LOCALIZATION NOTE (find_match_count): The supported plural forms are
+# [one|two|few|many|other], with [other] as the default value.
+# "{{current}}" and "{{total}}" will be replaced by a number representing the
+# index of the currently active find result, respectively a number representing
+# the total number of matches in the document.
+find_match_count={[ plural(total) ]}
+find_match_count[one]={{current}} {{total}}-ի համընկնումից
+find_match_count[two]={{current}} {{total}}-ի համընկնումներից
+find_match_count[few]={{current}} {{total}}-ի համընկնումներից
+find_match_count[many]={{current}} {{total}}-ի համընկնումներից
+find_match_count[other]={{current}} {{total}}-ի համընկնումներից
+# LOCALIZATION NOTE (find_match_count_limit): The supported plural forms are
+# [zero|one|two|few|many|other], with [other] as the default value.
+# "{{limit}}" will be replaced by a numerical value.
+find_match_count_limit={[ plural(limit) ]}
+find_match_count_limit[zero]=Աւելին քան {{limit}} համընկնումները
+find_match_count_limit[one]=Աւելին քան {{limit}} համընկնումը
+find_match_count_limit[two]=Աւելին քան {{limit}} համընկնումները
+find_match_count_limit[few]=Աւելին քան {{limit}} համընկնումները
+find_match_count_limit[many]=Աւելին քան {{limit}} համընկնումները
+find_match_count_limit[other]=Աւելին քան {{limit}} համընկնումները
+find_not_found=Արտայայտութիւնը չգտնուեց
+
+# Predefined zoom values
+page_scale_width=Էջի լայնութիւն
+page_scale_fit=Հարմարեցնել էջը
+page_scale_auto=Ինքնաշխատ խոշորացում
+page_scale_actual=Իրական չափը
+# LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
+# numerical scale value.
+page_scale_percent={{scale}}%
+
+loading_error=PDF նիշքը բացելիս սխալ է տեղի ունեցել։
+invalid_file_error=Սխալ կամ վնասուած PDF նիշք։
+missing_file_error=PDF նիշքը բացակաիւմ է։
+unexpected_response_error=Սպասարկիչի անսպասելի պատասխան։
+
+rendering_error=Սխալ է տեղի ունեցել էջի մեկնաբանման ժամանակ
+
+# LOCALIZATION NOTE (annotation_date_string): "{{date}}" and "{{time}}" will be
+# replaced by the modification date, and time, of the annotation.
+annotation_date_string={{date}}, {{time}}
+
+# LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
+# "{{type}}" will be replaced with an annotation type from a list defined in
+# the PDF spec (32000-1:2008 Table 169 – Annotation types).
+# Some common types are e.g.: "Check", "Text", "Comment", "Note"
+text_annotation_type.alt=[{{type}} Ծանոթութիւն]
+password_label=Մուտքագրէք  գաղտնաբառը այս PDF նիշքը բացելու համար
+password_invalid=Գաղտնաբառը սխալ է: Կրկին փորձէք:
+password_ok=Լաւ
+password_cancel=Չեղարկել
+
+printing_not_supported=Զգուշացում. Տպելը ամբողջութեամբ չի աջակցուում զննարկիչի կողմից։
+printing_not_ready=Զգուշացում. PDF֊ը ամբողջութեամբ չի բեռնաւորուել տպելու համար։
+web_fonts_disabled=Վեբ-տառատեսակները անջատուած են. հնարաւոր չէ աւգտագործել ներկառուցուած PDF տառատեսակները։
+

--- a/js/pdfjs/web/locale/ia/viewer.properties
+++ b/js/pdfjs/web/locale/ia/viewer.properties
@@ -1,0 +1,257 @@
+# Copyright 2012 Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Main toolbar buttons (tooltips and alt text for images)
+previous.title=Pagina previe
+previous_label=Previe
+next.title=Pagina sequente
+next_label=Sequente
+
+# LOCALIZATION NOTE (page.title): The tooltip for the pageNumber input.
+page.title=Pagina
+# LOCALIZATION NOTE (of_pages): "{{pagesCount}}" will be replaced by a number
+# representing the total number of pages in the document.
+of_pages=de {{pagesCount}}
+# LOCALIZATION NOTE (page_of_pages): "{{pageNumber}}" and "{{pagesCount}}"
+# will be replaced by a number representing the currently visible page,
+# respectively a number representing the total number of pages in the document.
+page_of_pages=({{pageNumber}} de {{pagesCount}})
+
+zoom_out.title=Distantiar
+zoom_out_label=Distantiar
+zoom_in.title=Approximar
+zoom_in_label=Approximar
+zoom.title=Zoom
+presentation_mode.title=Excambiar a modo presentation
+presentation_mode_label=Modo presentation
+open_file.title=Aperir le file
+open_file_label=Aperir
+print.title=Imprimer
+print_label=Imprimer
+
+save.title=Salvar
+save_label=Salvar
+bookmark1.title=Pagina actual (vide le URL del pagina actual)
+bookmark1_label=Pagina actual
+
+open_in_app.title=Aperir in app
+open_in_app_label=Aperir in app
+
+# Secondary toolbar and context menu
+tools.title=Instrumentos
+tools_label=Instrumentos
+first_page.title=Ir al prime pagina
+first_page_label=Ir al prime pagina
+last_page.title=Ir al prime pagina
+last_page_label=Ir al prime pagina
+page_rotate_cw.title=Rotar in senso horari
+page_rotate_cw_label=Rotar in senso horari
+page_rotate_ccw.title=Rotar in senso antihorari
+page_rotate_ccw_label=Rotar in senso antihorari
+
+cursor_text_select_tool.title=Activar le instrumento de selection de texto
+cursor_text_select_tool_label=Instrumento de selection de texto
+cursor_hand_tool.title=Activar le instrumento mano
+cursor_hand_tool_label=Instrumento mano
+
+scroll_page.title=Usar rolamento de pagina
+scroll_page_label=Rolamento de pagina
+scroll_vertical.title=Usar rolamento vertical
+scroll_vertical_label=Rolamento vertical
+scroll_horizontal.title=Usar rolamento horizontal
+scroll_horizontal_label=Rolamento horizontal
+scroll_wrapped.title=Usar rolamento incapsulate
+scroll_wrapped_label=Rolamento incapsulate
+
+spread_none.title=Non junger paginas dual
+spread_none_label=Sin paginas dual
+spread_odd.title=Junger paginas dual a partir de paginas con numeros impar
+spread_odd_label=Paginas dual impar
+spread_even.title=Junger paginas dual a partir de paginas con numeros par
+spread_even_label=Paginas dual par
+
+# Document properties dialog box
+document_properties.title=Proprietates del documento…
+document_properties_label=Proprietates del documento…
+document_properties_file_name=Nomine del file:
+document_properties_file_size=Dimension de file:
+# LOCALIZATION NOTE (document_properties_kb): "{{size_kb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in kilobytes, respectively in bytes.
+document_properties_kb={{size_kb}} KB ({{size_b}} bytes)
+# LOCALIZATION NOTE (document_properties_mb): "{{size_mb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in megabytes, respectively in bytes.
+document_properties_mb={{size_mb}} MB ({{size_b}} bytes)
+document_properties_title=Titulo:
+document_properties_author=Autor:
+document_properties_subject=Subjecto:
+document_properties_keywords=Parolas clave:
+document_properties_creation_date=Data de creation:
+document_properties_modification_date=Data de modification:
+# LOCALIZATION NOTE (document_properties_date_string): "{{date}}" and "{{time}}"
+# will be replaced by the creation/modification date, and time, of the PDF file.
+document_properties_date_string={{date}}, {{time}}
+document_properties_creator=Creator:
+document_properties_producer=Productor PDF:
+document_properties_version=Version PDF:
+document_properties_page_count=Numero de paginas:
+document_properties_page_size=Dimension del pagina:
+document_properties_page_size_unit_inches=in
+document_properties_page_size_unit_millimeters=mm
+document_properties_page_size_orientation_portrait=vertical
+document_properties_page_size_orientation_landscape=horizontal
+document_properties_page_size_name_a3=A3
+document_properties_page_size_name_a4=A4
+document_properties_page_size_name_letter=Littera
+document_properties_page_size_name_legal=Legal
+# LOCALIZATION NOTE (document_properties_page_size_dimension_string):
+# "{{width}}", "{{height}}", {{unit}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement and orientation, of the (current) page.
+document_properties_page_size_dimension_string={{width}} × {{height}} {{unit}} ({{orientation}})
+# LOCALIZATION NOTE (document_properties_page_size_dimension_name_string):
+# "{{width}}", "{{height}}", {{unit}}, {{name}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement, name, and orientation, of the (current) page.
+document_properties_page_size_dimension_name_string={{width}} × {{height}} {{unit}} ({{name}}, {{orientation}})
+# LOCALIZATION NOTE (document_properties_linearized): The linearization status of
+# the document; usually called "Fast Web View" in English locales of Adobe software.
+document_properties_linearized=Vista web rapide:
+document_properties_linearized_yes=Si
+document_properties_linearized_no=No
+document_properties_close=Clauder
+
+print_progress_message=Preparation del documento pro le impression…
+# LOCALIZATION NOTE (print_progress_percent): "{{progress}}" will be replaced by
+# a numerical per cent value.
+print_progress_percent={{progress}}%
+print_progress_close=Cancellar
+
+# Tooltips and alt text for side panel toolbar buttons
+# (the _label strings are alt text for the buttons, the .title strings are
+# tooltips)
+toggle_sidebar.title=Monstrar/celar le barra lateral
+toggle_sidebar_notification2.title=Monstrar/celar le barra lateral (le documento contine structura/attachamentos/stratos)
+toggle_sidebar_label=Monstrar/celar le barra lateral
+document_outline.title=Monstrar le schema del documento (clic duple pro expander/contraher tote le elementos)
+document_outline_label=Schema del documento
+attachments.title=Monstrar le annexos
+attachments_label=Annexos
+layers.title=Monstrar stratos (clicca duple pro remontar tote le stratos al stato predefinite)
+layers_label=Stratos
+thumbs.title=Monstrar le vignettes
+thumbs_label=Vignettes
+current_outline_item.title=Trovar le elemento de structura actual
+current_outline_item_label=Elemento de structura actual
+findbar.title=Cercar in le documento
+findbar_label=Cercar
+
+additional_layers=Altere stratos
+# LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
+page_landmark=Pagina {{page}}
+# Thumbnails panel item (tooltip and alt text for images)
+# LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
+# number.
+thumb_page_title=Pagina {{page}}
+# LOCALIZATION NOTE (thumb_page_canvas): "{{page}}" will be replaced by the page
+# number.
+thumb_page_canvas=Vignette del pagina {{page}}
+
+# Find panel button title and messages
+find_input.title=Cercar
+find_input.placeholder=Cercar in le documento…
+find_previous.title=Trovar le previe occurrentia del phrase
+find_previous_label=Previe
+find_next.title=Trovar le successive occurrentia del phrase
+find_next_label=Sequente
+find_highlight=Evidentiar toto
+find_match_case_label=Distinguer majusculas/minusculas
+find_match_diacritics_label=Differentiar diacriticos
+find_entire_word_label=Parolas integre
+find_reached_top=Initio del documento attingite, continuation ab fin
+find_reached_bottom=Fin del documento attingite, continuation ab initio
+# LOCALIZATION NOTE (find_match_count): The supported plural forms are
+# [one|two|few|many|other], with [other] as the default value.
+# "{{current}}" and "{{total}}" will be replaced by a number representing the
+# index of the currently active find result, respectively a number representing
+# the total number of matches in the document.
+find_match_count={[ plural(total) ]}
+find_match_count[one]={{current}} de {{total}} concordantia
+find_match_count[two]={{current}} de {{total}} concordantias
+find_match_count[few]={{current}} de {{total}} concordantias
+find_match_count[many]={{current}} de {{total}} concordantias
+find_match_count[other]={{current}} de {{total}} concordantias
+# LOCALIZATION NOTE (find_match_count_limit): The supported plural forms are
+# [zero|one|two|few|many|other], with [other] as the default value.
+# "{{limit}}" will be replaced by a numerical value.
+find_match_count_limit={[ plural(limit) ]}
+find_match_count_limit[zero]=Plus de {{limit}} concordantias
+find_match_count_limit[one]=Plus de {{limit}} concordantia
+find_match_count_limit[two]=Plus de {{limit}} concordantias
+find_match_count_limit[few]=Plus de {{limit}} concordantias
+find_match_count_limit[many]=Plus de {{limit}} correspondentias
+find_match_count_limit[other]=Plus de {{limit}} concordantias
+find_not_found=Phrase non trovate
+
+# Predefined zoom values
+page_scale_width=Plen largor del pagina
+page_scale_fit=Pagina integre
+page_scale_auto=Zoom automatic
+page_scale_actual=Dimension real
+# LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
+# numerical scale value.
+page_scale_percent={{scale}}%
+
+# Loading indicator messages
+loading_error=Un error occurreva durante que on cargava le file PDF.
+invalid_file_error=File PDF corrumpite o non valide.
+missing_file_error=File PDF mancante.
+unexpected_response_error=Responsa del servitor inexpectate.
+
+rendering_error=Un error occurreva durante que on processava le pagina.
+
+# LOCALIZATION NOTE (annotation_date_string): "{{date}}" and "{{time}}" will be
+# replaced by the modification date, and time, of the annotation.
+annotation_date_string={{date}}, {{time}}
+
+# LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
+# "{{type}}" will be replaced with an annotation type from a list defined in
+# the PDF spec (32000-1:2008 Table 169 – Annotation types).
+# Some common types are e.g.: "Check", "Text", "Comment", "Note"
+text_annotation_type.alt=[{{type}} Annotation]
+password_label=Insere le contrasigno pro aperir iste file PDF.
+password_invalid=Contrasigno invalide. Per favor retenta.
+password_ok=OK
+password_cancel=Cancellar
+
+printing_not_supported=Attention : le impression non es totalmente supportate per ce navigator.
+printing_not_ready=Attention: le file PDF non es integremente cargate pro lo poter imprimer.
+web_fonts_disabled=Le typos de litteras web es disactivate: impossibile usar le typos de litteras PDF incorporate.
+
+# Editor
+editor_free_text2.title=Texto
+editor_free_text2_label=Texto
+editor_ink2.title=Designar
+editor_ink2_label=Designar
+
+free_text2_default_content=Comenciar a scriber…
+
+# Editor Parameters
+editor_free_text_color=Color
+editor_free_text_size=Dimension
+editor_ink_color=Color
+editor_ink_thickness=Spissor
+editor_ink_opacity=Opacitate
+
+# Editor aria
+editor_free_text2_aria_label=Editor de texto
+editor_ink2_aria_label=Editor de designos
+editor_ink_canvas_aria_label=Imagine create per le usator

--- a/js/pdfjs/web/locale/id/viewer.properties
+++ b/js/pdfjs/web/locale/id/viewer.properties
@@ -1,0 +1,253 @@
+# Copyright 2012 Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Main toolbar buttons (tooltips and alt text for images)
+previous.title=Laman Sebelumnya
+previous_label=Sebelumnya
+next.title=Laman Selanjutnya
+next_label=Selanjutnya
+
+# LOCALIZATION NOTE (page.title): The tooltip for the pageNumber input.
+page.title=Halaman
+# LOCALIZATION NOTE (of_pages): "{{pagesCount}}" will be replaced by a number
+# representing the total number of pages in the document.
+of_pages=dari {{pagesCount}}
+# LOCALIZATION NOTE (page_of_pages): "{{pageNumber}}" and "{{pagesCount}}"
+# will be replaced by a number representing the currently visible page,
+# respectively a number representing the total number of pages in the document.
+page_of_pages=({{pageNumber}} dari {{pagesCount}})
+
+zoom_out.title=Perkecil
+zoom_out_label=Perkecil
+zoom_in.title=Perbesar
+zoom_in_label=Perbesar
+zoom.title=Perbesaran
+presentation_mode.title=Ganti ke Mode Presentasi
+presentation_mode_label=Mode Presentasi
+open_file.title=Buka Berkas
+open_file_label=Buka
+print.title=Cetak
+print_label=Cetak
+save.title=Simpan
+save_label=Simpan
+
+bookmark1.title=Laman Saat Ini (Lihat URL dari Laman Sekarang)
+bookmark1_label=Laman Saat Ini
+
+# Secondary toolbar and context menu
+tools.title=Alat
+tools_label=Alat
+first_page.title=Buka Halaman Pertama
+first_page_label=Buka Halaman Pertama
+last_page.title=Buka Halaman Terakhir
+last_page_label=Buka Halaman Terakhir
+page_rotate_cw.title=Putar Searah Jarum Jam
+page_rotate_cw_label=Putar Searah Jarum Jam
+page_rotate_ccw.title=Putar Berlawanan Arah Jarum Jam
+page_rotate_ccw_label=Putar Berlawanan Arah Jarum Jam
+
+cursor_text_select_tool.title=Aktifkan Alat Seleksi Teks
+cursor_text_select_tool_label=Alat Seleksi Teks
+cursor_hand_tool.title=Aktifkan Alat Tangan
+cursor_hand_tool_label=Alat Tangan
+
+scroll_page.title=Gunakan Pengguliran Laman
+scroll_page_label=Pengguliran Laman
+scroll_vertical.title=Gunakan Penggeseran Vertikal
+scroll_vertical_label=Penggeseran Vertikal
+scroll_horizontal.title=Gunakan Penggeseran Horizontal
+scroll_horizontal_label=Penggeseran Horizontal
+scroll_wrapped.title=Gunakan Penggeseran Terapit
+scroll_wrapped_label=Penggeseran Terapit
+
+spread_none.title=Jangan gabungkan lembar halaman
+spread_none_label=Tidak Ada Lembaran
+spread_odd.title=Gabungkan lembar lamanan mulai dengan halaman ganjil
+spread_odd_label=Lembaran Ganjil
+spread_even.title=Gabungkan lembar halaman dimulai dengan halaman genap
+spread_even_label=Lembaran Genap
+
+# Document properties dialog box
+document_properties.title=Properti Dokumen…
+document_properties_label=Properti Dokumen…
+document_properties_file_name=Nama berkas:
+document_properties_file_size=Ukuran berkas:
+# LOCALIZATION NOTE (document_properties_kb): "{{size_kb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in kilobytes, respectively in bytes.
+document_properties_kb={{size_kb}} KB ({{size_b}} byte)
+# LOCALIZATION NOTE (document_properties_mb): "{{size_mb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in megabytes, respectively in bytes.
+document_properties_mb={{size_mb}} MB ({{size_b}} byte)
+document_properties_title=Judul:
+document_properties_author=Penyusun:
+document_properties_subject=Subjek:
+document_properties_keywords=Kata Kunci:
+document_properties_creation_date=Tanggal Dibuat:
+document_properties_modification_date=Tanggal Dimodifikasi:
+# LOCALIZATION NOTE (document_properties_date_string): "{{date}}" and "{{time}}"
+# will be replaced by the creation/modification date, and time, of the PDF file.
+document_properties_date_string={{date}}, {{time}}
+document_properties_creator=Pembuat:
+document_properties_producer=Pemroduksi PDF:
+document_properties_version=Versi PDF:
+document_properties_page_count=Jumlah Halaman:
+document_properties_page_size=Ukuran Laman:
+document_properties_page_size_unit_inches=inci
+document_properties_page_size_unit_millimeters=mm
+document_properties_page_size_orientation_portrait=tegak
+document_properties_page_size_orientation_landscape=mendatar
+document_properties_page_size_name_a3=A3
+document_properties_page_size_name_a4=A4
+document_properties_page_size_name_letter=Letter
+document_properties_page_size_name_legal=Legal
+# LOCALIZATION NOTE (document_properties_page_size_dimension_string):
+# "{{width}}", "{{height}}", {{unit}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement and orientation, of the (current) page.
+document_properties_page_size_dimension_string={{width}} × {{height}} {{unit}} ({{orientation}})
+# LOCALIZATION NOTE (document_properties_page_size_dimension_name_string):
+# "{{width}}", "{{height}}", {{unit}}, {{name}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement, name, and orientation, of the (current) page.
+document_properties_page_size_dimension_name_string={{width}} × {{height}} {{unit}} ({{name}}, {{orientation}})
+# LOCALIZATION NOTE (document_properties_linearized): The linearization status of
+# the document; usually called "Fast Web View" in English locales of Adobe software.
+document_properties_linearized=Tampilan Web Kilat:
+document_properties_linearized_yes=Ya
+document_properties_linearized_no=Tidak
+document_properties_close=Tutup
+
+print_progress_message=Menyiapkan dokumen untuk pencetakan…
+# LOCALIZATION NOTE (print_progress_percent): "{{progress}}" will be replaced by
+# a numerical per cent value.
+print_progress_percent={{progress}}%
+print_progress_close=Batalkan
+
+# Tooltips and alt text for side panel toolbar buttons
+# (the _label strings are alt text for the buttons, the .title strings are
+# tooltips)
+toggle_sidebar.title=Aktif/Nonaktifkan Bilah Samping
+toggle_sidebar_notification2.title=Aktif/Nonaktifkan Bilah Samping (dokumen berisi kerangka/lampiran/lapisan)
+toggle_sidebar_label=Aktif/Nonaktifkan Bilah Samping
+document_outline.title=Tampilkan Kerangka Dokumen (klik ganda untuk membentangkan/menciutkan semua item)
+document_outline_label=Kerangka Dokumen
+attachments.title=Tampilkan Lampiran
+attachments_label=Lampiran
+layers.title=Tampilkan Lapisan (klik ganda untuk mengatur ulang semua lapisan ke keadaan baku)
+layers_label=Lapisan
+thumbs.title=Tampilkan Miniatur
+thumbs_label=Miniatur
+current_outline_item.title=Cari Butir Ikhtisar Saat Ini
+current_outline_item_label=Butir Ikhtisar Saat Ini
+findbar.title=Temukan di Dokumen
+findbar_label=Temukan
+
+additional_layers=Lapisan Tambahan
+# LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
+page_landmark=Halaman {{page}}
+# Thumbnails panel item (tooltip and alt text for images)
+# LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
+# number.
+thumb_page_title=Laman {{page}}
+# LOCALIZATION NOTE (thumb_page_canvas): "{{page}}" will be replaced by the page
+# number.
+thumb_page_canvas=Miniatur Laman {{page}}
+
+# Find panel button title and messages
+find_input.title=Temukan
+find_input.placeholder=Temukan di dokumen…
+find_previous.title=Temukan kata sebelumnya
+find_previous_label=Sebelumnya
+find_next.title=Temukan lebih lanjut
+find_next_label=Selanjutnya
+find_highlight=Sorot semuanya
+find_match_case_label=Cocokkan BESAR/kecil
+find_match_diacritics_label=Pencocokan Diakritik
+find_entire_word_label=Seluruh teks
+find_reached_top=Sampai di awal dokumen, dilanjutkan dari bawah
+find_reached_bottom=Sampai di akhir dokumen, dilanjutkan dari atas
+# LOCALIZATION NOTE (find_match_count): The supported plural forms are
+# [one|two|few|many|other], with [other] as the default value.
+# "{{current}}" and "{{total}}" will be replaced by a number representing the
+# index of the currently active find result, respectively a number representing
+# the total number of matches in the document.
+find_match_count={[ plural(total) ]}
+find_match_count[one]={{current}} dari {{total}} hasil
+find_match_count[two]={{current}} dari {{total}} hasil
+find_match_count[few]={{current}} dari {{total}} hasil
+find_match_count[many]={{current}} dari {{total}} hasil
+find_match_count[other]={{current}} dari {{total}} hasil
+# LOCALIZATION NOTE (find_match_count_limit): The supported plural forms are
+# [zero|one|two|few|many|other], with [other] as the default value.
+# "{{limit}}" will be replaced by a numerical value.
+find_match_count_limit={[ plural(limit) ]}
+find_match_count_limit[zero]=Ditemukan lebih dari {{limit}}
+find_match_count_limit[one]=Ditemukan lebih dari {{limit}}
+find_match_count_limit[two]=Ditemukan lebih dari {{limit}}
+find_match_count_limit[few]=Ditemukan lebih dari {{limit}}
+find_match_count_limit[many]=Ditemukan lebih dari {{limit}}
+find_match_count_limit[other]=Ditemukan lebih dari {{limit}}
+find_not_found=Frasa tidak ditemukan
+
+# Predefined zoom values
+page_scale_width=Lebar Laman
+page_scale_fit=Muat Laman
+page_scale_auto=Perbesaran Otomatis
+page_scale_actual=Ukuran Asli
+# LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
+# numerical scale value.
+page_scale_percent={{scale}}%
+
+loading_error=Galat terjadi saat memuat PDF.
+invalid_file_error=Berkas PDF tidak valid atau rusak.
+missing_file_error=Berkas PDF tidak ada.
+unexpected_response_error=Balasan server yang tidak diharapkan.
+
+rendering_error=Galat terjadi saat merender laman.
+
+# LOCALIZATION NOTE (annotation_date_string): "{{date}}" and "{{time}}" will be
+# replaced by the modification date, and time, of the annotation.
+annotation_date_string={{date}}, {{time}}
+
+# LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
+# "{{type}}" will be replaced with an annotation type from a list defined in
+# the PDF spec (32000-1:2008 Table 169 – Annotation types).
+# Some common types are e.g.: "Check", "Text", "Comment", "Note"
+text_annotation_type.alt=[Anotasi {{type}}]
+password_label=Masukkan sandi untuk membuka berkas PDF ini.
+password_invalid=Sandi tidak valid. Silakan coba lagi.
+password_ok=Oke
+password_cancel=Batal
+
+printing_not_supported=Peringatan: Pencetakan tidak didukung secara lengkap pada peramban ini.
+printing_not_ready=Peringatan: Berkas PDF masih belum dimuat secara lengkap untuk dapat dicetak.
+web_fonts_disabled=Font web dinonaktifkan: tidak dapat menggunakan font PDF yang tersemat.
+
+# Editor
+editor_free_text2.title=Teks
+editor_free_text2_label=Teks
+editor_ink2.title=Gambar
+editor_ink2_label=Gambar
+
+free_text2_default_content=Mulai mengetik…
+
+# Editor Parameters
+editor_free_text_color=Warna
+editor_free_text_size=Ukuran
+editor_ink_color=Warna
+editor_ink_thickness=Ketebalan
+editor_ink_opacity=Opasitas
+
+# Editor aria
+editor_free_text2_aria_label=Editor Teks
+editor_ink2_aria_label=Editor Gambar
+editor_ink_canvas_aria_label=Gambar yang dibuat pengguna

--- a/js/pdfjs/web/locale/is/viewer.properties
+++ b/js/pdfjs/web/locale/is/viewer.properties
@@ -1,0 +1,259 @@
+# Copyright 2012 Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Main toolbar buttons (tooltips and alt text for images)
+previous.title=Fyrri síða
+previous_label=Fyrri
+next.title=Næsta síða
+next_label=Næsti
+
+# LOCALIZATION NOTE (page.title): The tooltip for the pageNumber input.
+page.title=Síða
+# LOCALIZATION NOTE (of_pages): "{{pagesCount}}" will be replaced by a number
+# representing the total number of pages in the document.
+of_pages=af {{pagesCount}}
+# LOCALIZATION NOTE (page_of_pages): "{{pageNumber}}" and "{{pagesCount}}"
+# will be replaced by a number representing the currently visible page,
+# respectively a number representing the total number of pages in the document.
+page_of_pages=({{pageNumber}} af {{pagesCount}})
+
+zoom_out.title=Minnka aðdrátt
+zoom_out_label=Minnka aðdrátt
+zoom_in.title=Auka aðdrátt
+zoom_in_label=Auka aðdrátt
+zoom.title=Aðdráttur
+presentation_mode.title=Skipta yfir á kynningarham
+presentation_mode_label=Kynningarhamur
+open_file.title=Opna skrá
+open_file_label=Opna
+print.title=Prenta
+print_label=Prenta
+save.title=Vista
+save_label=Vista
+bookmark1.title=Núverandi síða (Skoða vefslóð frá núverandi síðu)
+bookmark1_label=Núverandi síða
+# LOCALIZATION NOTE (open_in_app.title): This string is used in Firefox for Android.
+open_in_app.title=Opna í smáforriti
+# LOCALIZATION NOTE (open_in_app_label): This string is used in Firefox for Android. Length of the translation matters since we are in a mobile context, with limited screen estate.
+open_in_app_label=Opna í smáforriti
+
+# Secondary toolbar and context menu
+tools.title=Verkfæri
+tools_label=Verkfæri
+first_page.title=Fara á fyrstu síðu
+first_page_label=Fara á fyrstu síðu
+last_page.title=Fara á síðustu síðu
+last_page_label=Fara á síðustu síðu
+page_rotate_cw.title=Snúa réttsælis
+page_rotate_cw_label=Snúa réttsælis
+page_rotate_ccw.title=Snúa rangsælis
+page_rotate_ccw_label=Snúa rangsælis
+
+cursor_text_select_tool.title=Virkja textavalsáhald
+cursor_text_select_tool_label=Textavalsáhald
+cursor_hand_tool.title=Virkja handarverkfæri
+cursor_hand_tool_label=Handarverkfæri
+
+scroll_page.title=Nota síðuskrun
+scroll_page_label=Síðuskrun
+scroll_vertical.title=Nota lóðrétt skrun
+scroll_vertical_label=Lóðrétt skrun
+scroll_horizontal.title=Nota lárétt skrun
+scroll_horizontal_label=Lárétt skrun
+scroll_wrapped.title=Nota línuskipt síðuskrun
+scroll_wrapped_label=Línuskipt síðuskrun
+
+spread_none.title=Ekki taka þátt í dreifingu síðna
+spread_none_label=Engin dreifing
+spread_odd.title=Taka þátt í dreifingu síðna með oddatölum
+spread_odd_label=Oddatöludreifing
+spread_even.title=Taktu þátt í dreifingu síðna með jöfnuntölum
+spread_even_label=Jafnatöludreifing
+
+# Document properties dialog box
+document_properties.title=Eiginleikar skjals…
+document_properties_label=Eiginleikar skjals…
+document_properties_file_name=Skráarnafn:
+document_properties_file_size=Skrárstærð:
+# LOCALIZATION NOTE (document_properties_kb): "{{size_kb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in kilobytes, respectively in bytes.
+document_properties_kb={{size_kb}} KB ({{size_b}} bytes)
+# LOCALIZATION NOTE (document_properties_mb): "{{size_mb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in megabytes, respectively in bytes.
+document_properties_mb={{size_mb}} MB ({{size_b}} bytes)
+document_properties_title=Titill:
+document_properties_author=Hönnuður:
+document_properties_subject=Efni:
+document_properties_keywords=Stikkorð:
+document_properties_creation_date=Búið til:
+document_properties_modification_date=Dags breytingar:
+# LOCALIZATION NOTE (document_properties_date_string): "{{date}}" and "{{time}}"
+# will be replaced by the creation/modification date, and time, of the PDF file.
+document_properties_date_string={{date}}, {{time}}
+document_properties_creator=Höfundur:
+document_properties_producer=PDF framleiðandi:
+document_properties_version=PDF útgáfa:
+document_properties_page_count=Blaðsíðufjöldi:
+document_properties_page_size=Stærð síðu:
+document_properties_page_size_unit_inches=in
+document_properties_page_size_unit_millimeters=mm
+document_properties_page_size_orientation_portrait=skammsnið
+document_properties_page_size_orientation_landscape=langsnið
+document_properties_page_size_name_a3=A3
+document_properties_page_size_name_a4=A4
+document_properties_page_size_name_letter=Letter
+document_properties_page_size_name_legal=Legal
+# LOCALIZATION NOTE (document_properties_page_size_dimension_string):
+# "{{width}}", "{{height}}", {{unit}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement and orientation, of the (current) page.
+document_properties_page_size_dimension_string={{width}} × {{height}} {{unit}} ({{orientation}})
+# LOCALIZATION NOTE (document_properties_page_size_dimension_name_string):
+# "{{width}}", "{{height}}", {{unit}}, {{name}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement, name, and orientation, of the (current) page.
+document_properties_page_size_dimension_name_string={{width}} × {{height}} {{unit}} ({{name}}, {{orientation}})
+# LOCALIZATION NOTE (document_properties_linearized): The linearization status of
+# the document; usually called "Fast Web View" in English locales of Adobe software.
+document_properties_linearized=Fljótleg vefskoðun:
+document_properties_linearized_yes=Já
+document_properties_linearized_no=Nei
+document_properties_close=Loka
+
+print_progress_message=Undirbý skjal fyrir prentun…
+# LOCALIZATION NOTE (print_progress_percent): "{{progress}}" will be replaced by
+# a numerical per cent value.
+print_progress_percent={{progress}}%
+print_progress_close=Hætta við
+
+# Tooltips and alt text for side panel toolbar buttons
+# (the _label strings are alt text for the buttons, the .title strings are
+# tooltips)
+toggle_sidebar.title=Víxla hliðarspjaldi af/á
+toggle_sidebar_notification2.title=Víxla hliðarslá (skjal inniheldur yfirlit/viðhengi/lög)
+toggle_sidebar_label=Víxla hliðarspjaldi af/á
+document_outline.title=Sýna yfirlit skjals (tvísmelltu til að opna/loka öllum hlutum)
+document_outline_label=Efnisskipan skjals
+attachments.title=Sýna viðhengi
+attachments_label=Viðhengi
+layers.title=Birta lög (tvísmelltu til að endurstilla öll lög í sjálfgefna stöðu)
+layers_label=Lög
+thumbs.title=Sýna smámyndir
+thumbs_label=Smámyndir
+current_outline_item.title=Finna núverandi atriði efnisskipunar
+current_outline_item_label=Núverandi atriði efnisskipunar
+findbar.title=Leita í skjali
+findbar_label=Leita
+
+additional_layers=Viðbótarlög
+# LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
+page_landmark=Síða {{page}}
+# Thumbnails panel item (tooltip and alt text for images)
+# LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
+# number.
+thumb_page_title=Síða {{page}}
+# LOCALIZATION NOTE (thumb_page_canvas): "{{page}}" will be replaced by the page
+# number.
+thumb_page_canvas=Smámynd af síðu {{page}}
+
+# Find panel button title and messages
+find_input.title=Leita
+find_input.placeholder=Leita í skjali…
+find_previous.title=Leita að fyrra tilfelli þessara orða
+find_previous_label=Fyrri
+find_next.title=Leita að næsta tilfelli þessara orða
+find_next_label=Næsti
+find_highlight=Lita allt
+find_match_case_label=Passa við stafstöðu
+find_match_diacritics_label=Passa við broddstafi
+find_entire_word_label=Heil orð
+find_reached_top=Náði efst í skjal, held áfram neðst
+find_reached_bottom=Náði enda skjals, held áfram efst
+# LOCALIZATION NOTE (find_match_count): The supported plural forms are
+# [one|two|few|many|other], with [other] as the default value.
+# "{{current}}" and "{{total}}" will be replaced by a number representing the
+# index of the currently active find result, respectively a number representing
+# the total number of matches in the document.
+find_match_count={[ plural(total) ]}
+find_match_count[one]={{current}} af {{total}} niðurstöðu
+find_match_count[two]={{current}} af {{total}} niðurstöðum
+find_match_count[few]={{current}} af {{total}} niðurstöðum
+find_match_count[many]={{current}} af {{total}} niðurstöðum
+find_match_count[other]={{current}} af {{total}} niðurstöðum
+# LOCALIZATION NOTE (find_match_count_limit): The supported plural forms are
+# [zero|one|two|few|many|other], with [other] as the default value.
+# "{{limit}}" will be replaced by a numerical value.
+find_match_count_limit={[ plural(limit) ]}
+find_match_count_limit[zero]=Fleiri en {{limit}} niðurstöður
+find_match_count_limit[one]=Fleiri en {{limit}} niðurstaða
+find_match_count_limit[two]=Fleiri en {{limit}} niðurstöður
+find_match_count_limit[few]=Fleiri en {{limit}} niðurstöður
+find_match_count_limit[many]=Fleiri en {{limit}} niðurstöður
+find_match_count_limit[other]=Fleiri en {{limit}} niðurstöður
+find_not_found=Fann ekki orðið
+
+# Predefined zoom values
+page_scale_width=Síðubreidd
+page_scale_fit=Passa á síðu
+page_scale_auto=Sjálfvirkur aðdráttur
+page_scale_actual=Raunstærð
+# LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
+# numerical scale value.
+page_scale_percent={{scale}}%
+
+# Loading indicator messages
+loading_error=Villa kom upp við að hlaða inn PDF.
+invalid_file_error=Ógild eða skemmd PDF skrá.
+missing_file_error=Vantar PDF skrá.
+unexpected_response_error=Óvænt svar frá netþjóni.
+rendering_error=Upp kom villa við að birta síðuna.
+
+# LOCALIZATION NOTE (annotation_date_string): "{{date}}" and "{{time}}" will be
+# replaced by the modification date, and time, of the annotation.
+annotation_date_string={{date}}, {{time}}
+
+# LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
+# "{{type}}" will be replaced with an annotation type from a list defined in
+# the PDF spec (32000-1:2008 Table 169 – Annotation types).
+# Some common types are e.g.: "Check", "Text", "Comment", "Note"
+text_annotation_type.alt=[{{type}} Skýring]
+password_label=Sláðu inn lykilorð til að opna þessa PDF skrá.
+password_invalid=Ógilt lykilorð. Reyndu aftur.
+password_ok=Í lagi
+password_cancel=Hætta við
+
+printing_not_supported=Aðvörun: Prentun er ekki með fyllilegan stuðning á þessum vafra.
+printing_not_ready=Aðvörun: Ekki er búið að hlaða inn allri PDF skránni fyrir prentun.
+web_fonts_disabled=Vef leturgerðir eru óvirkar: get ekki notað innbyggðar PDF leturgerðir.
+
+# Editor
+editor_free_text2.title=Texti
+editor_free_text2_label=Texti
+editor_ink2.title=Teikna
+editor_ink2_label=Teikna
+
+editor_stamp.title=Bæta við mynd
+editor_stamp_label=Bæta við mynd
+
+free_text2_default_content=Byrjaðu að skrifa…
+
+# Editor Parameters
+editor_free_text_color=Litur
+editor_free_text_size=Stærð
+editor_ink_color=Litur
+editor_ink_thickness=Þykkt
+editor_ink_opacity=Ógegnsæi
+
+# Editor aria
+editor_free_text2_aria_label=Textaritill
+editor_ink2_aria_label=Teikniritill
+editor_ink_canvas_aria_label=Mynd gerð af notanda

--- a/js/pdfjs/web/locale/it/viewer.properties
+++ b/js/pdfjs/web/locale/it/viewer.properties
@@ -1,0 +1,210 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# Copyright 2012 Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+previous.title = Pagina precedente
+previous_label = Precedente
+next.title = Pagina successiva
+next_label = Successiva
+
+page.title = Pagina
+of_pages = di {{pagesCount}}
+page_of_pages = ({{pageNumber}} di {{pagesCount}})
+
+zoom_out.title = Riduci zoom
+zoom_out_label = Riduci zoom
+zoom_in.title = Aumenta zoom
+zoom_in_label = Aumenta zoom
+zoom.title = Zoom
+presentation_mode.title = Passa alla modalità presentazione
+presentation_mode_label = Modalità presentazione
+open_file.title = Apri file
+open_file_label = Apri
+print.title = Stampa
+print_label = Stampa
+
+save.title = Salva
+save_label = Salva
+bookmark1.title = Pagina corrente (mostra URL della pagina corrente)
+bookmark1_label = Pagina corrente
+open_in_app.title = Apri in app
+open_in_app_label = Apri in app
+
+tools.title = Strumenti
+tools_label = Strumenti
+first_page.title = Vai alla prima pagina
+first_page_label = Vai alla prima pagina
+last_page.title = Vai all’ultima pagina
+last_page_label = Vai all’ultima pagina
+page_rotate_cw.title = Ruota in senso orario
+page_rotate_cw_label = Ruota in senso orario
+page_rotate_ccw.title = Ruota in senso antiorario
+page_rotate_ccw_label = Ruota in senso antiorario
+
+cursor_text_select_tool.title = Attiva strumento di selezione testo
+cursor_text_select_tool_label = Strumento di selezione testo
+cursor_hand_tool.title = Attiva strumento mano
+cursor_hand_tool_label = Strumento mano
+
+scroll_page.title = Utilizza scorrimento pagine
+scroll_page_label = Scorrimento pagine
+scroll_vertical.title = Scorri le pagine in verticale
+scroll_vertical_label = Scorrimento verticale
+scroll_horizontal.title = Scorri le pagine in orizzontale
+scroll_horizontal_label = Scorrimento orizzontale
+scroll_wrapped.title = Scorri le pagine in verticale, disponendole da sinistra a destra e andando a capo automaticamente
+scroll_wrapped_label = Scorrimento con a capo automatico
+
+spread_none.title = Non raggruppare pagine
+spread_none_label = Nessun raggruppamento
+spread_odd.title = Crea gruppi di pagine che iniziano con numeri di pagina dispari
+spread_odd_label = Raggruppamento dispari
+spread_even.title = Crea gruppi di pagine che iniziano con numeri di pagina pari
+spread_even_label = Raggruppamento pari
+
+document_properties.title = Proprietà del documento…
+document_properties_label = Proprietà del documento…
+document_properties_file_name = Nome file:
+document_properties_file_size = Dimensione file:
+document_properties_kb = {{size_kb}} kB ({{size_b}} byte)
+document_properties_mb = {{size_mb}} MB ({{size_b}} byte)
+document_properties_title = Titolo:
+document_properties_author = Autore:
+document_properties_subject = Oggetto:
+document_properties_keywords = Parole chiave:
+document_properties_creation_date = Data creazione:
+document_properties_modification_date = Data modifica:
+document_properties_date_string = {{date}}, {{time}}
+document_properties_creator = Autore originale:
+document_properties_producer = Produttore PDF:
+document_properties_version = Versione PDF:
+document_properties_page_count = Conteggio pagine:
+document_properties_page_size = Dimensioni pagina:
+document_properties_page_size_unit_inches = in
+document_properties_page_size_unit_millimeters = mm
+document_properties_page_size_orientation_portrait = verticale
+document_properties_page_size_orientation_landscape = orizzontale
+document_properties_page_size_name_a3 = A3
+document_properties_page_size_name_a4 = A4
+document_properties_page_size_name_letter = Lettera
+document_properties_page_size_name_legal = Legale
+document_properties_page_size_dimension_string = {{width}} × {{height}} {{unit}} ({{orientation}})
+document_properties_page_size_dimension_name_string = {{width}} × {{height}} {{unit}} ({{name}}, {{orientation}})
+document_properties_linearized = Visualizzazione web veloce:
+document_properties_linearized_yes = Sì
+document_properties_linearized_no = No
+document_properties_close = Chiudi
+
+print_progress_message = Preparazione documento per la stampa…
+print_progress_percent = {{progress}}%
+print_progress_close = Annulla
+
+toggle_sidebar.title = Attiva/disattiva barra laterale
+toggle_sidebar_notification2.title = Attiva/disattiva barra laterale (il documento contiene struttura/allegati/livelli)
+toggle_sidebar_label = Attiva/disattiva barra laterale
+document_outline.title = Visualizza la struttura del documento (doppio clic per visualizzare/comprimere tutti gli elementi)
+document_outline_label = Struttura documento
+attachments.title = Visualizza allegati
+attachments_label = Allegati
+layers.title = Visualizza livelli (doppio clic per ripristinare tutti i livelli allo stato predefinito)
+layers_label = Livelli
+thumbs.title = Mostra le miniature
+thumbs_label = Miniature
+current_outline_item.title = Trova elemento struttura corrente
+current_outline_item_label = Elemento struttura corrente
+findbar.title = Trova nel documento
+findbar_label = Trova
+
+additional_layers = Livelli aggiuntivi
+page_landmark = Pagina {{page}}
+thumb_page_title = Pagina {{page}}
+thumb_page_canvas = Miniatura della pagina {{page}}
+
+find_input.title = Trova
+find_input.placeholder = Trova nel documento…
+find_previous.title = Trova l’occorrenza precedente del testo da cercare
+find_previous_label = Precedente
+find_next.title = Trova l’occorrenza successiva del testo da cercare
+find_next_label = Successivo
+find_highlight = Evidenzia
+find_match_case_label = Maiuscole/minuscole
+find_match_diacritics_label = Segni diacritici
+find_entire_word_label = Parole intere
+find_reached_top = Raggiunto l’inizio della pagina, continua dalla fine
+find_reached_bottom = Raggiunta la fine della pagina, continua dall’inizio
+find_match_count = {[ plural(total) ]}
+find_match_count[one] = {{current}} di {{total}} corrispondenza
+find_match_count[two] = {{current}} di {{total}} corrispondenze
+find_match_count[few] = {{current}} di {{total}} corrispondenze
+find_match_count[many] = {{current}} di {{total}} corrispondenze
+find_match_count[other] = {{current}} di {{total}} corrispondenze
+find_match_count_limit = {[ plural(limit) ]}
+find_match_count_limit[zero] = Più di {{limit}} corrispondenze
+find_match_count_limit[one] = Più di {{limit}} corrispondenza
+find_match_count_limit[two] = Più di {{limit}} corrispondenze
+find_match_count_limit[few] = Più di {{limit}} corrispondenze
+find_match_count_limit[many] = Più di {{limit}} corrispondenze
+find_match_count_limit[other] = Più di {{limit}} corrispondenze
+find_not_found = Testo non trovato
+
+page_scale_width = Larghezza pagina
+page_scale_fit = Adatta a una pagina
+page_scale_auto = Zoom automatico
+page_scale_actual = Dimensioni effettive
+page_scale_percent = {{scale}}%
+
+loading_error = Si è verificato un errore durante il caricamento del PDF.
+invalid_file_error = File PDF non valido o danneggiato.
+missing_file_error = File PDF non disponibile.
+unexpected_response_error = Risposta imprevista del server
+
+rendering_error = Si è verificato un errore durante il rendering della pagina.
+
+annotation_date_string = {{date}}, {{time}}
+
+text_annotation_type.alt = [Annotazione: {{type}}]
+password_label = Inserire la password per aprire questo file PDF.
+password_invalid = Password non corretta. Riprovare.
+password_ok = OK
+password_cancel = Annulla
+
+printing_not_supported = Attenzione: la stampa non è completamente supportata da questo browser.
+printing_not_ready = Attenzione: il PDF non è ancora stato caricato completamente per la stampa.
+web_fonts_disabled = I web font risultano disattivati: impossibile utilizzare i caratteri incorporati nel PDF.
+
+# Editor
+editor_free_text2.title = Testo
+editor_free_text2_label = Testo
+editor_ink2.title = Disegno
+editor_ink2_label = Disegno
+editor_stamp.title = Aggiungi un’immagine
+editor_stamp_label = Aggiungi un’immagine
+
+free_text2_default_content = Inizia a digitare…
+
+# Editor Parameters
+editor_free_text_color = Colore
+editor_free_text_size = Dimensione
+editor_ink_color = Colore
+editor_ink_thickness = Spessore
+editor_ink_opacity = Opacità
+
+# Editor aria
+editor_free_text2_aria_label = Editor di testo
+editor_ink2_aria_label = Editor disegni
+editor_ink_canvas_aria_label = Immagine creata dall’utente
+

--- a/js/pdfjs/web/locale/ja/viewer.properties
+++ b/js/pdfjs/web/locale/ja/viewer.properties
@@ -1,0 +1,284 @@
+# Copyright 2012 Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Main toolbar buttons (tooltips and alt text for images)
+previous.title=前のページへ戻ります
+previous_label=前へ
+next.title=次のページへ進みます
+next_label=次へ
+
+# LOCALIZATION NOTE (page.title): The tooltip for the pageNumber input.
+page.title=ページ
+# LOCALIZATION NOTE (of_pages): "{{pagesCount}}" will be replaced by a number
+# representing the total number of pages in the document.
+of_pages=/ {{pagesCount}}
+# LOCALIZATION NOTE (page_of_pages): "{{pageNumber}}" and "{{pagesCount}}"
+# will be replaced by a number representing the currently visible page,
+# respectively a number representing the total number of pages in the document.
+page_of_pages=({{pageNumber}} / {{pagesCount}})
+
+zoom_out.title=表示を縮小します
+zoom_out_label=縮小
+zoom_in.title=表示を拡大します
+zoom_in_label=拡大
+zoom.title=拡大/縮小
+presentation_mode.title=プレゼンテーションモードに切り替えます
+presentation_mode_label=プレゼンテーションモード
+open_file.title=ファイルを開きます
+open_file_label=開く
+print.title=印刷します
+print_label=印刷
+download.title=ダウンロードします
+download_label=ダウンロード
+bookmark.title=現在のビューの URL です (コピーまたは新しいウィンドウに開く)
+bookmark_label=現在のビュー
+
+save.title=保存します
+save_label=保存
+bookmark1.title=現在のページの URL です (現在のページを表示する URL)
+bookmark1_label=現在のページ
+
+# LOCALIZATION NOTE (open_in_app.title): This string is used in Firefox for Android.
+open_in_app.title=アプリで開く
+# LOCALIZATION NOTE (open_in_app_label): This string is used in Firefox for Android. Length of the translation matters since we are in a mobile context, with limited screen estate.
+open_in_app_label=アプリで開く
+
+# Secondary toolbar and context menu
+tools.title=ツール
+tools_label=ツール
+first_page.title=最初のページへ移動します
+first_page_label=最初のページへ移動
+last_page.title=最後のページへ移動します
+last_page_label=最後のページへ移動
+page_rotate_cw.title=ページを右へ回転します
+page_rotate_cw_label=右回転
+page_rotate_ccw.title=ページを左へ回転します
+page_rotate_ccw_label=左回転
+
+cursor_text_select_tool.title=テキスト選択ツールを有効にします
+cursor_text_select_tool_label=テキスト選択ツール
+cursor_hand_tool.title=手のひらツールを有効にします
+cursor_hand_tool_label=手のひらツール
+
+scroll_page.title=ページ単位でスクロールします
+scroll_page_label=ページ単位でスクロール
+scroll_vertical.title=縦スクロールにします
+scroll_vertical_label=縦スクロール
+scroll_horizontal.title=横スクロールにします
+scroll_horizontal_label=横スクロール
+scroll_wrapped.title=折り返しスクロールにします
+scroll_wrapped_label=折り返しスクロール
+
+spread_none.title=見開きにしません
+spread_none_label=見開きにしない
+spread_odd.title=奇数ページ開始で見開きにします
+spread_odd_label=奇数ページ見開き
+spread_even.title=偶数ページ開始で見開きにします
+spread_even_label=偶数ページ見開き
+
+# Document properties dialog box
+document_properties.title=文書のプロパティ...
+document_properties_label=文書のプロパティ...
+document_properties_file_name=ファイル名:
+document_properties_file_size=ファイルサイズ:
+# LOCALIZATION NOTE (document_properties_kb): "{{size_kb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in kilobytes, respectively in bytes.
+document_properties_kb={{size_kb}} KB ({{size_b}} バイト)
+# LOCALIZATION NOTE (document_properties_mb): "{{size_mb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in megabytes, respectively in bytes.
+document_properties_mb={{size_mb}} MB ({{size_b}} バイト)
+document_properties_title=タイトル:
+document_properties_author=作成者:
+document_properties_subject=件名:
+document_properties_keywords=キーワード:
+document_properties_creation_date=作成日:
+document_properties_modification_date=更新日:
+# LOCALIZATION NOTE (document_properties_date_string): "{{date}}" and "{{time}}"
+# will be replaced by the creation/modification date, and time, of the PDF file.
+document_properties_date_string={{date}}, {{time}}
+document_properties_creator=アプリケーション:
+document_properties_producer=PDF 作成:
+document_properties_version=PDF のバージョン:
+document_properties_page_count=ページ数:
+document_properties_page_size=ページサイズ:
+document_properties_page_size_unit_inches=in
+document_properties_page_size_unit_millimeters=mm
+document_properties_page_size_orientation_portrait=縦
+document_properties_page_size_orientation_landscape=横
+document_properties_page_size_name_a3=A3
+document_properties_page_size_name_a4=A4
+document_properties_page_size_name_letter=レター
+document_properties_page_size_name_legal=リーガル
+# LOCALIZATION NOTE (document_properties_page_size_dimension_string):
+# "{{width}}", "{{height}}", {{unit}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement and orientation, of the (current) page.
+document_properties_page_size_dimension_string={{width}} × {{height}} {{unit}} ({{orientation}})
+# LOCALIZATION NOTE (document_properties_page_size_dimension_name_string):
+# "{{width}}", "{{height}}", {{unit}}, {{name}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement, name, and orientation, of the (current) page.
+document_properties_page_size_dimension_name_string={{width}} × {{height}} {{unit}} ({{name}}, {{orientation}})
+# LOCALIZATION NOTE (document_properties_linearized): The linearization status of
+# the document; usually called "Fast Web View" in English locales of Adobe software.
+document_properties_linearized=ウェブ表示用に最適化:
+document_properties_linearized_yes=はい
+document_properties_linearized_no=いいえ
+document_properties_close=閉じる
+
+print_progress_message=文書の印刷を準備しています...
+# LOCALIZATION NOTE (print_progress_percent): "{{progress}}" will be replaced by
+# a numerical per cent value.
+print_progress_percent={{progress}}%
+print_progress_close=キャンセル
+
+# Tooltips and alt text for side panel toolbar buttons
+# (the _label strings are alt text for the buttons, the .title strings are
+# tooltips)
+toggle_sidebar.title=サイドバー表示を切り替えます
+toggle_sidebar_notification2.title=サイドバー表示を切り替えます (文書に含まれるアウトライン / 添付 / レイヤー)
+toggle_sidebar_label=サイドバーの切り替え
+document_outline.title=文書の目次を表示します (ダブルクリックで項目を開閉します)
+document_outline_label=文書の目次
+attachments.title=添付ファイルを表示します
+attachments_label=添付ファイル
+layers.title=レイヤーを表示します (ダブルクリックですべてのレイヤーが初期状態に戻ります)
+layers_label=レイヤー
+thumbs.title=縮小版を表示します
+thumbs_label=縮小版
+current_outline_item.title=現在のアウトライン項目を検索
+current_outline_item_label=現在のアウトライン項目
+findbar.title=文書内を検索します
+findbar_label=検索
+
+additional_layers=追加レイヤー
+# LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
+page_landmark={{page}} ページ
+# Thumbnails panel item (tooltip and alt text for images)
+# LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
+# number.
+thumb_page_title={{page}} ページ
+# LOCALIZATION NOTE (thumb_page_canvas): "{{page}}" will be replaced by the page
+# number.
+thumb_page_canvas={{page}} ページの縮小版
+
+# Find panel button title and messages
+find_input.title=検索
+find_input.placeholder=文書内を検索...
+find_previous.title=現在より前の位置で指定文字列が現れる部分を検索します
+find_previous_label=前へ
+find_next.title=現在より後の位置で指定文字列が現れる部分を検索します
+find_next_label=次へ
+find_highlight=すべて強調表示
+find_match_case_label=大文字/小文字を区別
+find_match_diacritics_label=発音区別符号を区別
+find_entire_word_label=単語一致
+find_reached_top=文書先頭に到達したので末尾から続けて検索します
+find_reached_bottom=文書末尾に到達したので先頭から続けて検索します
+# LOCALIZATION NOTE (find_match_count): The supported plural forms are
+# [one|two|few|many|other], with [other] as the default value.
+# "{{current}}" and "{{total}}" will be replaced by a number representing the
+# index of the currently active find result, respectively a number representing
+# the total number of matches in the document.
+find_match_count={[ plural(total) ]}
+find_match_count[one]={{total}} 件中 {{current}} 件目
+find_match_count[two]={{total}} 件中 {{current}} 件目
+find_match_count[few]={{total}} 件中 {{current}} 件目
+find_match_count[many]={{total}} 件中 {{current}} 件目
+find_match_count[other]={{total}} 件中 {{current}} 件目
+# LOCALIZATION NOTE (find_match_count_limit): The supported plural forms are
+# [zero|one|two|few|many|other], with [other] as the default value.
+# "{{limit}}" will be replaced by a numerical value.
+find_match_count_limit={[ plural(limit) ]}
+find_match_count_limit[zero]={{limit}} 件以上一致
+find_match_count_limit[one]={{limit}} 件以上一致
+find_match_count_limit[two]={{limit}} 件以上一致
+find_match_count_limit[few]={{limit}} 件以上一致
+find_match_count_limit[many]={{limit}} 件以上一致
+find_match_count_limit[other]={{limit}} 件以上一致
+find_not_found=見つかりませんでした
+
+# Error panel labels
+error_more_info=詳細情報
+error_less_info=詳細情報を隠す
+error_close=閉じる
+# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
+# replaced by the PDF.JS version and build ID.
+error_version_info=PDF.js v{{version}} (ビルド: {{build}})
+# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
+# english string describing the error.
+error_message=メッセージ: {{message}}
+# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
+# trace.
+error_stack=スタック: {{stack}}
+# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
+error_file=ファイル: {{file}}
+# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
+error_line=行: {{line}}
+
+# Predefined zoom values
+page_scale_width=幅に合わせる
+page_scale_fit=ページのサイズに合わせる
+page_scale_auto=自動ズーム
+page_scale_actual=実際のサイズ
+# LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
+# numerical scale value.
+page_scale_percent={{scale}}%
+
+# Loading indicator messages
+loading=読み込み中...
+
+# Loading indicator messages
+loading_error=PDF の読み込み中にエラーが発生しました。
+invalid_file_error=無効または破損した PDF ファイル。
+missing_file_error=PDF ファイルが見つかりません。
+unexpected_response_error=サーバーから予期せぬ応答がありました。
+
+rendering_error=ページのレンダリング中にエラーが発生しました。
+
+# LOCALIZATION NOTE (annotation_date_string): "{{date}}" and "{{time}}" will be
+# replaced by the modification date, and time, of the annotation.
+annotation_date_string={{date}}, {{time}}
+
+# LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
+# "{{type}}" will be replaced with an annotation type from a list defined in
+# the PDF spec (32000-1:2008 Table 169 – Annotation types).
+# Some common types are e.g.: "Check", "Text", "Comment", "Note"
+text_annotation_type.alt=[{{type}} 注釈]
+password_label=この PDF ファイルを開くためのパスワードを入力してください。
+password_invalid=無効なパスワードです。もう一度やり直してください。
+password_ok=OK
+password_cancel=キャンセル
+
+printing_not_supported=警告: このブラウザーでは印刷が完全にサポートされていません。
+printing_not_ready=警告: PDF を印刷するための読み込みが終了していません。
+web_fonts_disabled=ウェブフォントが無効になっています: 埋め込まれた PDF のフォントを使用できません。
+
+# Editor
+editor_free_text2.title=フリーテキスト注釈
+editor_free_text2_label=フリーテキスト注釈
+editor_ink2.title=インク注釈
+editor_ink2_label=インク注釈
+
+free_text2_default_content=テキストを入力してください...
+
+# Editor Parameters
+editor_free_text_color=色
+editor_free_text_size=サイズ
+editor_ink_color=色
+editor_ink_thickness=太さ
+editor_ink_opacity=不透明度
+
+# Editor aria
+editor_free_text2_aria_label=フリーテキスト注釈エディター
+editor_ink2_aria_label=インク注釈エディター
+editor_ink_canvas_aria_label=ユーザー作成画像

--- a/js/pdfjs/web/locale/ka/viewer.properties
+++ b/js/pdfjs/web/locale/ka/viewer.properties
@@ -1,0 +1,257 @@
+# Copyright 2012 Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Main toolbar buttons (tooltips and alt text for images)
+previous.title=წინა გვერდი
+previous_label=წინა
+next.title=შემდეგი გვერდი
+next_label=შემდეგი
+
+# LOCALIZATION NOTE (page.title): The tooltip for the pageNumber input.
+page.title=გვერდი
+# LOCALIZATION NOTE (of_pages): "{{pagesCount}}" will be replaced by a number
+# representing the total number of pages in the document.
+of_pages={{pagesCount}}-დან
+# LOCALIZATION NOTE (page_of_pages): "{{pageNumber}}" and "{{pagesCount}}"
+# will be replaced by a number representing the currently visible page,
+# respectively a number representing the total number of pages in the document.
+page_of_pages=({{pageNumber}} {{pagesCount}}-დან)
+
+zoom_out.title=ზომის შემცირება
+zoom_out_label=დაშორება
+zoom_in.title=ზომის გაზრდა
+zoom_in_label=მოახლოება
+zoom.title=ზომა
+presentation_mode.title=ჩვენების რეჟიმზე გადართვა
+presentation_mode_label=ჩვენების რეჟიმი
+open_file.title=ფაილის გახსნა
+open_file_label=გახსნა
+print.title=ამობეჭდვა
+print_label=ამობეჭდვა
+
+save.title=შენახვა
+save_label=შენახვა
+bookmark1.title=მიმდინარე გვერდი (ბმული ამ გვერდისთვის)
+bookmark1_label=მიმდინარე გვერდი
+
+open_in_app.title=გახსნა პროგრამით
+open_in_app_label=გახსნა პროგრამით
+
+# Secondary toolbar and context menu
+tools.title=ხელსაწყოები
+tools_label=ხელსაწყოები
+first_page.title=პირველ გვერდზე გადასვლა
+first_page_label=პირველ გვერდზე გადასვლა
+last_page.title=ბოლო გვერდზე გადასვლა
+last_page_label=ბოლო გვერდზე გადასვლა
+page_rotate_cw.title=საათის ისრის მიმართულებით შებრუნება
+page_rotate_cw_label=მარჯვნივ გადაბრუნება
+page_rotate_ccw.title=საათის ისრის საპირისპიროდ შებრუნება
+page_rotate_ccw_label=მარცხნივ გადაბრუნება
+
+cursor_text_select_tool.title=მოსანიშნი მაჩვენებლის გამოყენება
+cursor_text_select_tool_label=მოსანიშნი მაჩვენებელი
+cursor_hand_tool.title=გადასაადგილებელი მაჩვენებლის გამოყენება
+cursor_hand_tool_label=გადასაადგილებელი
+
+scroll_page.title=გვერდზე გადაადგილების გამოყენება
+scroll_page_label=გვერდზე გადაადგილება
+scroll_vertical.title=გვერდების შვეულად ჩვენება
+scroll_vertical_label=შვეული გადაადგილება
+scroll_horizontal.title=გვერდების თარაზულად ჩვენება
+scroll_horizontal_label=განივი გადაადგილება
+scroll_wrapped.title=გვერდების ცხრილურად ჩვენება
+scroll_wrapped_label=ცხრილური გადაადგილება
+
+spread_none.title=ორ გვერდზე გაშლის გარეშე
+spread_none_label=ცალგვერდიანი ჩვენება
+spread_odd.title=ორ გვერდზე გაშლა, კენტი გვერდიდან დაწყებული
+spread_odd_label=ორ გვერდზე კენტიდან
+spread_even.title=ორ გვერდზე გაშლა, ლუწი გვერდიდან დაწყებული
+spread_even_label=ორ გვერდზე ლუწიდან
+
+# Document properties dialog box
+document_properties.title=დოკუმენტის შესახებ…
+document_properties_label=დოკუმენტის შესახებ…
+document_properties_file_name=ფაილის სახელი:
+document_properties_file_size=ფაილის მოცულობა:
+# LOCALIZATION NOTE (document_properties_kb): "{{size_kb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in kilobytes, respectively in bytes.
+document_properties_kb={{size_kb}} კბ ({{size_b}} ბაიტი)
+# LOCALIZATION NOTE (document_properties_mb): "{{size_mb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in megabytes, respectively in bytes.
+document_properties_mb={{size_mb}} მბ ({{size_b}} ბაიტი)
+document_properties_title=სათაური:
+document_properties_author=შემქმნელი:
+document_properties_subject=თემა:
+document_properties_keywords=საკვანძო სიტყვები:
+document_properties_creation_date=შექმნის დრო:
+document_properties_modification_date=ჩასწორების დრო:
+# LOCALIZATION NOTE (document_properties_date_string): "{{date}}" and "{{time}}"
+# will be replaced by the creation/modification date, and time, of the PDF file.
+document_properties_date_string={{date}}, {{time}}
+document_properties_creator=გამომცემი:
+document_properties_producer=PDF-შემდგენელი:
+document_properties_version=PDF-ვერსია:
+document_properties_page_count=გვერდები:
+document_properties_page_size=გვერდის ზომა:
+document_properties_page_size_unit_inches=დუიმი
+document_properties_page_size_unit_millimeters=მმ
+document_properties_page_size_orientation_portrait=შვეულად
+document_properties_page_size_orientation_landscape=თარაზულად
+document_properties_page_size_name_a3=A3
+document_properties_page_size_name_a4=A4
+document_properties_page_size_name_letter=Letter
+document_properties_page_size_name_legal=Legal
+# LOCALIZATION NOTE (document_properties_page_size_dimension_string):
+# "{{width}}", "{{height}}", {{unit}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement and orientation, of the (current) page.
+document_properties_page_size_dimension_string={{width}} × {{height}} {{unit}} ({{orientation}})
+# LOCALIZATION NOTE (document_properties_page_size_dimension_name_string):
+# "{{width}}", "{{height}}", {{unit}}, {{name}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement, name, and orientation, of the (current) page.
+document_properties_page_size_dimension_name_string={{width}} × {{height}} {{unit}} ({{name}}, {{orientation}})
+# LOCALIZATION NOTE (document_properties_linearized): The linearization status of
+# the document; usually called "Fast Web View" in English locales of Adobe software.
+document_properties_linearized=მსუბუქი ვებჩვენება:
+document_properties_linearized_yes=დიახ
+document_properties_linearized_no=არა
+document_properties_close=დახურვა
+
+print_progress_message=დოკუმენტი მზადდება ამოსაბეჭდად…
+# LOCALIZATION NOTE (print_progress_percent): "{{progress}}" will be replaced by
+# a numerical per cent value.
+print_progress_percent={{progress}}%
+print_progress_close=გაუქმება
+
+# Tooltips and alt text for side panel toolbar buttons
+# (the _label strings are alt text for the buttons, the .title strings are
+# tooltips)
+toggle_sidebar.title=გვერდითა ზოლის გამოჩენა/დამალვა
+toggle_sidebar_notification2.title=გვერდითი ზოლის გამოჩენა (შეიცავს სარჩევს/დანართს/ფენებს)
+toggle_sidebar_label=გვერდითა ზოლის გამოჩენა/დამალვა
+document_outline.title=დოკუმენტის სარჩევის ჩვენება (ორმაგი წკაპით თითოეულის ჩამოშლა/აკეცვა)
+document_outline_label=დოკუმენტის სარჩევი
+attachments.title=დანართების ჩვენება
+attachments_label=დანართები
+layers.title=ფენების გამოჩენა (ორმაგი წკაპით ყველა ფენის ნაგულისხმევზე დაბრუნება)
+layers_label=ფენები
+thumbs.title=შეთვალიერება
+thumbs_label=ესკიზები
+current_outline_item.title=მიმდინარე გვერდის მონახვა სარჩევში
+current_outline_item_label=მიმდინარე გვერდი სარჩევში
+findbar.title=პოვნა დოკუმენტში
+findbar_label=ძიება
+
+additional_layers=დამატებითი ფენები
+# LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
+page_landmark=გვერდი {{page}}
+# Thumbnails panel item (tooltip and alt text for images)
+# LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
+# number.
+thumb_page_title=გვერდი {{page}}
+# LOCALIZATION NOTE (thumb_page_canvas): "{{page}}" will be replaced by the page
+# number.
+thumb_page_canvas=გვერდის შეთვალიერება {{page}}
+
+# Find panel button title and messages
+find_input.title=ძიება
+find_input.placeholder=პოვნა დოკუმენტში…
+find_previous.title=ფრაზის წინა კონტექსტის პოვნა
+find_previous_label=წინა
+find_next.title=ფრაზის შემდეგი კონტექსტის პოვნა
+find_next_label=შემდეგი
+find_highlight=ყველას მონიშვნა
+find_match_case_label=მთავრულით
+find_match_diacritics_label=ნიშნებით
+find_entire_word_label=მთლიანი სიტყვები
+find_reached_top=მიღწეულია დოკუმენტის დასაწყისი, გრძელდება ბოლოდან
+find_reached_bottom=მიღწეულია დოკუმენტის ბოლო, გრძელდება დასაწყისიდან
+# LOCALIZATION NOTE (find_match_count): The supported plural forms are
+# [one|two|few|many|other], with [other] as the default value.
+# "{{current}}" and "{{total}}" will be replaced by a number representing the
+# index of the currently active find result, respectively a number representing
+# the total number of matches in the document.
+find_match_count={[ plural(total) ]}
+find_match_count[one]={{current}} / {{total}} თანხვედრიდან
+find_match_count[two]={{current}} / {{total}} თანხვედრიდან
+find_match_count[few]={{current}} / {{total}} თანხვედრიდან
+find_match_count[many]={{current}} / {{total}} თანხვედრიდან
+find_match_count[other]={{current}} / {{total}} თანხვედრიდან
+# LOCALIZATION NOTE (find_match_count_limit): The supported plural forms are
+# [zero|one|two|few|many|other], with [other] as the default value.
+# "{{limit}}" will be replaced by a numerical value.
+find_match_count_limit={[ plural(limit) ]}
+find_match_count_limit[zero]=არანაკლებ {{limit}} თანხვედრა
+find_match_count_limit[one]=არანაკლებ {{limit}} თანხვედრა
+find_match_count_limit[two]=არანაკლებ {{limit}} თანხვედრა
+find_match_count_limit[few]=არანაკლებ {{limit}} თანხვედრა
+find_match_count_limit[many]=არანაკლებ {{limit}} თანხვედრა
+find_match_count_limit[other]=არანაკლებ {{limit}} თანხვედრა
+find_not_found=ფრაზა ვერ მოიძებნა
+
+# Predefined zoom values
+page_scale_width=გვერდის სიგანეზე
+page_scale_fit=მთლიანი გვერდი
+page_scale_auto=ავტომატური
+page_scale_actual=საწყისი ზომა
+# LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
+# numerical scale value.
+page_scale_percent={{scale}}%
+
+# Loading indicator messages
+loading_error=შეცდომა, PDF-ფაილის ჩატვირთვისას.
+invalid_file_error=არამართებული ან დაზიანებული PDF-ფაილი.
+missing_file_error=ნაკლული PDF-ფაილი.
+unexpected_response_error=სერვერის მოულოდნელი პასუხი.
+
+rendering_error=შეცდომა, გვერდის ჩვენებისას.
+
+# LOCALIZATION NOTE (annotation_date_string): "{{date}}" and "{{time}}" will be
+# replaced by the modification date, and time, of the annotation.
+annotation_date_string={{date}}, {{time}}
+
+# LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
+# "{{type}}" will be replaced with an annotation type from a list defined in
+# the PDF spec (32000-1:2008 Table 169 – Annotation types).
+# Some common types are e.g.: "Check", "Text", "Comment", "Note"
+text_annotation_type.alt=[{{type}} შენიშვნა]
+password_label=შეიყვანეთ პაროლი PDF-ფაილის გასახსნელად.
+password_invalid=არასწორი პაროლი. გთხოვთ, სცადოთ ხელახლა.
+password_ok=კარგი
+password_cancel=გაუქმება
+
+printing_not_supported=გაფრთხილება: ამობეჭდვა ამ ბრაუზერში არაა სრულად მხარდაჭერილი.
+printing_not_ready=გაფრთხილება: PDF სრულად ჩატვირთული არაა, ამობეჭდვის დასაწყებად.
+web_fonts_disabled=ვებშრიფტები გამორთულია: ჩაშენებული PDF-შრიფტების გამოყენება ვერ ხერხდება.
+
+# Editor
+editor_free_text2.title=წარწერა
+editor_free_text2_label=ტექსტი
+editor_ink2.title=დახატვა
+editor_ink2_label=დახატვა
+
+free_text2_default_content=აკრიფეთ…
+
+# Editor Parameters
+editor_free_text_color=ფერი
+editor_free_text_size=ზომა
+editor_ink_color=ფერი
+editor_ink_thickness=სისქე
+editor_ink_opacity=გაუმჭვირვალობა
+
+# Editor aria
+editor_free_text2_aria_label=ნაწერის ჩასწორება
+editor_ink2_aria_label=ნახატის ჩასწორება
+editor_ink_canvas_aria_label=მომხმარებლის შექმნილი სურათი

--- a/js/pdfjs/web/locale/kab/viewer.properties
+++ b/js/pdfjs/web/locale/kab/viewer.properties
@@ -1,0 +1,257 @@
+# Copyright 2012 Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Main toolbar buttons (tooltips and alt text for images)
+previous.title=Asebter azewwar
+previous_label=Azewwar
+next.title=Asebter d-iteddun
+next_label=Ddu ɣer zdat
+
+# LOCALIZATION NOTE (page.title): The tooltip for the pageNumber input.
+page.title=Asebter
+# LOCALIZATION NOTE (of_pages): "{{pagesCount}}" will be replaced by a number
+# representing the total number of pages in the document.
+of_pages=ɣef {{pagesCount}}
+# LOCALIZATION NOTE (page_of_pages): "{{pageNumber}}" and "{{pagesCount}}"
+# will be replaced by a number representing the currently visible page,
+# respectively a number representing the total number of pages in the document.
+page_of_pages=({{pageNumber}} n {{pagesCount}})
+
+zoom_out.title=Semẓi
+zoom_out_label=Semẓi
+zoom_in.title=Semɣeṛ
+zoom_in_label=Semɣeṛ
+zoom.title=Semɣeṛ/Semẓi
+presentation_mode.title=Uɣal ɣer Uskar Tihawt
+presentation_mode_label=Askar Tihawt
+open_file.title=Ldi Afaylu
+open_file_label=Ldi
+print.title=Siggez
+print_label=Siggez
+
+save.title=Sekles
+save_label=Sekles
+bookmark1.title=Asebter amiran (Sken-d tansa URL seg usebter amiran)
+bookmark1_label=Asebter amiran
+
+open_in_app.title=Ldi deg usnas
+open_in_app_label=Ldi deg usnas
+
+# Secondary toolbar and context menu
+tools.title=Ifecka
+tools_label=Ifecka
+first_page.title=Ddu ɣer usebter amezwaru
+first_page_label=Ddu ɣer usebter amezwaru
+last_page.title=Ddu ɣer usebter aneggaru
+last_page_label=Ddu ɣer usebter aneggaru
+page_rotate_cw.title=Tuzzya tusrigt
+page_rotate_cw_label=Tuzzya tusrigt
+page_rotate_ccw.title=Tuzzya amgal-usrig
+page_rotate_ccw_label=Tuzzya amgal-usrig
+
+cursor_text_select_tool.title=Rmed afecku n tefrant n uḍris
+cursor_text_select_tool_label=Afecku n tefrant n uḍris
+cursor_hand_tool.title=Rmed afecku afus
+cursor_hand_tool_label=Afecku afus
+
+scroll_page.title=Seqdec adrurem n usebter
+scroll_page_label=Adrurem n usebter
+scroll_vertical.title=Seqdec adrurem ubdid
+scroll_vertical_label=Adrurem ubdid
+scroll_horizontal.title=Seqdec adrurem aglawan
+scroll_horizontal_label=Adrurem aglawan
+scroll_wrapped.title=Seqdec adrurem yuẓen
+scroll_wrapped_label=Adrurem yuẓen
+
+spread_none.title=Ur sedday ara isiɣzaf n usebter
+spread_none_label=Ulac isiɣzaf
+spread_odd.title=Seddu isiɣzaf n usebter ibeddun s yisebtar irayuganen
+spread_odd_label=Isiɣzaf irayuganen
+spread_even.title=Seddu isiɣzaf n usebter ibeddun s yisebtar iyuganen
+spread_even_label=Isiɣzaf iyuganen
+
+# Document properties dialog box
+document_properties.title=Taɣaṛa n isemli…
+document_properties_label=Taɣaṛa n isemli…
+document_properties_file_name=Isem n ufaylu:
+document_properties_file_size=Teɣzi n ufaylu:
+# LOCALIZATION NOTE (document_properties_kb): "{{size_kb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in kilobytes, respectively in bytes.
+document_properties_kb={{size_kb}} KAṬ ({{size_b}} ibiten)
+# LOCALIZATION NOTE (document_properties_mb): "{{size_mb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in megabytes, respectively in bytes.
+document_properties_mb={{size_mb}} MAṬ ({{size_b}} iṭamḍanen)
+document_properties_title=Azwel:
+document_properties_author=Ameskar:
+document_properties_subject=Amgay:
+document_properties_keywords=Awalen n tsaruţ
+document_properties_creation_date=Azemz n tmerna:
+document_properties_modification_date=Azemz n usnifel:
+# LOCALIZATION NOTE (document_properties_date_string): "{{date}}" and "{{time}}"
+# will be replaced by the creation/modification date, and time, of the PDF file.
+document_properties_date_string={{date}}, {{time}}
+document_properties_creator=Yerna-t:
+document_properties_producer=Afecku n uselket PDF:
+document_properties_version=Lqem PDF:
+document_properties_page_count=Amḍan n yisebtar:
+document_properties_page_size=Tuγzi n usebter:
+document_properties_page_size_unit_inches=deg
+document_properties_page_size_unit_millimeters=mm
+document_properties_page_size_orientation_portrait=s teɣzi
+document_properties_page_size_orientation_landscape=s tehri
+document_properties_page_size_name_a3=A3
+document_properties_page_size_name_a4=A4
+document_properties_page_size_name_letter=Asekkil
+document_properties_page_size_name_legal=Usḍif
+# LOCALIZATION NOTE (document_properties_page_size_dimension_string):
+# "{{width}}", "{{height}}", {{unit}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement and orientation, of the (current) page.
+document_properties_page_size_dimension_string={{width}} × {{height}} {{unit}} ({{orientation}})
+# LOCALIZATION NOTE (document_properties_page_size_dimension_name_string):
+# "{{width}}", "{{height}}", {{unit}}, {{name}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement, name, and orientation, of the (current) page.
+document_properties_page_size_dimension_name_string={{width}} × {{height}} {{unit}} ({{name}}, {{orientation}})
+# LOCALIZATION NOTE (document_properties_linearized): The linearization status of
+# the document; usually called "Fast Web View" in English locales of Adobe software.
+document_properties_linearized=Taskant Web taruradt:
+document_properties_linearized_yes=Ih
+document_properties_linearized_no=Ala
+document_properties_close=Mdel
+
+print_progress_message=Aheggi i usiggez n isemli…
+# LOCALIZATION NOTE (print_progress_percent): "{{progress}}" will be replaced by
+# a numerical per cent value.
+print_progress_percent={{progress}}%
+print_progress_close=Sefsex
+
+# Tooltips and alt text for side panel toolbar buttons
+# (the _label strings are alt text for the buttons, the .title strings are
+# tooltips)
+toggle_sidebar.title=Sken/Fer agalis adisan
+toggle_sidebar_notification2.title=Ffer/Sekn agalis adisan (isemli yegber aɣawas/ticeqqufin yeddan/tissiwin)
+toggle_sidebar_label=Sken/Fer agalis adisan
+document_outline.title=Sken isemli (Senned snat tikal i wesemɣer/Afneẓ n iferdisen meṛṛa)
+document_outline_label=Isɣalen n isebtar
+attachments.title=Sken ticeqqufin yeddan
+attachments_label=Ticeqqufin yeddan
+layers.title=Skeen tissiwin (sit sin yiberdan i uwennez n meṛṛa tissiwin ɣer waddad amezwer)
+layers_label=Tissiwin
+thumbs.title=Sken tanfult.
+thumbs_label=Tinfulin
+current_outline_item.title=Af-d aferdis n uɣawas amiran
+current_outline_item_label=Aferdis n uɣawas amiran
+findbar.title=Nadi deg isemli
+findbar_label=Nadi
+
+additional_layers=Tissiwin-nniḍen
+# LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
+page_landmark=Asebter {{page}}
+# Thumbnails panel item (tooltip and alt text for images)
+# LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
+# number.
+thumb_page_title=Asebter {{page}}
+# LOCALIZATION NOTE (thumb_page_canvas): "{{page}}" will be replaced by the page
+# number.
+thumb_page_canvas=Tanfult n usebter {{page}}
+
+# Find panel button title and messages
+find_input.title=Nadi
+find_input.placeholder=Nadi deg isemli…
+find_previous.title=Aff-d tamseḍriwt n twinest n deffir
+find_previous_label=Azewwar
+find_next.title=Aff-d timseḍriwt n twinest d-iteddun
+find_next_label=Ddu ɣer zdat
+find_highlight=Err izirig imaṛṛa
+find_match_case_label=Qadeṛ amasal n isekkilen
+find_match_diacritics_label=Qadeṛ ifeskilen
+find_entire_word_label=Awalen iččuranen
+find_reached_top=Yabbeḍ s afella n usebter, tuɣalin s wadda
+find_reached_bottom=Tebḍeḍ s adda n usebter, tuɣalin s afella
+# LOCALIZATION NOTE (find_match_count): The supported plural forms are
+# [one|two|few|many|other], with [other] as the default value.
+# "{{current}}" and "{{total}}" will be replaced by a number representing the
+# index of the currently active find result, respectively a number representing
+# the total number of matches in the document.
+find_match_count={[ plural(total) ]}
+find_match_count[one]={{current}} seg {{total}} n tmeɣṛuḍin
+find_match_count[two]={{current}} seg {{total}} n tmeɣṛuḍin
+find_match_count[few]={{current}} seg {{total}} n tmeɣṛuḍin
+find_match_count[many]={{current}} seg {{total}} n tmeɣṛuḍin
+find_match_count[other]={{current}} seg {{total}} n tmeɣṛuḍin
+# LOCALIZATION NOTE (find_match_count_limit): The supported plural forms are
+# [zero|one|two|few|many|other], with [other] as the default value.
+# "{{limit}}" will be replaced by a numerical value.
+find_match_count_limit={[ plural(limit) ]}
+find_match_count_limit[zero]=Ugar n {{limit}} n tmeɣṛuḍin
+find_match_count_limit[one]=Ugar n {{limit}} n tmeɣṛuḍin
+find_match_count_limit[two]=Ugar n {{limit}} n tmeɣṛuḍin
+find_match_count_limit[few]=Ugar n {{limit}} n tmeɣṛuḍin
+find_match_count_limit[many]=Ugar n {{limit}} n tmeɣṛuḍin
+find_match_count_limit[other]=Ugar n {{limit}} n tmeɣṛuḍin
+find_not_found=Ulac tawinest
+
+# Predefined zoom values
+page_scale_width=Tehri n usebter
+page_scale_fit=Asebter imaṛṛa
+page_scale_auto=Asemɣeṛ/Asemẓi awurman
+page_scale_actual=Teɣzi tilawt
+# LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
+# numerical scale value.
+page_scale_percent={{scale}}%
+
+# Loading indicator messages
+loading_error=Teḍra-d tuccḍa deg alluy n PDF:
+invalid_file_error=Afaylu PDF arameɣtu neɣ yexṣeṛ.
+missing_file_error=Ulac afaylu PDF.
+unexpected_response_error=Aqeddac yerra-d yir tiririt ur nettwaṛǧi ara.
+
+rendering_error=Teḍra-d tuccḍa deg uskan n usebter.
+
+# LOCALIZATION NOTE (annotation_date_string): "{{date}}" and "{{time}}" will be
+# replaced by the modification date, and time, of the annotation.
+annotation_date_string={{date}}, {{time}}
+
+# LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
+# "{{type}}" will be replaced with an annotation type from a list defined in
+# the PDF spec (32000-1:2008 Table 169 – Annotation types).
+# Some common types are e.g.: "Check", "Text", "Comment", "Note"
+text_annotation_type.alt=[Tabzimt {{type}}]
+password_label=Sekcem awal uffir akken ad ldiḍ afaylu-yagi PDF
+password_invalid=Awal uffir mačči d ameɣtu, Ɛreḍ tikelt-nniḍen.
+password_ok=IH
+password_cancel=Sefsex
+
+printing_not_supported=Ɣuṛ-k: Asiggez ur ittusefrak ara yakan imaṛṛa deg iminig-a.
+printing_not_ready=Ɣuṛ-k: Afaylu PDF ur d-yuli ara imeṛṛa akken ad ittusiggez.
+web_fonts_disabled=Tisefsiyin web ttwassensent; D awezɣi useqdec n tsefsiyin yettwarnan ɣer PDF.
+
+# Editor
+editor_free_text2.title=Aḍris
+editor_free_text2_label=Aḍris
+editor_ink2.title=Suneɣ
+editor_ink2_label=Suneɣ
+
+free_text2_default_content=Bdu tira...
+
+# Editor Parameters
+editor_free_text_color=Initen
+editor_free_text_size=Teɣzi
+editor_ink_color=Ini
+editor_ink_thickness=Tuzert
+editor_ink_opacity=Tebrek
+
+# Editor aria
+editor_free_text2_aria_label=Amaẓrag n uḍris
+editor_ink2_aria_label=Amaẓrag n usuneɣ
+editor_ink_canvas_aria_label=Tugna yettwarnan sɣur useqdac

--- a/js/pdfjs/web/locale/kk/viewer.properties
+++ b/js/pdfjs/web/locale/kk/viewer.properties
@@ -1,0 +1,259 @@
+# Copyright 2012 Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Main toolbar buttons (tooltips and alt text for images)
+previous.title=Алдыңғы парақ
+previous_label=Алдыңғысы
+next.title=Келесі парақ
+next_label=Келесі
+
+# LOCALIZATION NOTE (page.title): The tooltip for the pageNumber input.
+page.title=Парақ
+# LOCALIZATION NOTE (of_pages): "{{pagesCount}}" will be replaced by a number
+# representing the total number of pages in the document.
+of_pages={{pagesCount}} ішінен
+# LOCALIZATION NOTE (page_of_pages): "{{pageNumber}}" and "{{pagesCount}}"
+# will be replaced by a number representing the currently visible page,
+# respectively a number representing the total number of pages in the document.
+page_of_pages=(парақ {{pageNumber}}, {{pagesCount}} ішінен)
+
+zoom_out.title=Кішірейту
+zoom_out_label=Кішірейту
+zoom_in.title=Үлкейту
+zoom_in_label=Үлкейту
+zoom.title=Масштаб
+presentation_mode.title=Презентация режиміне ауысу
+presentation_mode_label=Презентация режимі
+open_file.title=Файлды ашу
+open_file_label=Ашу
+print.title=Баспаға шығару
+print_label=Баспаға шығару
+save.title=Сақтау
+save_label=Сақтау
+bookmark1.title=Ағымдағы бет (Ағымдағы беттен URL адресін көру)
+bookmark1_label=Ағымдағы бет
+# LOCALIZATION NOTE (open_in_app.title): This string is used in Firefox for Android.
+open_in_app.title=Қолданбада ашу
+# LOCALIZATION NOTE (open_in_app_label): This string is used in Firefox for Android. Length of the translation matters since we are in a mobile context, with limited screen estate.
+open_in_app_label=Қолданбада ашу
+
+# Secondary toolbar and context menu
+tools.title=Құралдар
+tools_label=Құралдар
+first_page.title=Алғашқы параққа өту
+first_page_label=Алғашқы параққа өту
+last_page.title=Соңғы параққа өту
+last_page_label=Соңғы параққа өту
+page_rotate_cw.title=Сағат тілі бағытымен айналдыру
+page_rotate_cw_label=Сағат тілі бағытымен бұру
+page_rotate_ccw.title=Сағат тілі бағытына қарсы бұру
+page_rotate_ccw_label=Сағат тілі бағытына қарсы бұру
+
+cursor_text_select_tool.title=Мәтінді таңдау құралын іске қосу
+cursor_text_select_tool_label=Мәтінді таңдау құралы
+cursor_hand_tool.title=Қол құралын іске қосу
+cursor_hand_tool_label=Қол құралы
+
+scroll_page.title=Беттерді айналдыруды пайдалану
+scroll_page_label=Беттерді айналдыру
+scroll_vertical.title=Вертикалды айналдыруды қолдану
+scroll_vertical_label=Вертикалды айналдыру
+scroll_horizontal.title=Горизонталды айналдыруды қолдану
+scroll_horizontal_label=Горизонталды айналдыру
+scroll_wrapped.title=Масштабталатын айналдыруды қолдану
+scroll_wrapped_label=Масштабталатын айналдыру
+
+spread_none.title=Жазық беттер режимін қолданбау
+spread_none_label=Жазық беттер режимсіз
+spread_odd.title=Жазық беттер тақ нөмірлі беттерден басталады
+spread_odd_label=Тақ нөмірлі беттер сол жақтан
+spread_even.title=Жазық беттер жұп нөмірлі беттерден басталады
+spread_even_label=Жұп нөмірлі беттер сол жақтан
+
+# Document properties dialog box
+document_properties.title=Құжат қасиеттері…
+document_properties_label=Құжат қасиеттері…
+document_properties_file_name=Файл аты:
+document_properties_file_size=Файл өлшемі:
+# LOCALIZATION NOTE (document_properties_kb): "{{size_kb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in kilobytes, respectively in bytes.
+document_properties_kb={{size_kb}} КБ ({{size_b}} байт)
+# LOCALIZATION NOTE (document_properties_mb): "{{size_mb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in megabytes, respectively in bytes.
+document_properties_mb={{size_mb}} МБ ({{size_b}} байт)
+document_properties_title=Тақырыбы:
+document_properties_author=Авторы:
+document_properties_subject=Тақырыбы:
+document_properties_keywords=Кілт сөздер:
+document_properties_creation_date=Жасалған күні:
+document_properties_modification_date=Түзету күні:
+# LOCALIZATION NOTE (document_properties_date_string): "{{date}}" and "{{time}}"
+# will be replaced by the creation/modification date, and time, of the PDF file.
+document_properties_date_string={{date}}, {{time}}
+document_properties_creator=Жасаған:
+document_properties_producer=PDF өндірген:
+document_properties_version=PDF нұсқасы:
+document_properties_page_count=Беттер саны:
+document_properties_page_size=Бет өлшемі:
+document_properties_page_size_unit_inches=дюйм
+document_properties_page_size_unit_millimeters=мм
+document_properties_page_size_orientation_portrait=тік
+document_properties_page_size_orientation_landscape=жатық
+document_properties_page_size_name_a3=A3
+document_properties_page_size_name_a4=A4
+document_properties_page_size_name_letter=Letter
+document_properties_page_size_name_legal=Legal
+# LOCALIZATION NOTE (document_properties_page_size_dimension_string):
+# "{{width}}", "{{height}}", {{unit}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement and orientation, of the (current) page.
+document_properties_page_size_dimension_string={{width}} × {{height}} {{unit}} ({{orientation}})
+# LOCALIZATION NOTE (document_properties_page_size_dimension_name_string):
+# "{{width}}", "{{height}}", {{unit}}, {{name}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement, name, and orientation, of the (current) page.
+document_properties_page_size_dimension_name_string={{width}} × {{height}} {{unit}} ({{name}}, {{orientation}})
+# LOCALIZATION NOTE (document_properties_linearized): The linearization status of
+# the document; usually called "Fast Web View" in English locales of Adobe software.
+document_properties_linearized=Жылдам Web көрінісі:
+document_properties_linearized_yes=Иә
+document_properties_linearized_no=Жоқ
+document_properties_close=Жабу
+
+print_progress_message=Құжатты баспаға шығару үшін дайындау…
+# LOCALIZATION NOTE (print_progress_percent): "{{progress}}" will be replaced by
+# a numerical per cent value.
+print_progress_percent={{progress}}%
+print_progress_close=Бас тарту
+
+# Tooltips and alt text for side panel toolbar buttons
+# (the _label strings are alt text for the buttons, the .title strings are
+# tooltips)
+toggle_sidebar.title=Бүйір панелін көрсету/жасыру
+toggle_sidebar_notification2.title=Бүйір панелін көрсету/жасыру (құжатта құрылымы/салынымдар/қабаттар бар)
+toggle_sidebar_label=Бүйір панелін көрсету/жасыру
+document_outline.title=Құжат құрылымын көрсету (барлық нәрселерді жазық қылу/жинау үшін қос шерту керек)
+document_outline_label=Құжат құрамасы
+attachments.title=Салынымдарды көрсету
+attachments_label=Салынымдар
+layers.title=Қабаттарды көрсету (барлық қабаттарды бастапқы күйге келтіру үшін екі рет шертіңіз)
+layers_label=Қабаттар
+thumbs.title=Кіші көріністерді көрсету
+thumbs_label=Кіші көріністер
+current_outline_item.title=Құрылымның ағымдағы элементін табу
+current_outline_item_label=Құрылымның ағымдағы элементі
+findbar.title=Құжаттан табу
+findbar_label=Табу
+
+additional_layers=Қосымша қабаттар
+# LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
+page_landmark=Бет {{page}}
+# Thumbnails panel item (tooltip and alt text for images)
+# LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
+# number.
+thumb_page_title={{page}} парағы
+# LOCALIZATION NOTE (thumb_page_canvas): "{{page}}" will be replaced by the page
+# number.
+thumb_page_canvas={{page}} парағы үшін кіші көрінісі
+
+# Find panel button title and messages
+find_input.title=Табу
+find_input.placeholder=Құжаттан табу…
+find_previous.title=Осы сөздердің мәтіннен алдыңғы кездесуін табу
+find_previous_label=Алдыңғысы
+find_next.title=Осы сөздердің мәтіннен келесі кездесуін табу
+find_next_label=Келесі
+find_highlight=Барлығын түспен ерекшелеу
+find_match_case_label=Регистрді ескеру
+find_match_diacritics_label=Диакритиканы ескеру
+find_entire_word_label=Сөздер толығымен
+find_reached_top=Құжаттың басына жеттік, соңынан бастап жалғастырамыз
+find_reached_bottom=Құжаттың соңына жеттік, басынан бастап жалғастырамыз
+# LOCALIZATION NOTE (find_match_count): The supported plural forms are
+# [one|two|few|many|other], with [other] as the default value.
+# "{{current}}" and "{{total}}" will be replaced by a number representing the
+# index of the currently active find result, respectively a number representing
+# the total number of matches in the document.
+find_match_count={[ plural(total) ]}
+find_match_count[one]={{current}} / {{total}} сәйкестік
+find_match_count[two]={{current}} / {{total}} сәйкестік
+find_match_count[few]={{current}} / {{total}} сәйкестік
+find_match_count[many]={{current}} / {{total}} сәйкестік
+find_match_count[other]={{current}} / {{total}} сәйкестік
+# LOCALIZATION NOTE (find_match_count_limit): The supported plural forms are
+# [zero|one|two|few|many|other], with [other] as the default value.
+# "{{limit}}" will be replaced by a numerical value.
+find_match_count_limit={[ plural(limit) ]}
+find_match_count_limit[zero]={{limit}} сәйкестіктен көп
+find_match_count_limit[one]={{limit}} сәйкестіктен көп
+find_match_count_limit[two]={{limit}} сәйкестіктен көп
+find_match_count_limit[few]={{limit}} сәйкестіктен көп
+find_match_count_limit[many]={{limit}} сәйкестіктен көп
+find_match_count_limit[other]={{limit}} сәйкестіктен көп
+find_not_found=Сөз(дер) табылмады
+
+# Predefined zoom values
+page_scale_width=Парақ ені
+page_scale_fit=Парақты сыйдыру
+page_scale_auto=Автомасштабтау
+page_scale_actual=Нақты өлшемі
+# LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
+# numerical scale value.
+page_scale_percent={{scale}}%
+
+# Loading indicator messages
+loading_error=PDF жүктеу кезінде қате кетті.
+invalid_file_error=Зақымдалған немесе қате PDF файл.
+missing_file_error=PDF файлы жоқ.
+unexpected_response_error=Сервердің күтпеген жауабы.
+rendering_error=Парақты өңдеу кезінде қате кетті.
+
+# LOCALIZATION NOTE (annotation_date_string): "{{date}}" and "{{time}}" will be
+# replaced by the modification date, and time, of the annotation.
+annotation_date_string={{date}}, {{time}}
+
+# LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
+# "{{type}}" will be replaced with an annotation type from a list defined in
+# the PDF spec (32000-1:2008 Table 169 – Annotation types).
+# Some common types are e.g.: "Check", "Text", "Comment", "Note"
+text_annotation_type.alt=[{{type}} аңдатпасы]
+password_label=Бұл PDF файлын ашу үшін парольді енгізіңіз.
+password_invalid=Пароль дұрыс емес. Қайталап көріңіз.
+password_ok=ОК
+password_cancel=Бас тарту
+
+printing_not_supported=Ескерту: Баспаға шығаруды бұл браузер толығымен қолдамайды.
+printing_not_ready=Ескерту: Баспаға шығару үшін, бұл PDF толығымен жүктеліп алынбады.
+web_fonts_disabled=Веб қаріптері сөндірілген: құрамына енгізілген PDF қаріптерін қолдану мүмкін емес.
+
+# Editor
+editor_free_text2.title=Мәтін
+editor_free_text2_label=Мәтін
+editor_ink2.title=Сурет салу
+editor_ink2_label=Сурет салу
+
+editor_stamp.title=Суретті қосу
+editor_stamp_label=Суретті қосу
+
+free_text2_default_content=Теруді бастау…
+
+# Editor Parameters
+editor_free_text_color=Түс
+editor_free_text_size=Өлшемі
+editor_ink_color=Түс
+editor_ink_thickness=Қалыңдығы
+editor_ink_opacity=Мөлдірсіздігі
+
+# Editor aria
+editor_free_text2_aria_label=Мәтін түзеткіші
+editor_ink2_aria_label=Сурет түзеткіші
+editor_ink_canvas_aria_label=Пайдаланушы жасаған сурет

--- a/js/pdfjs/web/locale/km/viewer.properties
+++ b/js/pdfjs/web/locale/km/viewer.properties
@@ -1,0 +1,189 @@
+# Copyright 2012 Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Main toolbar buttons (tooltips and alt text for images)
+previous.title=ទំព័រ​មុន
+previous_label=មុន
+next.title=ទំព័រ​បន្ទាប់
+next_label=បន្ទាប់
+
+# LOCALIZATION NOTE (page.title): The tooltip for the pageNumber input.
+page.title=ទំព័រ
+# LOCALIZATION NOTE (of_pages): "{{pagesCount}}" will be replaced by a number
+# representing the total number of pages in the document.
+of_pages=នៃ {{pagesCount}}
+# LOCALIZATION NOTE (page_of_pages): "{{pageNumber}}" and "{{pagesCount}}"
+# will be replaced by a number representing the currently visible page,
+# respectively a number representing the total number of pages in the document.
+page_of_pages=({{pageNumber}} នៃ {{pagesCount}})
+
+zoom_out.title=​បង្រួម
+zoom_out_label=​បង្រួម
+zoom_in.title=​ពង្រីក
+zoom_in_label=​ពង្រីក
+zoom.title=ពង្រីក
+presentation_mode.title=ប្ដូរ​ទៅ​របៀប​បទ​បង្ហាញ
+presentation_mode_label=របៀប​បទ​បង្ហាញ
+open_file.title=បើក​ឯកសារ
+open_file_label=បើក
+print.title=បោះពុម្ព
+print_label=បោះពុម្ព
+
+# Secondary toolbar and context menu
+tools.title=ឧបករណ៍
+tools_label=ឧបករណ៍
+first_page.title=ទៅកាន់​ទំព័រ​ដំបូង​
+first_page_label=ទៅកាន់​ទំព័រ​ដំបូង​
+last_page.title=ទៅកាន់​ទំព័រ​ចុងក្រោយ​
+last_page_label=ទៅកាន់​ទំព័រ​ចុងក្រោយ
+page_rotate_cw.title=បង្វិល​ស្រប​ទ្រនិច​នាឡិកា
+page_rotate_cw_label=បង្វិល​ស្រប​ទ្រនិច​នាឡិកា
+page_rotate_ccw.title=បង្វិល​ច្រាស​ទ្រនិច​នាឡិកា​​
+page_rotate_ccw_label=បង្វិល​ច្រាស​ទ្រនិច​នាឡិកា​​
+
+cursor_text_select_tool.title=បើក​ឧបករណ៍​ជ្រើស​អត្ថបទ
+cursor_text_select_tool_label=ឧបករណ៍​ជ្រើស​អត្ថបទ
+cursor_hand_tool.title=បើក​ឧបករណ៍​ដៃ
+cursor_hand_tool_label=ឧបករណ៍​ដៃ
+
+
+
+# Document properties dialog box
+document_properties.title=លក្ខណ​សម្បត្តិ​ឯកសារ…
+document_properties_label=លក្ខណ​សម្បត្តិ​ឯកសារ…
+document_properties_file_name=ឈ្មោះ​ឯកសារ៖
+document_properties_file_size=ទំហំ​ឯកសារ៖
+# LOCALIZATION NOTE (document_properties_kb): "{{size_kb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in kilobytes, respectively in bytes.
+document_properties_kb={{size_kb}} KB ({{size_b}} បៃ)
+# LOCALIZATION NOTE (document_properties_mb): "{{size_mb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in megabytes, respectively in bytes.
+document_properties_mb={{size_mb}} MB ({{size_b}} បៃ)
+document_properties_title=ចំណងជើង៖
+document_properties_author=អ្នក​និពន្ធ៖
+document_properties_subject=ប្រធានបទ៖
+document_properties_keywords=ពាក្យ​គន្លឹះ៖
+document_properties_creation_date=កាលបរិច្ឆេទ​បង្កើត៖
+document_properties_modification_date=កាលបរិច្ឆេទ​កែប្រែ៖
+# LOCALIZATION NOTE (document_properties_date_string): "{{date}}" and "{{time}}"
+# will be replaced by the creation/modification date, and time, of the PDF file.
+document_properties_date_string={{date}}, {{time}}
+document_properties_creator=អ្នក​បង្កើត៖
+document_properties_producer=កម្មវិធី​បង្កើត PDF ៖
+document_properties_version=កំណែ PDF ៖
+document_properties_page_count=ចំនួន​ទំព័រ៖
+document_properties_page_size_unit_inches=អ៊ីញ
+document_properties_page_size_unit_millimeters=មម
+document_properties_page_size_orientation_portrait=បញ្ឈរ
+document_properties_page_size_orientation_landscape=ផ្តេក
+document_properties_page_size_name_a3=A3
+document_properties_page_size_name_a4=A4
+document_properties_page_size_name_letter=សំបុត្រ
+# LOCALIZATION NOTE (document_properties_page_size_dimension_string):
+# "{{width}}", "{{height}}", {{unit}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement and orientation, of the (current) page.
+document_properties_page_size_dimension_string={{width}} × {{height}} {{unit}} ({{orientation}})
+# LOCALIZATION NOTE (document_properties_page_size_dimension_name_string):
+# "{{width}}", "{{height}}", {{unit}}, {{name}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement, name, and orientation, of the (current) page.
+document_properties_page_size_dimension_name_string={{width}} × {{height}} {{unit}} ({{name}}, {{orientation}})
+# LOCALIZATION NOTE (document_properties_linearized): The linearization status of
+# the document; usually called "Fast Web View" in English locales of Adobe software.
+document_properties_linearized_yes=បាទ/ចាស
+document_properties_linearized_no=ទេ
+document_properties_close=បិទ
+
+print_progress_message=កំពុង​រៀបចំ​ឯកសារ​សម្រាប់​បោះពុម្ព…
+# LOCALIZATION NOTE (print_progress_percent): "{{progress}}" will be replaced by
+# a numerical per cent value.
+print_progress_percent={{progress}}%
+print_progress_close=បោះបង់
+
+# Tooltips and alt text for side panel toolbar buttons
+# (the _label strings are alt text for the buttons, the .title strings are
+# tooltips)
+toggle_sidebar.title=បិទ/បើក​គ្រាប់​រំកិល
+toggle_sidebar_label=បិទ/បើក​គ្រាប់​រំកិល
+document_outline.title=បង្ហាញ​គ្រោង​ឯកសារ (ចុច​ទ្វេ​ដង​ដើម្បី​ពង្រីក/បង្រួម​ធាតុ​ទាំងអស់)
+document_outline_label=គ្រោង​ឯកសារ
+attachments.title=បង្ហាញ​ឯកសារ​ភ្ជាប់
+attachments_label=ឯកសារ​ភ្ជាប់
+thumbs.title=បង្ហាញ​រូបភាព​តូចៗ
+thumbs_label=រួបភាព​តូចៗ
+findbar.title=រក​នៅ​ក្នុង​ឯកសារ
+findbar_label=រក
+
+# LOCALIZATION NOTE (page_canvas): "{{page}}" will be replaced by the page number.
+# Thumbnails panel item (tooltip and alt text for images)
+# LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
+# number.
+thumb_page_title=ទំព័រ {{page}}
+# LOCALIZATION NOTE (thumb_page_canvas): "{{page}}" will be replaced by the page
+# number.
+thumb_page_canvas=រូបភាព​តូច​របស់​ទំព័រ {{page}}
+
+# Find panel button title and messages
+find_input.title=រក
+find_input.placeholder=រក​នៅ​ក្នុង​ឯកសារ...
+find_previous.title=រក​ពាក្យ ឬ​ឃ្លា​ដែល​បាន​ជួប​មុន
+find_previous_label=មុន
+find_next.title=រក​ពាក្យ ឬ​ឃ្លា​ដែល​បាន​ជួប​បន្ទាប់
+find_next_label=បន្ទាប់
+find_highlight=បន្លិច​ទាំងអស់
+find_match_case_label=ករណី​ដំណូច
+find_reached_top=បាន​បន្ត​ពី​ខាង​ក្រោម ទៅ​ដល់​ខាង​​លើ​នៃ​ឯកសារ
+find_reached_bottom=បាន​បន្ត​ពី​ខាងលើ ទៅដល់​ចុង​​នៃ​ឯកសារ
+# LOCALIZATION NOTE (find_match_count): The supported plural forms are
+# [one|two|few|many|other], with [other] as the default value.
+# "{{current}}" and "{{total}}" will be replaced by a number representing the
+# index of the currently active find result, respectively a number representing
+# the total number of matches in the document.
+# LOCALIZATION NOTE (find_match_count_limit): The supported plural forms are
+# [zero|one|two|few|many|other], with [other] as the default value.
+# "{{limit}}" will be replaced by a numerical value.
+find_not_found=រក​មិន​ឃើញ​ពាក្យ ឬ​ឃ្លា
+
+# Predefined zoom values
+page_scale_width=ទទឹង​ទំព័រ
+page_scale_fit=សម​ទំព័រ
+page_scale_auto=ពង្រីក​ស្វ័យប្រវត្តិ
+page_scale_actual=ទំហំ​ជាក់ស្ដែង
+# LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
+# numerical scale value.
+page_scale_percent={{scale}}%
+
+loading_error=មាន​កំហុស​បាន​កើតឡើង​ពេល​កំពុង​ផ្ទុក PDF ។
+invalid_file_error=ឯកសារ PDF ខូច ឬ​មិន​ត្រឹមត្រូវ ។
+missing_file_error=បាត់​ឯកសារ PDF
+unexpected_response_error=ការ​ឆ្លើយ​តម​ម៉ាស៊ីន​មេ​ដែល​មិន​បាន​រំពឹង។
+
+# LOCALIZATION NOTE (annotation_date_string): "{{date}}" and "{{time}}" will be
+# replaced by the modification date, and time, of the annotation.
+
+rendering_error=មាន​កំហុស​បាន​កើតឡើង​ពេល​បង្ហាញ​ទំព័រ ។
+
+# LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
+# "{{type}}" will be replaced with an annotation type from a list defined in
+# the PDF spec (32000-1:2008 Table 169 – Annotation types).
+# Some common types are e.g.: "Check", "Text", "Comment", "Note"
+text_annotation_type.alt=[{{type}} ចំណារ​ពន្យល់]
+password_label=បញ្ចូល​ពាក្យសម្ងាត់​ដើម្បី​បើក​ឯកសារ PDF នេះ។
+password_invalid=ពាក្យសម្ងាត់​មិន​ត្រឹមត្រូវ។ សូម​ព្យាយាម​ម្ដងទៀត។
+password_ok=យល់​ព្រម
+password_cancel=បោះបង់
+
+printing_not_supported=ការ​ព្រមាន ៖ កា​រ​បោះពុម្ព​មិន​ត្រូវ​បាន​គាំទ្រ​ពេញលេញ​ដោយ​កម្មវិធី​រុករក​នេះ​ទេ ។
+printing_not_ready=ព្រមាន៖ PDF មិន​ត្រូវ​បាន​ផ្ទុក​ទាំងស្រុង​ដើម្បី​បោះពុម្ព​ទេ។
+web_fonts_disabled=បាន​បិទ​ពុម្ពអក្សរ​បណ្ដាញ ៖ មិន​អាច​ប្រើ​ពុម្ពអក្សរ PDF ដែល​បាន​បង្កប់​បាន​ទេ ។
+

--- a/js/pdfjs/web/locale/kn/viewer.properties
+++ b/js/pdfjs/web/locale/kn/viewer.properties
@@ -1,0 +1,166 @@
+# Copyright 2012 Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Main toolbar buttons (tooltips and alt text for images)
+previous.title=ಹಿಂದಿನ ಪುಟ
+previous_label=ಹಿಂದಿನ
+next.title=ಮುಂದಿನ ಪುಟ
+next_label=ಮುಂದಿನ
+
+# LOCALIZATION NOTE (page.title): The tooltip for the pageNumber input.
+page.title=ಪುಟ
+# LOCALIZATION NOTE (of_pages): "{{pagesCount}}" will be replaced by a number
+# representing the total number of pages in the document.
+of_pages={{pagesCount}} ರಲ್ಲಿ
+# LOCALIZATION NOTE (page_of_pages): "{{pageNumber}}" and "{{pagesCount}}"
+# will be replaced by a number representing the currently visible page,
+# respectively a number representing the total number of pages in the document.
+page_of_pages=({{pagesCount}} ರಲ್ಲಿ {{pageNumber}})
+
+zoom_out.title=ಕಿರಿದಾಗಿಸು
+zoom_out_label=ಕಿರಿದಾಗಿಸಿ
+zoom_in.title=ಹಿರಿದಾಗಿಸು
+zoom_in_label=ಹಿರಿದಾಗಿಸಿ
+zoom.title=ಗಾತ್ರಬದಲಿಸು
+presentation_mode.title=ಪ್ರಸ್ತುತಿ (ಪ್ರಸೆಂಟೇಶನ್) ಕ್ರಮಕ್ಕೆ ಬದಲಾಯಿಸು
+presentation_mode_label=ಪ್ರಸ್ತುತಿ (ಪ್ರಸೆಂಟೇಶನ್) ಕ್ರಮ
+open_file.title=ಕಡತವನ್ನು ತೆರೆ
+open_file_label=ತೆರೆಯಿರಿ
+print.title=ಮುದ್ರಿಸು
+print_label=ಮುದ್ರಿಸಿ
+
+# Secondary toolbar and context menu
+tools.title=ಉಪಕರಣಗಳು
+tools_label=ಉಪಕರಣಗಳು
+first_page.title=ಮೊದಲ ಪುಟಕ್ಕೆ ತೆರಳು
+first_page_label=ಮೊದಲ ಪುಟಕ್ಕೆ ತೆರಳು
+last_page.title=ಕೊನೆಯ ಪುಟಕ್ಕೆ ತೆರಳು
+last_page_label=ಕೊನೆಯ ಪುಟಕ್ಕೆ ತೆರಳು
+page_rotate_cw.title=ಪ್ರದಕ್ಷಿಣೆಯಲ್ಲಿ ತಿರುಗಿಸು
+page_rotate_cw_label=ಪ್ರದಕ್ಷಿಣೆಯಲ್ಲಿ ತಿರುಗಿಸು
+page_rotate_ccw.title=ಅಪ್ರದಕ್ಷಿಣೆಯಲ್ಲಿ ತಿರುಗಿಸು
+page_rotate_ccw_label=ಅಪ್ರದಕ್ಷಿಣೆಯಲ್ಲಿ ತಿರುಗಿಸು
+
+cursor_text_select_tool.title=ಪಠ್ಯ ಆಯ್ಕೆ ಉಪಕರಣವನ್ನು ಸಕ್ರಿಯಗೊಳಿಸಿ
+cursor_text_select_tool_label=ಪಠ್ಯ ಆಯ್ಕೆಯ ಉಪಕರಣ
+cursor_hand_tool.title=ಕೈ ಉಪಕರಣವನ್ನು ಸಕ್ರಿಯಗೊಳಿಸಿ
+cursor_hand_tool_label=ಕೈ ಉಪಕರಣ
+
+
+
+# Document properties dialog box
+document_properties.title=ಡಾಕ್ಯುಮೆಂಟ್‌ ಗುಣಗಳು...
+document_properties_label=ಡಾಕ್ಯುಮೆಂಟ್‌ ಗುಣಗಳು...
+document_properties_file_name=ಕಡತದ ಹೆಸರು:
+document_properties_file_size=ಕಡತದ ಗಾತ್ರ:
+# LOCALIZATION NOTE (document_properties_kb): "{{size_kb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in kilobytes, respectively in bytes.
+document_properties_kb={{size_kb}} KB ({{size_b}} ಬೈಟ್‍ಗಳು)
+# LOCALIZATION NOTE (document_properties_mb): "{{size_mb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in megabytes, respectively in bytes.
+document_properties_mb={{size_mb}} MB ({{size_b}} ಬೈಟ್‍ಗಳು)
+document_properties_title=ಶೀರ್ಷಿಕೆ:
+document_properties_author=ಕರ್ತೃ:
+document_properties_subject=ವಿಷಯ:
+document_properties_keywords=ಮುಖ್ಯಪದಗಳು:
+document_properties_creation_date=ರಚಿಸಿದ ದಿನಾಂಕ:
+document_properties_modification_date=ಮಾರ್ಪಡಿಸಲಾದ ದಿನಾಂಕ:
+# LOCALIZATION NOTE (document_properties_date_string): "{{date}}" and "{{time}}"
+# will be replaced by the creation/modification date, and time, of the PDF file.
+document_properties_date_string={{date}}, {{time}}
+document_properties_creator=ರಚಿಸಿದವರು:
+document_properties_producer=PDF ಉತ್ಪಾದಕ:
+document_properties_version=PDF ಆವೃತ್ತಿ:
+document_properties_page_count=ಪುಟದ ಎಣಿಕೆ:
+document_properties_page_size_unit_inches=ಇದರಲ್ಲಿ
+document_properties_page_size_orientation_portrait=ಭಾವಚಿತ್ರ
+document_properties_page_size_orientation_landscape=ಪ್ರಕೃತಿ ಚಿತ್ರ
+# LOCALIZATION NOTE (document_properties_page_size_dimension_string):
+# "{{width}}", "{{height}}", {{unit}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement and orientation, of the (current) page.
+# LOCALIZATION NOTE (document_properties_page_size_dimension_name_string):
+# "{{width}}", "{{height}}", {{unit}}, {{name}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement, name, and orientation, of the (current) page.
+document_properties_close=ಮುಚ್ಚು
+
+print_progress_message=ಮುದ್ರಿಸುವುದಕ್ಕಾಗಿ ದಸ್ತಾವೇಜನ್ನು ಸಿದ್ಧಗೊಳಿಸಲಾಗುತ್ತಿದೆ…
+# LOCALIZATION NOTE (print_progress_percent): "{{progress}}" will be replaced by
+# a numerical per cent value.
+print_progress_percent={{progress}}%
+print_progress_close=ರದ್ದು ಮಾಡು
+
+# Tooltips and alt text for side panel toolbar buttons
+# (the _label strings are alt text for the buttons, the .title strings are
+# tooltips)
+toggle_sidebar.title=ಬದಿಪಟ್ಟಿಯನ್ನು ಹೊರಳಿಸು
+toggle_sidebar_label=ಬದಿಪಟ್ಟಿಯನ್ನು ಹೊರಳಿಸು
+document_outline_label=ದಸ್ತಾವೇಜಿನ ಹೊರರೇಖೆ
+attachments.title=ಲಗತ್ತುಗಳನ್ನು ತೋರಿಸು
+attachments_label=ಲಗತ್ತುಗಳು
+thumbs.title=ಚಿಕ್ಕಚಿತ್ರದಂತೆ ತೋರಿಸು
+thumbs_label=ಚಿಕ್ಕಚಿತ್ರಗಳು
+findbar.title=ದಸ್ತಾವೇಜಿನಲ್ಲಿ ಹುಡುಕು
+findbar_label=ಹುಡುಕು
+
+# Thumbnails panel item (tooltip and alt text for images)
+# LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
+# number.
+thumb_page_title=ಪುಟ {{page}}
+# LOCALIZATION NOTE (thumb_page_canvas): "{{page}}" will be replaced by the page
+# number.
+thumb_page_canvas=ಪುಟವನ್ನು ಚಿಕ್ಕಚಿತ್ರದಂತೆ ತೋರಿಸು {{page}}
+
+# Find panel button title and messages
+find_input.title=ಹುಡುಕು
+find_input.placeholder=ದಸ್ತಾವೇಜಿನಲ್ಲಿ ಹುಡುಕು…
+find_previous.title=ವಾಕ್ಯದ ಹಿಂದಿನ ಇರುವಿಕೆಯನ್ನು ಹುಡುಕು
+find_previous_label=ಹಿಂದಿನ
+find_next.title=ವಾಕ್ಯದ ಮುಂದಿನ ಇರುವಿಕೆಯನ್ನು ಹುಡುಕು
+find_next_label=ಮುಂದಿನ
+find_highlight=ಎಲ್ಲವನ್ನು ಹೈಲೈಟ್ ಮಾಡು
+find_match_case_label=ಕೇಸನ್ನು ಹೊಂದಿಸು
+find_reached_top=ದಸ್ತಾವೇಜಿನ ಮೇಲ್ಭಾಗವನ್ನು ತಲುಪಿದೆ, ಕೆಳಗಿನಿಂದ ಆರಂಭಿಸು
+find_reached_bottom=ದಸ್ತಾವೇಜಿನ ಕೊನೆಯನ್ನು ತಲುಪಿದೆ, ಮೇಲಿನಿಂದ ಆರಂಭಿಸು
+find_not_found=ವಾಕ್ಯವು ಕಂಡು ಬಂದಿಲ್ಲ
+
+# Predefined zoom values
+page_scale_width=ಪುಟದ ಅಗಲ
+page_scale_fit=ಪುಟದ ಸರಿಹೊಂದಿಕೆ
+page_scale_auto=ಸ್ವಯಂಚಾಲಿತ ಗಾತ್ರಬದಲಾವಣೆ
+page_scale_actual=ನಿಜವಾದ ಗಾತ್ರ
+# LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
+# numerical scale value.
+page_scale_percent={{scale}}%
+
+loading_error=PDF ಅನ್ನು ಲೋಡ್ ಮಾಡುವಾಗ ಒಂದು ದೋಷ ಎದುರಾಗಿದೆ.
+invalid_file_error=ಅಮಾನ್ಯವಾದ ಅಥವ ಹಾಳಾದ PDF ಕಡತ.
+missing_file_error=PDF ಕಡತ ಇಲ್ಲ.
+unexpected_response_error=ಅನಿರೀಕ್ಷಿತವಾದ ಪೂರೈಕೆಗಣಕದ ಪ್ರತಿಕ್ರಿಯೆ.
+
+rendering_error=ಪುಟವನ್ನು ನಿರೂಪಿಸುವಾಗ ಒಂದು ದೋಷ ಎದುರಾಗಿದೆ.
+
+# LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
+# "{{type}}" will be replaced with an annotation type from a list defined in
+# the PDF spec (32000-1:2008 Table 169 – Annotation types).
+# Some common types are e.g.: "Check", "Text", "Comment", "Note"
+text_annotation_type.alt=[{{type}} ಟಿಪ್ಪಣಿ]
+password_label=PDF ಅನ್ನು ತೆರೆಯಲು ಗುಪ್ತಪದವನ್ನು ನಮೂದಿಸಿ.
+password_invalid=ಅಮಾನ್ಯವಾದ ಗುಪ್ತಪದ, ದಯವಿಟ್ಟು ಇನ್ನೊಮ್ಮೆ ಪ್ರಯತ್ನಿಸಿ.
+password_ok=OK
+password_cancel=ರದ್ದು ಮಾಡು
+
+printing_not_supported=ಎಚ್ಚರಿಕೆ: ಈ ಜಾಲವೀಕ್ಷಕದಲ್ಲಿ ಮುದ್ರಣಕ್ಕೆ ಸಂಪೂರ್ಣ ಬೆಂಬಲವಿಲ್ಲ.
+printing_not_ready=ಎಚ್ಚರಿಕೆ: PDF ಕಡತವು ಮುದ್ರಿಸಲು ಸಂಪೂರ್ಣವಾಗಿ ಲೋಡ್ ಆಗಿಲ್ಲ.
+web_fonts_disabled=ಜಾಲ ಅಕ್ಷರಶೈಲಿಯನ್ನು ನಿಷ್ಕ್ರಿಯಗೊಳಿಸಲಾಗಿದೆ: ಅಡಕಗೊಳಿಸಿದ PDF ಅಕ್ಷರಶೈಲಿಗಳನ್ನು ಬಳಸಲು ಸಾಧ್ಯವಾಗಿಲ್ಲ.
+

--- a/js/pdfjs/web/locale/ko/viewer.properties
+++ b/js/pdfjs/web/locale/ko/viewer.properties
@@ -1,0 +1,259 @@
+# Copyright 2012 Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Main toolbar buttons (tooltips and alt text for images)
+previous.title=이전 페이지
+previous_label=이전
+next.title=다음 페이지
+next_label=다음
+
+# LOCALIZATION NOTE (page.title): The tooltip for the pageNumber input.
+page.title=페이지
+# LOCALIZATION NOTE (of_pages): "{{pagesCount}}" will be replaced by a number
+# representing the total number of pages in the document.
+of_pages=/ {{pagesCount}}
+# LOCALIZATION NOTE (page_of_pages): "{{pageNumber}}" and "{{pagesCount}}"
+# will be replaced by a number representing the currently visible page,
+# respectively a number representing the total number of pages in the document.
+page_of_pages=({{pageNumber}} / {{pagesCount}})
+
+zoom_out.title=축소
+zoom_out_label=축소
+zoom_in.title=확대
+zoom_in_label=확대
+zoom.title=확대/축소
+presentation_mode.title=프레젠테이션 모드로 전환
+presentation_mode_label=프레젠테이션 모드
+open_file.title=파일 열기
+open_file_label=열기
+print.title=인쇄
+print_label=인쇄
+save.title=저장
+save_label=저장
+bookmark1.title=현재 페이지 (현재 페이지에서 URL 보기)
+bookmark1_label=현재 페이지
+# LOCALIZATION NOTE (open_in_app.title): This string is used in Firefox for Android.
+open_in_app.title=앱에서 열기
+# LOCALIZATION NOTE (open_in_app_label): This string is used in Firefox for Android. Length of the translation matters since we are in a mobile context, with limited screen estate.
+open_in_app_label=앱에서 열기
+
+# Secondary toolbar and context menu
+tools.title=도구
+tools_label=도구
+first_page.title=첫 페이지로 이동
+first_page_label=첫 페이지로 이동
+last_page.title=마지막 페이지로 이동
+last_page_label=마지막 페이지로 이동
+page_rotate_cw.title=시계방향으로 회전
+page_rotate_cw_label=시계방향으로 회전
+page_rotate_ccw.title=시계 반대방향으로 회전
+page_rotate_ccw_label=시계 반대방향으로 회전
+
+cursor_text_select_tool.title=텍스트 선택 도구 활성화
+cursor_text_select_tool_label=텍스트 선택 도구
+cursor_hand_tool.title=손 도구 활성화
+cursor_hand_tool_label=손 도구
+
+scroll_page.title=페이지 스크롤 사용
+scroll_page_label=페이지 스크롤
+scroll_vertical.title=세로 스크롤 사용
+scroll_vertical_label=세로 스크롤
+scroll_horizontal.title=가로 스크롤 사용
+scroll_horizontal_label=가로 스크롤
+scroll_wrapped.title=래핑(자동 줄 바꿈) 스크롤 사용
+scroll_wrapped_label=래핑 스크롤
+
+spread_none.title=한 페이지 보기
+spread_none_label=펼침 없음
+spread_odd.title=홀수 페이지로 시작하는 두 페이지 보기
+spread_odd_label=홀수 펼침
+spread_even.title=짝수 페이지로 시작하는 두 페이지 보기
+spread_even_label=짝수 펼침
+
+# Document properties dialog box
+document_properties.title=문서 속성…
+document_properties_label=문서 속성…
+document_properties_file_name=파일 이름:
+document_properties_file_size=파일 크기:
+# LOCALIZATION NOTE (document_properties_kb): "{{size_kb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in kilobytes, respectively in bytes.
+document_properties_kb={{size_kb}} KB ({{size_b}}바이트)
+# LOCALIZATION NOTE (document_properties_mb): "{{size_mb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in megabytes, respectively in bytes.
+document_properties_mb={{size_mb}} MB ({{size_b}}바이트)
+document_properties_title=제목:
+document_properties_author=작성자:
+document_properties_subject=주제:
+document_properties_keywords=키워드:
+document_properties_creation_date=작성 날짜:
+document_properties_modification_date=수정 날짜:
+# LOCALIZATION NOTE (document_properties_date_string): "{{date}}" and "{{time}}"
+# will be replaced by the creation/modification date, and time, of the PDF file.
+document_properties_date_string={{date}}, {{time}}
+document_properties_creator=작성 프로그램:
+document_properties_producer=PDF 변환 소프트웨어:
+document_properties_version=PDF 버전:
+document_properties_page_count=페이지 수:
+document_properties_page_size=페이지 크기:
+document_properties_page_size_unit_inches=in
+document_properties_page_size_unit_millimeters=mm
+document_properties_page_size_orientation_portrait=세로 방향
+document_properties_page_size_orientation_landscape=가로 방향
+document_properties_page_size_name_a3=A3
+document_properties_page_size_name_a4=A4
+document_properties_page_size_name_letter=레터
+document_properties_page_size_name_legal=리걸
+# LOCALIZATION NOTE (document_properties_page_size_dimension_string):
+# "{{width}}", "{{height}}", {{unit}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement and orientation, of the (current) page.
+document_properties_page_size_dimension_string={{width}} × {{height}} {{unit}} ({{orientation}})
+# LOCALIZATION NOTE (document_properties_page_size_dimension_name_string):
+# "{{width}}", "{{height}}", {{unit}}, {{name}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement, name, and orientation, of the (current) page.
+document_properties_page_size_dimension_name_string={{width}} × {{height}} {{unit}} ({{name}}, {{orientation}})
+# LOCALIZATION NOTE (document_properties_linearized): The linearization status of
+# the document; usually called "Fast Web View" in English locales of Adobe software.
+document_properties_linearized=빠른 웹 보기:
+document_properties_linearized_yes=예
+document_properties_linearized_no=아니요
+document_properties_close=닫기
+
+print_progress_message=인쇄 문서 준비 중…
+# LOCALIZATION NOTE (print_progress_percent): "{{progress}}" will be replaced by
+# a numerical per cent value.
+print_progress_percent={{progress}}%
+print_progress_close=취소
+
+# Tooltips and alt text for side panel toolbar buttons
+# (the _label strings are alt text for the buttons, the .title strings are
+# tooltips)
+toggle_sidebar.title=사이드바 표시/숨기기
+toggle_sidebar_notification2.title=사이드바 표시/숨기기 (문서에 아웃라인/첨부파일/레이어 포함됨)
+toggle_sidebar_label=사이드바 표시/숨기기
+document_outline.title=문서 아웃라인 보기 (더블 클릭해서 모든 항목 펼치기/접기)
+document_outline_label=문서 아웃라인
+attachments.title=첨부파일 보기
+attachments_label=첨부파일
+layers.title=레이어 보기 (더블 클릭해서 모든 레이어를 기본 상태로 재설정)
+layers_label=레이어
+thumbs.title=미리보기
+thumbs_label=미리보기
+current_outline_item.title=현재 아웃라인 항목 찾기
+current_outline_item_label=현재 아웃라인 항목
+findbar.title=검색
+findbar_label=검색
+
+additional_layers=추가 레이어
+# LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
+page_landmark={{page}} 페이지
+# Thumbnails panel item (tooltip and alt text for images)
+# LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
+# number.
+thumb_page_title={{page}} 페이지
+# LOCALIZATION NOTE (thumb_page_canvas): "{{page}}" will be replaced by the page
+# number.
+thumb_page_canvas={{page}} 페이지 미리보기
+
+# Find panel button title and messages
+find_input.title=찾기
+find_input.placeholder=문서에서 찾기…
+find_previous.title=지정 문자열에 일치하는 1개 부분을 검색
+find_previous_label=이전
+find_next.title=지정 문자열에 일치하는 다음 부분을 검색
+find_next_label=다음
+find_highlight=모두 강조 표시
+find_match_case_label=대/소문자 구분
+find_match_diacritics_label=분음 부호 일치
+find_entire_word_label=단어 단위로
+find_reached_top=문서 처음까지 검색하고 끝으로 돌아와 검색했습니다.
+find_reached_bottom=문서 끝까지 검색하고 앞으로 돌아와 검색했습니다.
+# LOCALIZATION NOTE (find_match_count): The supported plural forms are
+# [one|two|few|many|other], with [other] as the default value.
+# "{{current}}" and "{{total}}" will be replaced by a number representing the
+# index of the currently active find result, respectively a number representing
+# the total number of matches in the document.
+find_match_count={[ plural(total) ]}
+find_match_count[one]={{total}} 중 {{current}} 일치
+find_match_count[two]={{total}} 중 {{current}} 일치
+find_match_count[few]={{total}} 중 {{current}} 일치
+find_match_count[many]={{total}} 중 {{current}} 일치
+find_match_count[other]={{total}} 중 {{current}} 일치
+# LOCALIZATION NOTE (find_match_count_limit): The supported plural forms are
+# [zero|one|two|few|many|other], with [other] as the default value.
+# "{{limit}}" will be replaced by a numerical value.
+find_match_count_limit={[ plural(limit) ]}
+find_match_count_limit[zero]={{limit}} 이상 일치
+find_match_count_limit[one]={{limit}} 이상 일치
+find_match_count_limit[two]={{limit}} 이상 일치
+find_match_count_limit[few]={{limit}} 이상 일치
+find_match_count_limit[many]={{limit}} 이상 일치
+find_match_count_limit[other]={{limit}} 이상 일치
+find_not_found=검색 결과 없음
+
+# Predefined zoom values
+page_scale_width=페이지 너비에 맞추기
+page_scale_fit=페이지에 맞추기
+page_scale_auto=자동
+page_scale_actual=실제 크기
+# LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
+# numerical scale value.
+page_scale_percent={{scale}}%
+
+# Loading indicator messages
+loading_error=PDF를 로드하는 동안 오류가 발생했습니다.
+invalid_file_error=잘못되었거나 손상된 PDF 파일.
+missing_file_error=PDF 파일 없음.
+unexpected_response_error=예기치 않은 서버 응답입니다.
+rendering_error=페이지를 렌더링하는 동안 오류가 발생했습니다.
+
+# LOCALIZATION NOTE (annotation_date_string): "{{date}}" and "{{time}}" will be
+# replaced by the modification date, and time, of the annotation.
+annotation_date_string={{date}} {{time}}
+
+# LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
+# "{{type}}" will be replaced with an annotation type from a list defined in
+# the PDF spec (32000-1:2008 Table 169 – Annotation types).
+# Some common types are e.g.: "Check", "Text", "Comment", "Note"
+text_annotation_type.alt=[{{type}} 주석]
+password_label=이 PDF 파일을 열 수 있는 비밀번호를 입력하세요.
+password_invalid=잘못된 비밀번호입니다. 다시 시도하세요.
+password_ok=확인
+password_cancel=취소
+
+printing_not_supported=경고: 이 브라우저는 인쇄를 완전히 지원하지 않습니다.
+printing_not_ready=경고: 이 PDF를 인쇄를 할 수 있을 정도로 읽어들이지 못했습니다.
+web_fonts_disabled=웹 폰트가 비활성화됨: 내장된 PDF 글꼴을 사용할 수 없습니다.
+
+# Editor
+editor_free_text2.title=텍스트
+editor_free_text2_label=텍스트
+editor_ink2.title=그리기
+editor_ink2_label=그리기
+
+editor_stamp.title=이미지 추가
+editor_stamp_label=이미지 추가
+
+free_text2_default_content=입력하세요…
+
+# Editor Parameters
+editor_free_text_color=색상
+editor_free_text_size=크기
+editor_ink_color=색상
+editor_ink_thickness=두께
+editor_ink_opacity=불투명도
+
+# Editor aria
+editor_free_text2_aria_label=텍스트 편집기
+editor_ink2_aria_label=그리기 편집기
+editor_ink_canvas_aria_label=사용자 생성 이미지

--- a/js/pdfjs/web/locale/lij/viewer.properties
+++ b/js/pdfjs/web/locale/lij/viewer.properties
@@ -1,0 +1,214 @@
+# Copyright 2012 Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Main toolbar buttons (tooltips and alt text for images)
+previous.title=Pagina primma
+previous_label=Precedente
+next.title=Pagina dòppo
+next_label=Pròscima
+
+# LOCALIZATION NOTE (page.title): The tooltip for the pageNumber input.
+page.title=Pagina
+# LOCALIZATION NOTE (of_pages): "{{pagesCount}}" will be replaced by a number
+# representing the total number of pages in the document.
+of_pages=de {{pagesCount}}
+# LOCALIZATION NOTE (page_of_pages): "{{pageNumber}}" and "{{pagesCount}}"
+# will be replaced by a number representing the currently visible page,
+# respectively a number representing the total number of pages in the document.
+page_of_pages=({{pageNumber}} de {{pagesCount}})
+
+zoom_out.title=Diminoisci zoom
+zoom_out_label=Diminoisci zoom
+zoom_in.title=Aomenta zoom
+zoom_in_label=Aomenta zoom
+zoom.title=Zoom
+presentation_mode.title=Vanni into mòddo de prezentaçion
+presentation_mode_label=Mòddo de prezentaçion
+open_file.title=Arvi file
+open_file_label=Arvi
+print.title=Stanpa
+print_label=Stanpa
+
+# Secondary toolbar and context menu
+tools.title=Atressi
+tools_label=Atressi
+first_page.title=Vanni a-a primma pagina
+first_page_label=Vanni a-a primma pagina
+last_page.title=Vanni a l'urtima pagina
+last_page_label=Vanni a l'urtima pagina
+page_rotate_cw.title=Gia into verso oraio
+page_rotate_cw_label=Gia into verso oraio
+page_rotate_ccw.title=Gia into verso antioraio
+page_rotate_ccw_label=Gia into verso antioraio
+
+cursor_text_select_tool.title=Abilita strumento de seleçion do testo
+cursor_text_select_tool_label=Strumento de seleçion do testo
+cursor_hand_tool.title=Abilita strumento man
+cursor_hand_tool_label=Strumento man
+
+scroll_vertical.title=Deuvia rebelamento verticale
+scroll_vertical_label=Rebelamento verticale
+scroll_horizontal.title=Deuvia rebelamento orizontâ
+scroll_horizontal_label=Rebelamento orizontâ
+scroll_wrapped.title=Deuvia rebelamento incapsolou
+scroll_wrapped_label=Rebelamento incapsolou
+
+spread_none.title=No unite a-a difuxon de pagina
+spread_none_label=No difuxon
+spread_odd.title=Uniscite a-a difuxon de pagina co-o numero dèspa
+spread_odd_label=Difuxon dèspa
+spread_even.title=Uniscite a-a difuxon de pagina co-o numero pari
+spread_even_label=Difuxon pari
+
+# Document properties dialog box
+document_properties.title=Propietæ do documento…
+document_properties_label=Propietæ do documento…
+document_properties_file_name=Nomme schedaio:
+document_properties_file_size=Dimenscion schedaio:
+# LOCALIZATION NOTE (document_properties_kb): "{{size_kb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in kilobytes, respectively in bytes.
+document_properties_kb={{size_kb}} kB ({{size_b}} byte)
+# LOCALIZATION NOTE (document_properties_mb): "{{size_mb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in megabytes, respectively in bytes.
+document_properties_mb={{size_mb}} MB ({{size_b}} byte)
+document_properties_title=Titolo:
+document_properties_author=Aoto:
+document_properties_subject=Ogetto:
+document_properties_keywords=Paròlle ciave:
+document_properties_creation_date=Dæta creaçion:
+document_properties_modification_date=Dæta cangiamento:
+# LOCALIZATION NOTE (document_properties_date_string): "{{date}}" and "{{time}}"
+# will be replaced by the creation/modification date, and time, of the PDF file.
+document_properties_date_string={{date}}, {{time}}
+document_properties_creator=Aotô originale:
+document_properties_producer=Produtô PDF:
+document_properties_version=Verscion PDF:
+document_properties_page_count=Contezzo pagine:
+document_properties_page_size=Dimenscion da pagina:
+document_properties_page_size_unit_inches=dii gròsci
+document_properties_page_size_unit_millimeters=mm
+document_properties_page_size_orientation_portrait=drito
+document_properties_page_size_orientation_landscape=desteizo
+document_properties_page_size_name_a3=A3
+document_properties_page_size_name_a4=A4
+document_properties_page_size_name_letter=Letia
+document_properties_page_size_name_legal=Lezze
+# LOCALIZATION NOTE (document_properties_page_size_dimension_string):
+# "{{width}}", "{{height}}", {{unit}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement and orientation, of the (current) page.
+document_properties_page_size_dimension_string={{width}} × {{height}} {{unit}} ({{orientation}})
+# LOCALIZATION NOTE (document_properties_page_size_dimension_name_string):
+# "{{width}}", "{{height}}", {{unit}}, {{name}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement, name, and orientation, of the (current) page.
+document_properties_page_size_dimension_name_string={{width}} × {{height}} {{unit}} ({{name}}, {{orientation}})
+# LOCALIZATION NOTE (document_properties_linearized): The linearization status of
+# the document; usually called "Fast Web View" in English locales of Adobe software.
+document_properties_linearized=Vista veloce do Web:
+document_properties_linearized_yes=Sci
+document_properties_linearized_no=No
+document_properties_close=Særa
+
+print_progress_message=Praparo o documento pe-a stanpa…
+# LOCALIZATION NOTE (print_progress_percent): "{{progress}}" will be replaced by
+# a numerical per cent value.
+print_progress_percent={{progress}}%
+print_progress_close=Anulla
+
+# Tooltips and alt text for side panel toolbar buttons
+# (the _label strings are alt text for the buttons, the .title strings are
+# tooltips)
+toggle_sidebar.title=Ativa/dizativa bara de scianco
+toggle_sidebar_label=Ativa/dizativa bara de scianco
+document_outline.title=Fanni vedde o contorno do documento (scicca doggio pe espande/ridue tutti i elementi)
+document_outline_label=Contorno do documento
+attachments.title=Fanni vedde alegæ
+attachments_label=Alegæ
+thumbs.title=Mostra miniatue
+thumbs_label=Miniatue
+findbar.title=Treuva into documento
+findbar_label=Treuva
+
+# Thumbnails panel item (tooltip and alt text for images)
+# LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
+# number.
+thumb_page_title=Pagina {{page}}
+# LOCALIZATION NOTE (thumb_page_canvas): "{{page}}" will be replaced by the page
+# number.
+thumb_page_canvas=Miniatua da pagina {{page}}
+
+# Find panel button title and messages
+find_input.title=Treuva
+find_input.placeholder=Treuva into documento…
+find_previous.title=Treuva a ripetiçion precedente do testo da çercâ
+find_previous_label=Precedente
+find_next.title=Treuva a ripetiçion dòppo do testo da çercâ
+find_next_label=Segoente
+find_highlight=Evidençia
+find_match_case_label=Maioscole/minoscole
+find_entire_word_label=Poula intrega
+find_reached_top=Razonto a fin da pagina, continoa da l'iniçio
+find_reached_bottom=Razonto l'iniçio da pagina, continoa da-a fin
+# LOCALIZATION NOTE (find_match_count): The supported plural forms are
+# [one|two|few|many|other], with [other] as the default value.
+# "{{current}}" and "{{total}}" will be replaced by a number representing the
+# index of the currently active find result, respectively a number representing
+# the total number of matches in the document.
+find_match_count={[ plural(total) ]}
+find_match_count[one]={{current}} de {{total}} corispondensa
+find_match_count[two]={{current}} de {{total}} corispondense
+find_match_count[few]={{current}} de {{total}} corispondense
+find_match_count[many]={{current}} de {{total}} corispondense
+find_match_count[other]={{current}} de {{total}} corispondense
+# LOCALIZATION NOTE (find_match_count_limit): The supported plural forms are
+# [zero|one|two|few|many|other], with [other] as the default value.
+# "{{limit}}" will be replaced by a numerical value.
+find_match_count_limit={[ plural(limit) ]}
+find_match_count_limit[zero]=Ciù de {{limit}} corispondense
+find_match_count_limit[one]=Ciù de {{limit}} corispondensa
+find_match_count_limit[two]=Ciù de {{limit}} corispondense
+find_match_count_limit[few]=Ciù de {{limit}} corispondense
+find_match_count_limit[many]=Ciù de {{limit}} corispondense
+find_match_count_limit[other]=Ciù de {{limit}} corispondense
+find_not_found=Testo no trovou
+
+# Predefined zoom values
+page_scale_width=Larghessa pagina
+page_scale_fit=Adatta a una pagina
+page_scale_auto=Zoom aotomatico
+page_scale_actual=Dimenscioin efetive
+# LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
+# numerical scale value.
+page_scale_percent={{scale}}%
+
+loading_error=S'é verificou 'n'erô itno caregamento do PDF.
+invalid_file_error=O schedaio PDF o l'é no valido ò aroinou.
+missing_file_error=O schedaio PDF o no gh'é.
+unexpected_response_error=Risposta inprevista do-u server
+
+rendering_error=Gh'é stæto 'n'erô itno rendering da pagina.
+
+# LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
+# "{{type}}" will be replaced with an annotation type from a list defined in
+# the PDF spec (32000-1:2008 Table 169 – Annotation types).
+# Some common types are e.g.: "Check", "Text", "Comment", "Note"
+text_annotation_type.alt=[Anotaçion: {{type}}]
+password_label=Dimme a paròlla segreta pe arvî sto schedaio PDF.
+password_invalid=Paròlla segreta sbalia. Preuva torna.
+password_ok=Va ben
+password_cancel=Anulla
+
+printing_not_supported=Atençion: a stanpa a no l'é conpletamente soportâ da sto navegatô.
+printing_not_ready=Atençion: o PDF o no l'é ancon caregou conpletamente pe-a stanpa.
+web_fonts_disabled=I font do web en dizativæ: inposcibile adeuviâ i carateri do PDF.
+

--- a/js/pdfjs/web/locale/lo/viewer.properties
+++ b/js/pdfjs/web/locale/lo/viewer.properties
@@ -1,0 +1,257 @@
+# Copyright 2012 Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Main toolbar buttons (tooltips and alt text for images)
+previous.title=ຫນ້າກ່ອນຫນ້າ
+previous_label=ກ່ອນຫນ້າ
+next.title=ຫນ້າຖັດໄປ
+next_label=ຖັດໄປ
+
+# LOCALIZATION NOTE (page.title): The tooltip for the pageNumber input.
+page.title=ຫນ້າ
+# LOCALIZATION NOTE (of_pages): "{{pagesCount}}" will be replaced by a number
+# representing the total number of pages in the document.
+of_pages=ຈາກ {{pagesCount}}
+# LOCALIZATION NOTE (page_of_pages): "{{pageNumber}}" and "{{pagesCount}}"
+# will be replaced by a number representing the currently visible page,
+# respectively a number representing the total number of pages in the document.
+page_of_pages=({{pageNumber}} ຈາກ {{pagesCount}})
+
+zoom_out.title=ຂະຫຍາຍອອກ
+zoom_out_label=ຂະຫຍາຍອອກ
+zoom_in.title=ຂະຫຍາຍເຂົ້າ
+zoom_in_label=ຂະຫຍາຍເຂົ້າ
+zoom.title=ຂະຫຍາຍ
+presentation_mode.title=ສັບປ່ຽນເປັນໂຫມດການນຳສະເຫນີ
+presentation_mode_label=ໂຫມດການນຳສະເຫນີ
+open_file.title=ເປີດໄຟລ໌
+open_file_label=ເປີດ
+print.title=ພິມ
+print_label=ພິມ
+
+save.title=ບັນທຶກ
+save_label=ບັນທຶກ
+bookmark1.title=ໜ້າປັດຈຸບັນ (ເບິ່ງ URL ຈາກໜ້າປັດຈຸບັນ)
+bookmark1_label=ຫນ້າ​ປັດ​ຈຸ​ບັນ
+
+open_in_app.title=ເປີດໃນ App
+open_in_app_label=ເປີດໃນ App
+
+# Secondary toolbar and context menu
+tools.title=ເຄື່ອງມື
+tools_label=ເຄື່ອງມື
+first_page.title=ໄປທີ່ຫນ້າທຳອິດ
+first_page_label=ໄປທີ່ຫນ້າທຳອິດ
+last_page.title=ໄປທີ່ຫນ້າສຸດທ້າຍ
+last_page_label=ໄປທີ່ຫນ້າສຸດທ້າຍ
+page_rotate_cw.title=ຫມູນຕາມເຂັມໂມງ
+page_rotate_cw_label=ຫມູນຕາມເຂັມໂມງ
+page_rotate_ccw.title=ຫມູນທວນເຂັມໂມງ
+page_rotate_ccw_label=ຫມູນທວນເຂັມໂມງ
+
+cursor_text_select_tool.title=ເປີດໃຊ້ເຄື່ອງມືການເລືອກຂໍ້ຄວາມ
+cursor_text_select_tool_label=ເຄື່ອງມືເລືອກຂໍ້ຄວາມ
+cursor_hand_tool.title=ເປີດໃຊ້ເຄື່ອງມືມື
+cursor_hand_tool_label=ເຄື່ອງມືມື
+
+scroll_page.title=ໃຊ້ການເລື່ອນໜ້າ
+scroll_page_label=ເລື່ອນໜ້າ
+scroll_vertical.title=ໃຊ້ການເລື່ອນແນວຕັ້ງ
+scroll_vertical_label=ເລື່ອນແນວຕັ້ງ
+scroll_horizontal.title=ໃຊ້ການເລື່ອນແນວນອນ
+scroll_horizontal_label=ເລື່ອນແນວນອນ
+scroll_wrapped.title=ໃຊ້ Wrapped Scrolling
+scroll_wrapped_label=Wrapped Scrolling
+
+spread_none.title=ບໍ່ຕ້ອງຮ່ວມການແຜ່ກະຈາຍຫນ້າ
+spread_none_label=ບໍ່ມີການແຜ່ກະຈາຍ
+spread_odd.title=ເຂົ້າຮ່ວມການແຜ່ກະຈາຍຫນ້າເລີ່ມຕົ້ນດ້ວຍຫນ້າເລກຄີກ
+spread_odd_label=ການແຜ່ກະຈາຍຄີກ
+spread_even.title=ເຂົ້າຮ່ວມການແຜ່ກະຈາຍຂອງຫນ້າເລີ່ມຕົ້ນດ້ວຍຫນ້າເລກຄູ່
+spread_even_label=ການແຜ່ກະຈາຍຄູ່
+
+# Document properties dialog box
+document_properties.title=ຄຸນສົມບັດເອກະສານ...
+document_properties_label=ຄຸນສົມບັດເອກະສານ...
+document_properties_file_name=ຊື່ໄຟລ໌:
+document_properties_file_size=ຂະຫນາດໄຟລ໌:
+# LOCALIZATION NOTE (document_properties_kb): "{{size_kb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in kilobytes, respectively in bytes.
+document_properties_kb={{size_kb}} KB ({{size_b}}  ໄບຕ໌)
+# LOCALIZATION NOTE (document_properties_mb): "{{size_mb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in megabytes, respectively in bytes.
+document_properties_mb={{size_mb}} MB ({{size_b}} ໄບຕ໌)
+document_properties_title=ຫົວຂໍ້:
+document_properties_author=ຜູ້ຂຽນ:
+document_properties_subject=ຫົວຂໍ້:
+document_properties_keywords=ຄໍາທີ່ຕ້ອງການຄົ້ນຫາ:
+document_properties_creation_date=ວັນທີສ້າງ:
+document_properties_modification_date=ວັນທີແກ້ໄຂ:
+# LOCALIZATION NOTE (document_properties_date_string): "{{date}}" and "{{time}}"
+# will be replaced by the creation/modification date, and time, of the PDF file.
+document_properties_date_string={{date}}, {{time}}
+document_properties_creator=ຜູ້ສ້າງ:
+document_properties_producer=ຜູ້ຜະລິດ PDF:
+document_properties_version=ເວີຊັ່ນ PDF:
+document_properties_page_count=ຈຳນວນໜ້າ:
+document_properties_page_size=ຂະໜາດໜ້າ:
+document_properties_page_size_unit_inches=in
+document_properties_page_size_unit_millimeters=mm
+document_properties_page_size_orientation_portrait=ລວງຕັ້ງ
+document_properties_page_size_orientation_landscape=ລວງນອນ
+document_properties_page_size_name_a3=A3
+document_properties_page_size_name_a4=A4
+document_properties_page_size_name_letter=ຈົດໝາຍ
+document_properties_page_size_name_legal=ຂໍ້ກົດຫມາຍ
+# LOCALIZATION NOTE (document_properties_page_size_dimension_string):
+# "{{width}}", "{{height}}", {{unit}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement and orientation, of the (current) page.
+document_properties_page_size_dimension_string={{width}} × {{height}} {{unit}} ({{orientation}})
+# LOCALIZATION NOTE (document_properties_page_size_dimension_name_string):
+# "{{width}}", "{{height}}", {{unit}}, {{name}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement, name, and orientation, of the (current) page.
+document_properties_page_size_dimension_name_string={{width}} × {{height}} {{unit}} ({{name}}, {{orientation}})
+# LOCALIZATION NOTE (document_properties_linearized): The linearization status of
+# the document; usually called "Fast Web View" in English locales of Adobe software.
+document_properties_linearized=ມຸມມອງເວັບທີ່ໄວ:
+document_properties_linearized_yes=ແມ່ນ
+document_properties_linearized_no=ບໍ່
+document_properties_close=ປິດ
+
+print_progress_message=ກຳລັງກະກຽມເອກະສານສຳລັບການພິມ...
+# LOCALIZATION NOTE (print_progress_percent): "{{progress}}" will be replaced by
+# a numerical per cent value.
+print_progress_percent={{progress}}%
+print_progress_close=ຍົກເລີກ
+
+# Tooltips and alt text for side panel toolbar buttons
+# (the _label strings are alt text for the buttons, the .title strings are
+# tooltips)
+toggle_sidebar.title=ເປີດ/ປິດແຖບຂ້າງ
+toggle_sidebar_notification2.title=ສະຫຼັບແຖບດ້ານຂ້າງ (ເອກະສານປະກອບມີໂຄງຮ່າງ/ໄຟລ໌ແນບ/ຊັ້ນຂໍ້ມູນ)
+toggle_sidebar_label=ເປີດ/ປິດແຖບຂ້າງ
+document_outline.title=ສະ​ແດງ​ໂຄງ​ຮ່າງ​ເອ​ກະ​ສານ (ກົດ​ສອງ​ຄັ້ງ​ເພື່ອ​ຂະ​ຫຍາຍ / ຫຍໍ້​ລາຍ​ການ​ທັງ​ຫມົດ​)
+document_outline_label=ເຄົ້າຮ່າງເອກະສານ
+attachments.title=ສະແດງໄຟລ໌ແນບ
+attachments_label=ໄຟລ໌ແນບ
+layers.title=ສະແດງຊັ້ນຂໍ້ມູນ (ຄລິກສອງເທື່ອເພື່ອຣີເຊັດຊັ້ນຂໍ້ມູນທັງໝົດໃຫ້ເປັນສະຖານະເລີ່ມຕົ້ນ)
+layers_label=ຊັ້ນ
+thumbs.title=ສະແດງຮູບຫຍໍ້
+thumbs_label=ຮູບຕົວຢ່າງ
+current_outline_item.title=ຊອກຫາລາຍການໂຄງຮ່າງປະຈຸບັນ
+current_outline_item_label=ລາຍການໂຄງຮ່າງປະຈຸບັນ
+findbar.title=ຊອກຫາໃນເອກະສານ
+findbar_label=ຄົ້ນຫາ
+
+additional_layers=ຊັ້ນຂໍ້ມູນເພີ່ມເຕີມ
+# LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
+page_landmark=ໜ້າ {{page}}
+# Thumbnails panel item (tooltip and alt text for images)
+# LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
+# number.
+thumb_page_title=ໜ້າ {{page}}
+# LOCALIZATION NOTE (thumb_page_canvas): "{{page}}" will be replaced by the page
+# number.
+thumb_page_canvas=ຮູບຕົວຢ່າງຂອງໜ້າ {{page}}
+
+# Find panel button title and messages
+find_input.title=ຄົ້ນຫາ
+find_input.placeholder=ຊອກຫາໃນເອກະສານ...
+find_previous.title=ຊອກຫາການປະກົດຕົວທີ່ຜ່ານມາຂອງປະໂຫຍກ
+find_previous_label=ກ່ອນຫນ້ານີ້
+find_next.title=ຊອກຫາຕຳແຫນ່ງຖັດໄປຂອງວະລີ
+find_next_label=ຕໍ່ໄປ
+find_highlight=ໄຮໄລທ໌ທັງຫມົດ
+find_match_case_label=ກໍລະນີທີ່ກົງກັນ
+find_match_diacritics_label=ເຄື່ອງໝາຍກຳກັບການອອກສຽງກົງກັນ
+find_entire_word_label=ກົງກັນທຸກຄຳ
+find_reached_top=ມາຮອດເທິງຂອງເອກະສານ, ສືບຕໍ່ຈາກລຸ່ມ
+find_reached_bottom=ຮອດຕອນທ້າຍຂອງເອກະສານ, ສືບຕໍ່ຈາກເທິງ
+# LOCALIZATION NOTE (find_match_count): The supported plural forms are
+# [one|two|few|many|other], with [other] as the default value.
+# "{{current}}" and "{{total}}" will be replaced by a number representing the
+# index of the currently active find result, respectively a number representing
+# the total number of matches in the document.
+find_match_count={[ plural(total) ]}
+find_match_count[one]={{current}} ຂອງ {{total}} ກົງກັນ
+find_match_count[two]={{current}} ຂອງ {{total}} ກົງກັນ
+find_match_count[few]={{current}} ຂອງ {{total}} ກົງກັນ
+find_match_count[many]={{current}} ຂອງ {{total}} ກົງກັນ
+find_match_count[other]={{current}} ຂອງ {{total}} ກົງກັນ
+# LOCALIZATION NOTE (find_match_count_limit): The supported plural forms are
+# [zero|one|two|few|many|other], with [other] as the default value.
+# "{{limit}}" will be replaced by a numerical value.
+find_match_count_limit={[ plural(limit) ]}
+find_match_count_limit[zero]=ຫຼາຍກວ່າ {{limit}} ກົງກັນ
+find_match_count_limit[one]=ກົງກັນຫຼາຍກວ່າ {{limit}}
+find_match_count_limit[two]=ຫຼາຍກວ່າ {{limit}} ກົງກັນ
+find_match_count_limit[few]=ຫຼາຍກວ່າ {{limit}} ກົງກັນ
+find_match_count_limit[many]=ຫຼາຍກວ່າ {{limit}} ກົງກັນ
+find_match_count_limit[other]=ຫຼາຍກວ່າ {{limit}} ກົງກັນ
+find_not_found=ບໍ່ພົບວະລີທີ່ຕ້ອງການ
+
+# Predefined zoom values
+page_scale_width=ຄວາມກວ້າງໜ້າ
+page_scale_fit=ໜ້າພໍດີ
+page_scale_auto=ຊູມອັດຕະໂນມັດ
+page_scale_actual=ຂະໜາດຕົວຈິງ
+# LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
+# numerical scale value.
+page_scale_percent={{scale}}%
+
+# Loading indicator messages
+loading_error=ມີຂໍ້ຜິດພາດເກີດຂື້ນຂະນະທີ່ກຳລັງໂຫລດ PDF.
+invalid_file_error=ໄຟລ໌ PDF ບໍ່ຖືກຕ້ອງຫລືເສຍຫາຍ.
+missing_file_error=ບໍ່ມີໄຟລ໌ PDF.
+unexpected_response_error=ການຕອບສະໜອງຂອງເຊີບເວີທີ່ບໍ່ຄາດຄິດ.
+
+rendering_error=ມີຂໍ້ຜິດພາດເກີດຂື້ນຂະນະທີ່ກຳລັງເຣັນເດີຫນ້າ.
+
+# LOCALIZATION NOTE (annotation_date_string): "{{date}}" and "{{time}}" will be
+# replaced by the modification date, and time, of the annotation.
+annotation_date_string={{date}}, {{time}}
+
+# LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
+# "{{type}}" will be replaced with an annotation type from a list defined in
+# the PDF spec (32000-1:2008 Table 169 – Annotation types).
+# Some common types are e.g.: "Check", "Text", "Comment", "Note"
+text_annotation_type.alt=[{{type}} ຄຳບັນຍາຍ]
+password_label=ໃສ່ລະຫັດຜ່ານເພື່ອເປີດໄຟລ໌ PDF ນີ້.
+password_invalid=ລະຫັດຜ່ານບໍ່ຖືກຕ້ອງ. ກະລຸນາລອງອີກຄັ້ງ.
+password_ok=ຕົກລົງ
+password_cancel=ຍົກເລີກ
+
+printing_not_supported=ຄຳເຕືອນ: ບຼາວເຊີນີ້ບໍ່ຮອງຮັບການພິມຢ່າງເຕັມທີ່.
+printing_not_ready=ຄໍາ​ເຕືອນ​: PDF ບໍ່​ໄດ້​ຖືກ​ໂຫຼດ​ຢ່າງ​ເຕັມ​ທີ່​ສໍາ​ລັບ​ການ​ພິມ​.
+web_fonts_disabled=ຟອນເວັບຖືກປິດໃຊ້ງານ: ບໍ່ສາມາດໃຊ້ຟອນ PDF ທີ່ຝັງໄວ້ໄດ້.
+
+# Editor
+editor_free_text2.title=ຂໍ້ຄວາມ
+editor_free_text2_label=ຂໍ້ຄວາມ
+editor_ink2.title=ແຕ້ມ
+editor_ink2_label=ແຕ້ມ
+
+free_text2_default_content=ເລີ່ມພິມ...
+
+# Editor Parameters
+editor_free_text_color=ສີ
+editor_free_text_size=ຂະຫນາດ
+editor_ink_color=ສີ
+editor_ink_thickness=ຄວາມຫນາ
+editor_ink_opacity=ຄວາມໂປ່ງໃສ
+
+# Editor aria
+editor_free_text2_aria_label=ຕົວແກ້ໄຂຂໍ້ຄວາມ
+editor_ink2_aria_label=ຕົວແກ້ໄຂຮູບແຕ້ມ
+editor_ink_canvas_aria_label=ຮູບພາບທີ່ຜູ້ໃຊ້ສ້າງ

--- a/js/pdfjs/web/locale/lt/viewer.properties
+++ b/js/pdfjs/web/locale/lt/viewer.properties
@@ -1,0 +1,229 @@
+# Copyright 2012 Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Main toolbar buttons (tooltips and alt text for images)
+previous.title=Ankstesnis puslapis
+previous_label=Ankstesnis
+next.title=Kitas puslapis
+next_label=Kitas
+
+# LOCALIZATION NOTE (page.title): The tooltip for the pageNumber input.
+page.title=Puslapis
+# LOCALIZATION NOTE (of_pages): "{{pagesCount}}" will be replaced by a number
+# representing the total number of pages in the document.
+of_pages=iš {{pagesCount}}
+# LOCALIZATION NOTE (page_of_pages): "{{pageNumber}}" and "{{pagesCount}}"
+# will be replaced by a number representing the currently visible page,
+# respectively a number representing the total number of pages in the document.
+page_of_pages=({{pageNumber}} iš {{pagesCount}})
+
+zoom_out.title=Sumažinti
+zoom_out_label=Sumažinti
+zoom_in.title=Padidinti
+zoom_in_label=Padidinti
+zoom.title=Mastelis
+presentation_mode.title=Pereiti į pateikties veikseną
+presentation_mode_label=Pateikties veiksena
+open_file.title=Atverti failą
+open_file_label=Atverti
+print.title=Spausdinti
+print_label=Spausdinti
+
+# Secondary toolbar and context menu
+tools.title=Priemonės
+tools_label=Priemonės
+first_page.title=Eiti į pirmą puslapį
+first_page_label=Eiti į pirmą puslapį
+last_page.title=Eiti į paskutinį puslapį
+last_page_label=Eiti į paskutinį puslapį
+page_rotate_cw.title=Pasukti pagal laikrodžio rodyklę
+page_rotate_cw_label=Pasukti pagal laikrodžio rodyklę
+page_rotate_ccw.title=Pasukti prieš laikrodžio rodyklę
+page_rotate_ccw_label=Pasukti prieš laikrodžio rodyklę
+
+cursor_text_select_tool.title=Įjungti teksto žymėjimo įrankį
+cursor_text_select_tool_label=Teksto žymėjimo įrankis
+cursor_hand_tool.title=Įjungti vilkimo įrankį
+cursor_hand_tool_label=Vilkimo įrankis
+
+scroll_page.title=Naudoti puslapio slinkimą
+scroll_page_label=Puslapio slinkimas
+scroll_vertical.title=Naudoti vertikalų slinkimą
+scroll_vertical_label=Vertikalus slinkimas
+scroll_horizontal.title=Naudoti horizontalų slinkimą
+scroll_horizontal_label=Horizontalus slinkimas
+scroll_wrapped.title=Naudoti išklotą slinkimą
+scroll_wrapped_label=Išklotas slinkimas
+
+spread_none.title=Nejungti puslapių į dvilapius
+spread_none_label=Be dvilapių
+spread_odd.title=Sujungti į dvilapius pradedant nelyginiais puslapiais
+spread_odd_label=Nelyginiai dvilapiai
+spread_even.title=Sujungti į dvilapius pradedant lyginiais puslapiais
+spread_even_label=Lyginiai dvilapiai
+
+# Document properties dialog box
+document_properties.title=Dokumento savybės…
+document_properties_label=Dokumento savybės…
+document_properties_file_name=Failo vardas:
+document_properties_file_size=Failo dydis:
+# LOCALIZATION NOTE (document_properties_kb): "{{size_kb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in kilobytes, respectively in bytes.
+document_properties_kb={{size_kb}} KB ({{size_b}} B)
+# LOCALIZATION NOTE (document_properties_mb): "{{size_mb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in megabytes, respectively in bytes.
+document_properties_mb={{size_mb}} MB ({{size_b}} B)
+document_properties_title=Antraštė:
+document_properties_author=Autorius:
+document_properties_subject=Tema:
+document_properties_keywords=Reikšminiai žodžiai:
+document_properties_creation_date=Sukūrimo data:
+document_properties_modification_date=Modifikavimo data:
+# LOCALIZATION NOTE (document_properties_date_string): "{{date}}" and "{{time}}"
+# will be replaced by the creation/modification date, and time, of the PDF file.
+document_properties_date_string={{date}}, {{time}}
+document_properties_creator=Kūrėjas:
+document_properties_producer=PDF generatorius:
+document_properties_version=PDF versija:
+document_properties_page_count=Puslapių skaičius:
+document_properties_page_size=Puslapio dydis:
+document_properties_page_size_unit_inches=in
+document_properties_page_size_unit_millimeters=mm
+document_properties_page_size_orientation_portrait=stačias
+document_properties_page_size_orientation_landscape=gulsčias
+document_properties_page_size_name_a3=A3
+document_properties_page_size_name_a4=A4
+document_properties_page_size_name_letter=Laiškas
+document_properties_page_size_name_legal=Dokumentas
+# LOCALIZATION NOTE (document_properties_page_size_dimension_string):
+# "{{width}}", "{{height}}", {{unit}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement and orientation, of the (current) page.
+document_properties_page_size_dimension_string={{width}} × {{height}} {{unit}} ({{orientation}})
+# LOCALIZATION NOTE (document_properties_page_size_dimension_name_string):
+# "{{width}}", "{{height}}", {{unit}}, {{name}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement, name, and orientation, of the (current) page.
+document_properties_page_size_dimension_name_string={{width}} × {{height}} {{unit}} ({{name}}, {{orientation}})
+# LOCALIZATION NOTE (document_properties_linearized): The linearization status of
+# the document; usually called "Fast Web View" in English locales of Adobe software.
+document_properties_linearized=Spartus žiniatinklio rodinys:
+document_properties_linearized_yes=Taip
+document_properties_linearized_no=Ne
+document_properties_close=Užverti
+
+print_progress_message=Dokumentas ruošiamas spausdinimui…
+# LOCALIZATION NOTE (print_progress_percent): "{{progress}}" will be replaced by
+# a numerical per cent value.
+print_progress_percent={{progress}}%
+print_progress_close=Atsisakyti
+
+# Tooltips and alt text for side panel toolbar buttons
+# (the _label strings are alt text for the buttons, the .title strings are
+# tooltips)
+toggle_sidebar.title=Rodyti / slėpti šoninį polangį
+toggle_sidebar_notification2.title=Parankinė (dokumentas turi struktūrą / priedų / sluoksnių)
+toggle_sidebar_label=Šoninis polangis
+document_outline.title=Rodyti dokumento struktūrą (spustelėkite dukart norėdami išplėsti/suskleisti visus elementus)
+document_outline_label=Dokumento struktūra
+attachments.title=Rodyti priedus
+attachments_label=Priedai
+layers.title=Rodyti sluoksnius (spustelėkite dukart, norėdami atstatyti visus sluoksnius į numatytąją būseną)
+layers_label=Sluoksniai
+thumbs.title=Rodyti puslapių miniatiūras
+thumbs_label=Miniatiūros
+current_outline_item.title=Rasti dabartinį struktūros elementą
+current_outline_item_label=Dabartinis struktūros elementas
+findbar.title=Ieškoti dokumente
+findbar_label=Rasti
+
+additional_layers=Papildomi sluoksniai
+# LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
+page_landmark={{page}} puslapis
+# Thumbnails panel item (tooltip and alt text for images)
+# LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
+# number.
+thumb_page_title={{page}} puslapis
+# LOCALIZATION NOTE (thumb_page_canvas): "{{page}}" will be replaced by the page
+# number.
+thumb_page_canvas={{page}} puslapio miniatiūra
+
+# Find panel button title and messages
+find_input.title=Rasti
+find_input.placeholder=Rasti dokumente…
+find_previous.title=Ieškoti ankstesnio frazės egzemplioriaus
+find_previous_label=Ankstesnis
+find_next.title=Ieškoti tolesnio frazės egzemplioriaus
+find_next_label=Tolesnis
+find_highlight=Viską paryškinti
+find_match_case_label=Skirti didžiąsias ir mažąsias raides
+find_match_diacritics_label=Skirti diakritinius ženklus
+find_entire_word_label=Ištisi žodžiai
+find_reached_top=Pasiekus dokumento pradžią, paieška pratęsta nuo pabaigos
+find_reached_bottom=Pasiekus dokumento pabaigą, paieška pratęsta nuo pradžios
+# LOCALIZATION NOTE (find_match_count): The supported plural forms are
+# [one|two|few|many|other], with [other] as the default value.
+# "{{current}}" and "{{total}}" will be replaced by a number representing the
+# index of the currently active find result, respectively a number representing
+# the total number of matches in the document.
+find_match_count={[ plural(total) ]}
+find_match_count[one]={{current}} iš {{total}} atitikmens
+find_match_count[two]={{current}} iš {{total}} atitikmenų
+find_match_count[few]={{current}} iš {{total}} atitikmenų
+find_match_count[many]={{current}} iš {{total}} atitikmenų
+find_match_count[other]={{current}} iš {{total}} atitikmens
+# LOCALIZATION NOTE (find_match_count_limit): The supported plural forms are
+# [zero|one|two|few|many|other], with [other] as the default value.
+# "{{limit}}" will be replaced by a numerical value.
+find_match_count_limit={[ plural(limit) ]}
+find_match_count_limit[zero]=Daugiau nei {{limit}} atitikmenų
+find_match_count_limit[one]=Daugiau nei {{limit}} atitikmuo
+find_match_count_limit[two]=Daugiau nei {{limit}} atitikmenys
+find_match_count_limit[few]=Daugiau nei {{limit}} atitikmenys
+find_match_count_limit[many]=Daugiau nei {{limit}} atitikmenų
+find_match_count_limit[other]=Daugiau nei {{limit}} atitikmuo
+find_not_found=Ieškoma frazė nerasta
+
+# Predefined zoom values
+page_scale_width=Priderinti prie lapo pločio
+page_scale_fit=Pritaikyti prie lapo dydžio
+page_scale_auto=Automatinis mastelis
+page_scale_actual=Tikras dydis
+# LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
+# numerical scale value.
+page_scale_percent={{scale}}%
+
+loading_error=Įkeliant PDF failą įvyko klaida.
+invalid_file_error=Tai nėra PDF failas arba jis yra sugadintas.
+missing_file_error=PDF failas nerastas.
+unexpected_response_error=Netikėtas serverio atsakas.
+
+rendering_error=Atvaizduojant puslapį įvyko klaida.
+
+# LOCALIZATION NOTE (annotation_date_string): "{{date}}" and "{{time}}" will be
+# replaced by the modification date, and time, of the annotation.
+annotation_date_string={{date}}, {{time}}
+
+# LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
+# "{{type}}" will be replaced with an annotation type from a list defined in
+# the PDF spec (32000-1:2008 Table 169 – Annotation types).
+# Some common types are e.g.: "Check", "Text", "Comment", "Note"
+text_annotation_type.alt=[„{{type}}“ tipo anotacija]
+password_label=Įveskite slaptažodį šiam PDF failui atverti.
+password_invalid=Slaptažodis neteisingas. Bandykite dar kartą.
+password_ok=Gerai
+password_cancel=Atsisakyti
+
+printing_not_supported=Dėmesio! Spausdinimas šioje naršyklėje nėra pilnai realizuotas.
+printing_not_ready=Dėmesio! PDF failas dar nėra pilnai įkeltas spausdinimui.
+web_fonts_disabled=Saityno šriftai išjungti – PDF faile esančių šriftų naudoti negalima.
+

--- a/js/pdfjs/web/locale/ltg/viewer.properties
+++ b/js/pdfjs/web/locale/ltg/viewer.properties
@@ -1,0 +1,192 @@
+# Copyright 2012 Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Main toolbar buttons (tooltips and alt text for images)
+previous.title=Īprīkšejā lopa
+previous_label=Īprīkšejā
+next.title=Nuokomuo lopa
+next_label=Nuokomuo
+
+# LOCALIZATION NOTE (page.title): The tooltip for the pageNumber input.
+page.title=Lopa
+# LOCALIZATION NOTE (of_pages): "{{pagesCount}}" will be replaced by a number
+# representing the total number of pages in the document.
+of_pages=nu {{pagesCount}}
+# LOCALIZATION NOTE (page_of_pages): "{{pageNumber}}" and "{{pagesCount}}"
+# will be replaced by a number representing the currently visible page,
+# respectively a number representing the total number of pages in the document.
+page_of_pages=({{pageNumber}} nu {{pagesCount}})
+
+zoom_out.title=Attuolynuot 
+zoom_out_label=Attuolynuot
+zoom_in.title=Pītuvynuot
+zoom_in_label=Pītuvynuot
+zoom.title=Palelynuojums
+presentation_mode.title=Puorslēgtīs iz Prezentacejis režymu
+presentation_mode_label=Prezentacejis režyms
+open_file.title=Attaiseit failu
+open_file_label=Attaiseit
+print.title=Drukuošona
+print_label=Drukōt
+
+# Secondary toolbar and context menu
+tools.title=Reiki
+tools_label=Reiki
+first_page.title=Īt iz pyrmū lopu
+first_page_label=Īt iz pyrmū lopu
+last_page.title=Īt iz piedejū lopu
+last_page_label=Īt iz piedejū lopu
+page_rotate_cw.title=Pagrīzt pa pulksteni
+page_rotate_cw_label=Pagrīzt pa pulksteni
+page_rotate_ccw.title=Pagrīzt pret pulksteni
+page_rotate_ccw_label=Pagrīzt pret pulksteni
+
+cursor_text_select_tool.title=Aktivizēt teksta izvieles reiku
+cursor_text_select_tool_label=Teksta izvieles reiks
+cursor_hand_tool.title=Aktivēt rūkys reiku
+cursor_hand_tool_label=Rūkys reiks
+
+scroll_vertical.title=Izmontōt vertikalū ritinōšonu
+scroll_vertical_label=Vertikalō ritinōšona
+scroll_horizontal.title=Izmontōt horizontalū ritinōšonu
+scroll_horizontal_label=Horizontalō ritinōšona
+scroll_wrapped.title=Izmontōt mārūgojamū ritinōšonu
+scroll_wrapped_label=Mārūgojamō ritinōšona
+
+spread_none.title=Naizmontōt lopu atvāruma režimu
+spread_none_label=Bez atvārumim
+spread_odd.title=Izmontōt lopu atvārumus sōkut nu napōra numeru lopom
+spread_odd_label=Napōra lopys pa kreisi
+spread_even.title=Izmontōt lopu atvārumus sōkut nu pōra numeru lopom
+spread_even_label=Pōra lopys pa kreisi
+
+# Document properties dialog box
+document_properties.title=Dokumenta īstatiejumi…
+document_properties_label=Dokumenta īstatiejumi…
+document_properties_file_name=Faila nūsaukums:
+document_properties_file_size=Faila izmārs:
+# LOCALIZATION NOTE (document_properties_kb): "{{size_kb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in kilobytes, respectively in bytes.
+document_properties_kb={{size_kb}} KB ({{size_b}} biti)
+# LOCALIZATION NOTE (document_properties_mb): "{{size_mb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in megabytes, respectively in bytes.
+document_properties_mb={{size_mb}} MB ({{size_b}} biti)
+document_properties_title=Nūsaukums:
+document_properties_author=Autors:
+document_properties_subject=Tema:
+document_properties_keywords=Atslāgi vuordi:
+document_properties_creation_date=Izveides datums:
+document_properties_modification_date=lobuošonys datums:
+# LOCALIZATION NOTE (document_properties_date_string): "{{date}}" and "{{time}}"
+# will be replaced by the creation/modification date, and time, of the PDF file.
+document_properties_date_string={{date}}, {{time}}
+document_properties_creator=Radeituojs:
+document_properties_producer=PDF producents:
+document_properties_version=PDF verseja:
+document_properties_page_count=Lopu skaits:
+document_properties_page_size=Lopas izmārs:
+document_properties_page_size_unit_inches=collas
+document_properties_page_size_unit_millimeters=mm
+document_properties_page_size_orientation_portrait=portreta orientaceja
+document_properties_page_size_orientation_landscape=ainovys orientaceja
+document_properties_page_size_name_a3=A3
+document_properties_page_size_name_a4=A4
+document_properties_page_size_name_letter=Letter
+document_properties_page_size_name_legal=Legal
+# LOCALIZATION NOTE (document_properties_page_size_dimension_string):
+# "{{width}}", "{{height}}", {{unit}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement and orientation, of the (current) page.
+document_properties_page_size_dimension_string={{width}} × {{height}} {{unit}} ({{orientation}})
+# LOCALIZATION NOTE (document_properties_page_size_dimension_name_string):
+# "{{width}}", "{{height}}", {{unit}}, {{name}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement, name, and orientation, of the (current) page.
+document_properties_page_size_dimension_name_string={{width}} × {{height}} {{unit}} ({{name}}, {{orientation}})
+# LOCALIZATION NOTE (document_properties_linearized): The linearization status of
+# the document; usually called "Fast Web View" in English locales of Adobe software.
+document_properties_linearized=Fast Web View:
+document_properties_linearized_yes=Jā
+document_properties_linearized_no=Nā
+document_properties_close=Aiztaiseit
+
+print_progress_message=Preparing document for printing…
+# LOCALIZATION NOTE (print_progress_percent): "{{progress}}" will be replaced by
+# a numerical per cent value.
+print_progress_percent={{progress}}%
+print_progress_close=Atceļt
+
+# Tooltips and alt text for side panel toolbar buttons
+# (the _label strings are alt text for the buttons, the .title strings are
+# tooltips)
+toggle_sidebar.title=Puorslēgt suonu jūslu
+toggle_sidebar_label=Puorslēgt suonu jūslu
+document_outline.title=Show Document Outline (double-click to expand/collapse all items)
+document_outline_label=Dokumenta saturs
+attachments.title=Show Attachments
+attachments_label=Attachments
+thumbs.title=Paruodeit seiktālus
+thumbs_label=Seiktāli
+findbar.title=Mekleit dokumentā
+findbar_label=Mekleit
+
+# Thumbnails panel item (tooltip and alt text for images)
+# LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
+# number.
+thumb_page_title=Lopa {{page}}
+# LOCALIZATION NOTE (thumb_page_canvas): "{{page}}" will be replaced by the page
+# number.
+thumb_page_canvas=Lopys {{page}} seiktāls
+
+# Find panel button title and messages
+find_input.title=Mekleit
+find_input.placeholder=Mekleit dokumentā…
+find_previous.title=Atrast īprīkšejū
+find_previous_label=Īprīkšejā
+find_next.title=Atrast nuokamū
+find_next_label=Nuokomuo
+find_highlight=Īkruosuot vysys
+find_match_case_label=Lelū, mozū burtu jiuteigs
+find_reached_top=Sasnīgts dokumenta suokums, turpynojom nu beigom
+find_reached_bottom=Sasnīgtys dokumenta beigys, turpynojom nu suokuma
+find_not_found=Frāze nav atrosta
+
+# Predefined zoom values
+page_scale_width=Lopys plotumā
+page_scale_fit=Ītylpynūt lopu
+page_scale_auto=Automatiskais izmārs
+page_scale_actual=Patīsais izmārs
+# LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
+# numerical scale value.
+page_scale_percent={{scale}}%
+
+loading_error=Īluodejūt PDF nūtyka klaida.
+invalid_file_error=Nadereigs voi būjuots PDF fails.
+missing_file_error=PDF fails nav atrosts.
+unexpected_response_error=Unexpected server response.
+
+rendering_error=Attālojūt lopu rodās klaida
+
+# LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
+# "{{type}}" will be replaced with an annotation type from a list defined in
+# the PDF spec (32000-1:2008 Table 169 – Annotation types).
+# Some common types are e.g.: "Check", "Text", "Comment", "Note"
+text_annotation_type.alt=[{{type}} Annotation]
+password_label=Īvodit paroli, kab attaiseitu PDF failu.
+password_invalid=Napareiza parole, raugit vēļreiz.
+password_ok=Labi
+password_cancel=Atceļt
+
+printing_not_supported=Uzmaneibu: Drukuošona nu itei puorlūka dorbojās tikai daleji.
+printing_not_ready=Uzmaneibu: PDF nav pilneibā īluodeits drukuošonai.
+web_fonts_disabled=Šķārsteikla fonti nav aktivizāti: Navar īgult PDF fontus.
+

--- a/js/pdfjs/web/locale/lv/viewer.properties
+++ b/js/pdfjs/web/locale/lv/viewer.properties
@@ -1,0 +1,214 @@
+# Copyright 2012 Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Main toolbar buttons (tooltips and alt text for images)
+previous.title=Iepriekšējā lapa
+previous_label=Iepriekšējā
+next.title=Nākamā lapa
+next_label=Nākamā
+
+# LOCALIZATION NOTE (page.title): The tooltip for the pageNumber input.
+page.title=Lapa
+# LOCALIZATION NOTE (of_pages): "{{pagesCount}}" will be replaced by a number
+# representing the total number of pages in the document.
+of_pages=no {{pagesCount}}
+# LOCALIZATION NOTE (page_of_pages): "{{pageNumber}}" and "{{pagesCount}}"
+# will be replaced by a number representing the currently visible page,
+# respectively a number representing the total number of pages in the document.
+page_of_pages=({{pageNumber}} no {{pagesCount}})
+
+zoom_out.title=Attālināt\u0020
+zoom_out_label=Attālināt
+zoom_in.title=Pietuvināt
+zoom_in_label=Pietuvināt
+zoom.title=Palielinājums
+presentation_mode.title=Pārslēgties uz Prezentācijas režīmu
+presentation_mode_label=Prezentācijas režīms
+open_file.title=Atvērt failu
+open_file_label=Atvērt
+print.title=Drukāšana
+print_label=Drukāt
+
+# Secondary toolbar and context menu
+tools.title=Rīki
+tools_label=Rīki
+first_page.title=Iet uz pirmo lapu
+first_page_label=Iet uz pirmo lapu
+last_page.title=Iet uz pēdējo lapu
+last_page_label=Iet uz pēdējo lapu
+page_rotate_cw.title=Pagriezt pa pulksteni
+page_rotate_cw_label=Pagriezt pa pulksteni
+page_rotate_ccw.title=Pagriezt pret pulksteni
+page_rotate_ccw_label=Pagriezt pret pulksteni
+
+cursor_text_select_tool.title=Aktivizēt teksta izvēles rīku
+cursor_text_select_tool_label=Teksta izvēles rīks
+cursor_hand_tool.title=Aktivēt rokas rīku
+cursor_hand_tool_label=Rokas rīks
+
+scroll_vertical.title=Izmantot vertikālo ritināšanu
+scroll_vertical_label=Vertikālā ritināšana
+scroll_horizontal.title=Izmantot horizontālo ritināšanu
+scroll_horizontal_label=Horizontālā ritināšana
+scroll_wrapped.title=Izmantot apkļauto ritināšanu
+scroll_wrapped_label=Apkļautā ritināšana
+
+spread_none.title=Nepievienoties lapu izpletumiem
+spread_none_label=Neizmantot izpletumus
+spread_odd.title=Izmantot lapu izpletumus sākot ar nepāra numuru lapām
+spread_odd_label=Nepāra izpletumi
+spread_even.title=Izmantot lapu izpletumus sākot ar pāra numuru lapām
+spread_even_label=Pāra izpletumi
+
+# Document properties dialog box
+document_properties.title=Dokumenta iestatījumi…
+document_properties_label=Dokumenta iestatījumi…
+document_properties_file_name=Faila nosaukums:
+document_properties_file_size=Faila izmērs:
+# LOCALIZATION NOTE (document_properties_kb): "{{size_kb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in kilobytes, respectively in bytes.
+document_properties_kb={{size_kb}} KB ({{size_b}} biti)
+# LOCALIZATION NOTE (document_properties_mb): "{{size_mb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in megabytes, respectively in bytes.
+document_properties_mb={{size_mb}} MB ({{size_b}} biti)
+document_properties_title=Nosaukums:
+document_properties_author=Autors:
+document_properties_subject=Tēma:
+document_properties_keywords=Atslēgas vārdi:
+document_properties_creation_date=Izveides datums:
+document_properties_modification_date=LAbošanas datums:
+# LOCALIZATION NOTE (document_properties_date_string): "{{date}}" and "{{time}}"
+# will be replaced by the creation/modification date, and time, of the PDF file.
+document_properties_date_string={{date}}, {{time}}
+document_properties_creator=Radītājs:
+document_properties_producer=PDF producents:
+document_properties_version=PDF versija:
+document_properties_page_count=Lapu skaits:
+document_properties_page_size=Papīra izmērs:
+document_properties_page_size_unit_inches=collas
+document_properties_page_size_unit_millimeters=mm
+document_properties_page_size_orientation_portrait=portretorientācija
+document_properties_page_size_orientation_landscape=ainavorientācija
+document_properties_page_size_name_a3=A3
+document_properties_page_size_name_a4=A4
+document_properties_page_size_name_letter=Vēstule
+document_properties_page_size_name_legal=Juridiskie teksti
+# LOCALIZATION NOTE (document_properties_page_size_dimension_string):
+# "{{width}}", "{{height}}", {{unit}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement and orientation, of the (current) page.
+document_properties_page_size_dimension_string={{width}} × {{height}} {{unit}} ({{orientation}})
+# LOCALIZATION NOTE (document_properties_page_size_dimension_name_string):
+# "{{width}}", "{{height}}", {{unit}}, {{name}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement, name, and orientation, of the (current) page.
+document_properties_page_size_dimension_name_string={{width}} × {{height}} {{unit}} ({{name}}, {{orientation}})
+# LOCALIZATION NOTE (document_properties_linearized): The linearization status of
+# the document; usually called "Fast Web View" in English locales of Adobe software.
+document_properties_linearized=Ātrā tīmekļa skats:
+document_properties_linearized_yes=Jā
+document_properties_linearized_no=Nē
+document_properties_close=Aizvērt
+
+print_progress_message=Gatavo dokumentu drukāšanai...
+# LOCALIZATION NOTE (print_progress_percent): "{{progress}}" will be replaced by
+# a numerical per cent value.
+print_progress_percent={{progress}}%
+print_progress_close=Atcelt
+
+# Tooltips and alt text for side panel toolbar buttons
+# (the _label strings are alt text for the buttons, the .title strings are
+# tooltips)
+toggle_sidebar.title=Pārslēgt sānu joslu
+toggle_sidebar_label=Pārslēgt sānu joslu
+document_outline.title=Rādīt dokumenta struktūru (veiciet dubultklikšķi lai izvērstu/sakļautu visus vienumus)
+document_outline_label=Dokumenta saturs
+attachments.title=Rādīt pielikumus
+attachments_label=Pielikumi
+thumbs.title=Parādīt sīktēlus
+thumbs_label=Sīktēli
+findbar.title=Meklēt dokumentā
+findbar_label=Meklēt
+
+# Thumbnails panel item (tooltip and alt text for images)
+# LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
+# number.
+thumb_page_title=Lapa {{page}}
+# LOCALIZATION NOTE (thumb_page_canvas): "{{page}}" will be replaced by the page
+# number.
+thumb_page_canvas=Lapas {{page}} sīktēls
+
+# Find panel button title and messages
+find_input.title=Meklēt
+find_input.placeholder=Meklēt dokumentā…
+find_previous.title=Atrast iepriekšējo
+find_previous_label=Iepriekšējā
+find_next.title=Atrast nākamo
+find_next_label=Nākamā
+find_highlight=Iekrāsot visas
+find_match_case_label=Lielo, mazo burtu jutīgs
+find_entire_word_label=Veselus vārdus
+find_reached_top=Sasniegts dokumenta sākums, turpinām no beigām
+find_reached_bottom=Sasniegtas dokumenta beigas, turpinām no sākuma
+# LOCALIZATION NOTE (find_match_count): The supported plural forms are
+# [one|two|few|many|other], with [other] as the default value.
+# "{{current}}" and "{{total}}" will be replaced by a number representing the
+# index of the currently active find result, respectively a number representing
+# the total number of matches in the document.
+find_match_count={[ plural(total) ]}
+find_match_count[one]={{current}} no {{total}} rezultāta
+find_match_count[two]={{current}} no {{total}} rezultātiem
+find_match_count[few]={{current}} no {{total}} rezultātiem
+find_match_count[many]={{current}} no {{total}} rezultātiem
+find_match_count[other]={{current}} no {{total}} rezultātiem
+# LOCALIZATION NOTE (find_match_count_limit): The supported plural forms are
+# [zero|one|two|few|many|other], with [other] as the default value.
+# "{{limit}}" will be replaced by a numerical value.
+find_match_count_limit={[ plural(limit) ]}
+find_match_count_limit[zero]=Vairāk nekā {{limit}} rezultāti
+find_match_count_limit[one]=Vairāk nekā {{limit}} rezultāti
+find_match_count_limit[two]=Vairāk nekā {{limit}} rezultāti
+find_match_count_limit[few]=Vairāk nekā {{limit}} rezultāti
+find_match_count_limit[many]=Vairāk nekā {{limit}} rezultāti
+find_match_count_limit[other]=Vairāk nekā {{limit}} rezultāti
+find_not_found=Frāze nav atrasta
+
+# Predefined zoom values
+page_scale_width=Lapas platumā
+page_scale_fit=Ietilpinot lapu
+page_scale_auto=Automātiskais izmērs
+page_scale_actual=Patiesais izmērs
+# LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
+# numerical scale value.
+page_scale_percent={{scale}}%
+
+loading_error=Ielādējot PDF notika kļūda.
+invalid_file_error=Nederīgs vai bojāts PDF fails.
+missing_file_error=PDF fails nav atrasts.
+unexpected_response_error=Negaidīa servera atbilde.
+
+rendering_error=Attēlojot lapu radās kļūda
+
+# LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
+# "{{type}}" will be replaced with an annotation type from a list defined in
+# the PDF spec (32000-1:2008 Table 169 – Annotation types).
+# Some common types are e.g.: "Check", "Text", "Comment", "Note"
+text_annotation_type.alt=[{{type}} anotācija]
+password_label=Ievadiet paroli, lai atvērtu PDF failu.
+password_invalid=Nepareiza parole, mēģiniet vēlreiz.
+password_ok=Labi
+password_cancel=Atcelt
+
+printing_not_supported=Uzmanību: Drukāšana no šī pārlūka darbojas tikai daļēji.
+printing_not_ready=Uzmanību: PDF nav pilnībā ielādēts drukāšanai.
+web_fonts_disabled=Tīmekļa fonti nav aktivizēti: Nevar iegult PDF fontus.
+

--- a/js/pdfjs/web/locale/meh/viewer.properties
+++ b/js/pdfjs/web/locale/meh/viewer.properties
@@ -1,0 +1,106 @@
+# Copyright 2012 Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Main toolbar buttons (tooltips and alt text for images)
+previous.title=Página yata
+
+# LOCALIZATION NOTE (page.title): The tooltip for the pageNumber input.
+# LOCALIZATION NOTE (of_pages): "{{pagesCount}}" will be replaced by a number
+# representing the total number of pages in the document.
+# LOCALIZATION NOTE (page_of_pages): "{{pageNumber}}" and "{{pagesCount}}"
+# will be replaced by a number representing the currently visible page,
+# respectively a number representing the total number of pages in the document.
+
+zoom.title=Nasa´a ka´nu/Nasa´a luli
+open_file_label=Síne
+
+# Secondary toolbar and context menu
+
+
+
+
+# Document properties dialog box
+# LOCALIZATION NOTE (document_properties_kb): "{{size_kb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in kilobytes, respectively in bytes.
+# LOCALIZATION NOTE (document_properties_mb): "{{size_mb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in megabytes, respectively in bytes.
+# LOCALIZATION NOTE (document_properties_date_string): "{{date}}" and "{{time}}"
+# will be replaced by the creation/modification date, and time, of the PDF file.
+document_properties_date_string={{date}}, {{time}}
+# LOCALIZATION NOTE (document_properties_page_size_dimension_string):
+# "{{width}}", "{{height}}", {{unit}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement and orientation, of the (current) page.
+document_properties_page_size_dimension_string={{width}} × {{height}} {{unit}} ({{orientation}})
+# LOCALIZATION NOTE (document_properties_page_size_dimension_name_string):
+# "{{width}}", "{{height}}", {{unit}}, {{name}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement, name, and orientation, of the (current) page.
+document_properties_page_size_dimension_name_string={{width}} × {{height}} {{unit}} ({{name}}, {{orientation}})
+# LOCALIZATION NOTE (document_properties_linearized): The linearization status of
+# the document; usually called "Fast Web View" in English locales of Adobe software.
+document_properties_linearized_yes=Kuvi
+document_properties_close=Nakasɨ
+
+# LOCALIZATION NOTE (print_progress_percent): "{{progress}}" will be replaced by
+# a numerical per cent value.
+print_progress_percent={{progress}}%
+print_progress_close=Nkuvi-ka
+
+# Tooltips and alt text for side panel toolbar buttons
+# (the _label strings are alt text for the buttons, the .title strings are
+# tooltips)
+findbar_label=Nánuku
+
+# Thumbnails panel item (tooltip and alt text for images)
+# LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
+# number.
+# LOCALIZATION NOTE (thumb_page_canvas): "{{page}}" will be replaced by the page
+# number.
+
+# Find panel button title and messages
+find_input.title=Nánuku
+# LOCALIZATION NOTE (find_match_count): The supported plural forms are
+# [one|two|few|many|other], with [other] as the default value.
+# "{{current}}" and "{{total}}" will be replaced by a number representing the
+# index of the currently active find result, respectively a number representing
+# the total number of matches in the document.
+find_match_count={[ plural(total) ]}
+# LOCALIZATION NOTE (find_match_count_limit): The supported plural forms are
+# [zero|one|two|few|many|other], with [other] as the default value.
+# "{{limit}}" will be replaced by a numerical value.
+find_match_count_limit={[ plural(limit) ]}
+
+# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
+# english string describing the error.
+# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
+# trace.
+# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
+# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
+
+# Predefined zoom values
+# LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
+# numerical scale value.
+page_scale_percent={{scale}}%
+
+# Loading indicator messages
+
+# LOCALIZATION NOTE (annotation_date_string): "{{date}}" and "{{time}}" will be
+# replaced by the modification date, and time, of the annotation.
+annotation_date_string={{date}}, {{time}}
+
+# LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
+# "{{type}}" will be replaced with an annotation type from a list defined in
+# the PDF spec (32000-1:2008 Table 169 – Annotation types).
+# Some common types are e.g.: "Check", "Text", "Comment", "Note"
+password_cancel=Nkuvi-ka
+

--- a/js/pdfjs/web/locale/mk/viewer.properties
+++ b/js/pdfjs/web/locale/mk/viewer.properties
@@ -1,0 +1,118 @@
+# Copyright 2012 Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Main toolbar buttons (tooltips and alt text for images)
+previous.title=Претходна страница
+previous_label=Претходна
+next.title=Следна страница
+next_label=Следна
+
+# LOCALIZATION NOTE (page.title): The tooltip for the pageNumber input.
+# LOCALIZATION NOTE (of_pages): "{{pagesCount}}" will be replaced by a number
+# representing the total number of pages in the document.
+# LOCALIZATION NOTE (page_of_pages): "{{pageNumber}}" and "{{pagesCount}}"
+# will be replaced by a number representing the currently visible page,
+# respectively a number representing the total number of pages in the document.
+
+zoom_out.title=Намалување
+zoom_out_label=Намали
+zoom_in.title=Зголемување
+zoom_in_label=Зголеми
+zoom.title=Променување на големина
+presentation_mode.title=Премини во презентациски режим
+presentation_mode_label=Презентациски режим
+open_file.title=Отворање датотека
+open_file_label=Отвори
+print.title=Печатење
+print_label=Печати
+
+# Secondary toolbar and context menu
+tools.title=Алатки
+
+
+
+
+# Document properties dialog box
+# LOCALIZATION NOTE (document_properties_kb): "{{size_kb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in kilobytes, respectively in bytes.
+# LOCALIZATION NOTE (document_properties_mb): "{{size_mb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in megabytes, respectively in bytes.
+# LOCALIZATION NOTE (document_properties_date_string): "{{date}}" and "{{time}}"
+# will be replaced by the creation/modification date, and time, of the PDF file.
+# LOCALIZATION NOTE (document_properties_page_size_dimension_string):
+# "{{width}}", "{{height}}", {{unit}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement and orientation, of the (current) page.
+# LOCALIZATION NOTE (document_properties_page_size_dimension_name_string):
+# "{{width}}", "{{height}}", {{unit}}, {{name}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement, name, and orientation, of the (current) page.
+# LOCALIZATION NOTE (document_properties_linearized): The linearization status of
+# the document; usually called "Fast Web View" in English locales of Adobe software.
+
+# LOCALIZATION NOTE (print_progress_percent): "{{progress}}" will be replaced by
+# a numerical per cent value.
+print_progress_close=Откажи
+
+# Tooltips and alt text for side panel toolbar buttons
+# (the _label strings are alt text for the buttons, the .title strings are
+# tooltips)
+toggle_sidebar.title=Вклучи странична лента
+toggle_sidebar_label=Вклучи странична лента
+thumbs.title=Прикажување на икони
+thumbs_label=Икони
+findbar.title=Најди во документот
+findbar_label=Најди
+
+# Thumbnails panel item (tooltip and alt text for images)
+# LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
+# number.
+thumb_page_title=Страница {{page}}
+# LOCALIZATION NOTE (thumb_page_canvas): "{{page}}" will be replaced by the page
+# number.
+thumb_page_canvas=Икона од страница {{page}}
+
+# Find panel button title and messages
+find_previous.title=Најди ја предходната појава на фразата
+find_previous_label=Претходно
+find_next.title=Најди ја следната појава на фразата
+find_next_label=Следно
+find_highlight=Означи сѐ
+find_match_case_label=Токму така
+find_reached_top=Барањето стигна до почетокот на документот и почнува од крајот
+find_reached_bottom=Барањето стигна до крајот на документот и почнува од почеток
+find_not_found=Фразата не е пронајдена
+
+# Predefined zoom values
+page_scale_width=Ширина на страница
+page_scale_fit=Цела страница
+page_scale_auto=Автоматска големина
+page_scale_actual=Вистинска големина
+# LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
+# numerical scale value.
+
+loading_error=Настана грешка при вчитувањето на PDF-от.
+invalid_file_error=Невалидна или корумпирана PDF датотека.
+missing_file_error=Недостасува PDF документ.
+
+rendering_error=Настана грешка при прикажувањето на страницата.
+
+# LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
+# "{{type}}" will be replaced with an annotation type from a list defined in
+# the PDF spec (32000-1:2008 Table 169 – Annotation types).
+# Some common types are e.g.: "Check", "Text", "Comment", "Note"
+password_cancel=Откажи
+
+printing_not_supported=Предупредување: Печатењето не е целосно поддржано во овој прелистувач.
+printing_not_ready=Предупредување: PDF документот не е целосно вчитан за печатење.
+web_fonts_disabled=Интернет фонтовите се оневозможени: не може да се користат вградените PDF фонтови.
+

--- a/js/pdfjs/web/locale/mr/viewer.properties
+++ b/js/pdfjs/web/locale/mr/viewer.properties
@@ -1,0 +1,210 @@
+# Copyright 2012 Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Main toolbar buttons (tooltips and alt text for images)
+previous.title=मागील पृष्ठ
+previous_label=मागील
+next.title=पुढील पृष्ठ
+next_label=पुढील
+
+# LOCALIZATION NOTE (page.title): The tooltip for the pageNumber input.
+page.title=पृष्ठ
+# LOCALIZATION NOTE (of_pages): "{{pagesCount}}" will be replaced by a number
+# representing the total number of pages in the document.
+of_pages={{pagesCount}}पैकी
+# LOCALIZATION NOTE (page_of_pages): "{{pageNumber}}" and "{{pagesCount}}"
+# will be replaced by a number representing the currently visible page,
+# respectively a number representing the total number of pages in the document.
+page_of_pages=({{pagesCount}} पैकी {{pageNumber}})
+
+zoom_out.title=छोटे करा
+zoom_out_label=छोटे करा
+zoom_in.title=मोठे करा
+zoom_in_label=मोठे करा
+zoom.title=लहान किंवा मोठे करा
+presentation_mode.title=प्रस्तुतिकरण मोडचा वापर करा
+presentation_mode_label=प्रस्तुतिकरण मोड
+open_file.title=फाइल उघडा
+open_file_label=उघडा
+print.title=छपाई करा
+print_label=छपाई करा
+
+# Secondary toolbar and context menu
+tools.title=साधने
+tools_label=साधने
+first_page.title=पहिल्या पृष्ठावर जा
+first_page_label=पहिल्या पृष्ठावर जा
+last_page.title=शेवटच्या पृष्ठावर जा
+last_page_label=शेवटच्या पृष्ठावर जा
+page_rotate_cw.title=घड्याळाच्या काट्याच्या दिशेने फिरवा
+page_rotate_cw_label=घड्याळाच्या काट्याच्या दिशेने फिरवा
+page_rotate_ccw.title=घड्याळाच्या काट्याच्या उलट दिशेने फिरवा
+page_rotate_ccw_label=घड्याळाच्या काट्याच्या उलट दिशेने फिरवा
+
+cursor_text_select_tool.title=मजकूर निवड साधन कार्यान्वयीत करा
+cursor_text_select_tool_label=मजकूर निवड साधन
+cursor_hand_tool.title=हात साधन कार्यान्वित करा
+cursor_hand_tool_label=हस्त साधन
+
+scroll_vertical.title=अनुलंब स्क्रोलिंग वापरा
+scroll_vertical_label=अनुलंब स्क्रोलिंग
+scroll_horizontal.title=क्षैतिज स्क्रोलिंग वापरा
+scroll_horizontal_label=क्षैतिज स्क्रोलिंग
+
+
+# Document properties dialog box
+document_properties.title=दस्तऐवज गुणधर्म…
+document_properties_label=दस्तऐवज गुणधर्म…
+document_properties_file_name=फाइलचे नाव:
+document_properties_file_size=फाइल आकार:
+# LOCALIZATION NOTE (document_properties_kb): "{{size_kb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in kilobytes, respectively in bytes.
+document_properties_kb={{size_kb}} KB ({{size_b}} बाइट्स)
+# LOCALIZATION NOTE (document_properties_mb): "{{size_mb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in megabytes, respectively in bytes.
+document_properties_mb={{size_mb}} MB ({{size_b}} बाइट्स)
+document_properties_title=शिर्षक:
+document_properties_author=लेखक:
+document_properties_subject=विषय:
+document_properties_keywords=मुख्यशब्द:
+document_properties_creation_date=निर्माण दिनांक:
+document_properties_modification_date=दुरूस्ती दिनांक:
+# LOCALIZATION NOTE (document_properties_date_string): "{{date}}" and "{{time}}"
+# will be replaced by the creation/modification date, and time, of the PDF file.
+document_properties_date_string={{date}}, {{time}}
+document_properties_creator=निर्माता:
+document_properties_producer=PDF निर्माता:
+document_properties_version=PDF आवृत्ती:
+document_properties_page_count=पृष्ठ संख्या:
+document_properties_page_size=पृष्ठ आकार:
+document_properties_page_size_unit_inches=इंच
+document_properties_page_size_unit_millimeters=मीमी
+document_properties_page_size_orientation_portrait=उभी मांडणी
+document_properties_page_size_orientation_landscape=आडवे
+document_properties_page_size_name_a3=A3
+document_properties_page_size_name_a4=A4
+document_properties_page_size_name_letter=Letter
+document_properties_page_size_name_legal=Legal
+# LOCALIZATION NOTE (document_properties_page_size_dimension_string):
+# "{{width}}", "{{height}}", {{unit}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement and orientation, of the (current) page.
+document_properties_page_size_dimension_string={{width}} × {{height}} {{unit}} ({{orientation}})
+# LOCALIZATION NOTE (document_properties_page_size_dimension_name_string):
+# "{{width}}", "{{height}}", {{unit}}, {{name}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement, name, and orientation, of the (current) page.
+document_properties_page_size_dimension_name_string={{width}} × {{height}} {{unit}} ({{name}}, {{orientation}})
+# LOCALIZATION NOTE (document_properties_linearized): The linearization status of
+# the document; usually called "Fast Web View" in English locales of Adobe software.
+document_properties_linearized=जलद वेब दृष्य:
+document_properties_linearized_yes=हो
+document_properties_linearized_no=नाही
+document_properties_close=बंद करा
+
+print_progress_message=छपाई करीता पृष्ठ तयार करीत आहे…
+# LOCALIZATION NOTE (print_progress_percent): "{{progress}}" will be replaced by
+# a numerical per cent value.
+print_progress_percent={{progress}}%
+print_progress_close=रद्द करा
+
+# Tooltips and alt text for side panel toolbar buttons
+# (the _label strings are alt text for the buttons, the .title strings are
+# tooltips)
+toggle_sidebar.title=बाजूचीपट्टी टॉगल करा
+toggle_sidebar_label=बाजूचीपट्टी टॉगल करा
+document_outline.title=दस्तऐवज बाह्यरेखा दर्शवा (विस्तृत करण्यासाठी दोनवेळा क्लिक करा /सर्व घटक दाखवा)
+document_outline_label=दस्तऐवज रूपरेषा
+attachments.title=जोडपत्र दाखवा
+attachments_label=जोडपत्र
+thumbs.title=थंबनेल्स् दाखवा
+thumbs_label=थंबनेल्स्
+findbar.title=दस्तऐवजात शोधा
+findbar_label=शोधा
+
+# Thumbnails panel item (tooltip and alt text for images)
+# LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
+# number.
+thumb_page_title=पृष्ठ {{page}}
+# LOCALIZATION NOTE (thumb_page_canvas): "{{page}}" will be replaced by the page
+# number.
+thumb_page_canvas=पृष्ठाचे थंबनेल {{page}}
+
+# Find panel button title and messages
+find_input.title=शोधा
+find_input.placeholder=दस्तऐवजात शोधा…
+find_previous.title=वाकप्रयोगची मागील घटना शोधा
+find_previous_label=मागील
+find_next.title=वाकप्रयोगची पुढील घटना शोधा
+find_next_label=पुढील
+find_highlight=सर्व ठळक करा
+find_match_case_label=आकार जुळवा
+find_entire_word_label=संपूर्ण शब्द
+find_reached_top=दस्तऐवजाच्या शीर्षकास पोहचले, तळपासून पुढे
+find_reached_bottom=दस्तऐवजाच्या तळाला पोहचले, शीर्षकापासून पुढे
+# LOCALIZATION NOTE (find_match_count): The supported plural forms are
+# [one|two|few|many|other], with [other] as the default value.
+# "{{current}}" and "{{total}}" will be replaced by a number representing the
+# index of the currently active find result, respectively a number representing
+# the total number of matches in the document.
+find_match_count={[ plural(total) ]}
+find_match_count[one]={{total}} पैकी {{current}} सुसंगत
+find_match_count[two]={{total}} पैकी {{current}} सुसंगत
+find_match_count[few]={{total}} पैकी {{current}} सुसंगत
+find_match_count[many]={{total}} पैकी {{current}} सुसंगत
+find_match_count[other]={{total}} पैकी {{current}} सुसंगत
+# LOCALIZATION NOTE (find_match_count_limit): The supported plural forms are
+# [zero|one|two|few|many|other], with [other] as the default value.
+# "{{limit}}" will be replaced by a numerical value.
+find_match_count_limit={[ plural(limit) ]}
+find_match_count_limit[zero]={{limit}} पेक्षा अधिक जुळण्या
+find_match_count_limit[one]={{limit}} पेक्षा अधिक जुळण्या
+find_match_count_limit[two]={{limit}} पेक्षा अधिक जुळण्या
+find_match_count_limit[few]={{limit}} पेक्षा अधिक जुळण्या
+find_match_count_limit[many]={{limit}} पेक्षा अधिक जुळण्या
+find_match_count_limit[other]={{limit}} पेक्षा अधिक जुळण्या
+find_not_found=वाकप्रयोग आढळले नाही
+
+# Predefined zoom values
+page_scale_width=पृष्ठाची रूंदी
+page_scale_fit=पृष्ठ बसवा
+page_scale_auto=स्वयं लाहन किंवा मोठे करणे
+page_scale_actual=प्रत्यक्ष आकार
+# LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
+# numerical scale value.
+page_scale_percent={{scale}}%
+
+loading_error=PDF लोड करतेवेळी त्रुटी आढळली.
+invalid_file_error=अवैध किंवा दोषीत PDF फाइल.
+missing_file_error=न आढळणारी PDF फाइल.
+unexpected_response_error=अनपेक्षित सर्व्हर प्रतिसाद.
+
+rendering_error=पृष्ठ दाखवतेवेळी त्रुटी आढळली.
+
+# LOCALIZATION NOTE (annotation_date_string): "{{date}}" and "{{time}}" will be
+# replaced by the modification date, and time, of the annotation.
+annotation_date_string={{date}}, {{time}}
+
+# LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
+# "{{type}}" will be replaced with an annotation type from a list defined in
+# the PDF spec (32000-1:2008 Table 169 – Annotation types).
+# Some common types are e.g.: "Check", "Text", "Comment", "Note"
+text_annotation_type.alt=[{{type}} टिपण्णी]
+password_label=ही PDF फाइल उघडण्याकरिता पासवर्ड द्या.
+password_invalid=अवैध पासवर्ड. कृपया पुन्हा प्रयत्न करा.
+password_ok=ठीक आहे
+password_cancel=रद्द करा
+
+printing_not_supported=सावधानता: या ब्राउझरतर्फे छपाइ पूर्णपणे समर्थीत नाही.
+printing_not_ready=सावधानता: छपाईकरिता PDF पूर्णतया लोड झाले नाही.
+web_fonts_disabled=वेब टंक असमर्थीत आहेत: एम्बेडेड PDF टंक वापर अशक्य.
+

--- a/js/pdfjs/web/locale/ms/viewer.properties
+++ b/js/pdfjs/web/locale/ms/viewer.properties
@@ -1,0 +1,214 @@
+# Copyright 2012 Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Main toolbar buttons (tooltips and alt text for images)
+previous.title=Halaman Dahulu
+previous_label=Dahulu
+next.title=Halaman Berikut
+next_label=Berikut
+
+# LOCALIZATION NOTE (page.title): The tooltip for the pageNumber input.
+page.title=Halaman
+# LOCALIZATION NOTE (of_pages): "{{pagesCount}}" will be replaced by a number
+# representing the total number of pages in the document.
+of_pages=daripada {{pagesCount}}
+# LOCALIZATION NOTE (page_of_pages): "{{pageNumber}}" and "{{pagesCount}}"
+# will be replaced by a number representing the currently visible page,
+# respectively a number representing the total number of pages in the document.
+page_of_pages=({{pageNumber}} daripada {{pagesCount}})
+
+zoom_out.title=Zum Keluar
+zoom_out_label=Zum Keluar
+zoom_in.title=Zum Masuk
+zoom_in_label=Zum Masuk
+zoom.title=Zum
+presentation_mode.title=Tukar ke Mod Persembahan
+presentation_mode_label=Mod Persembahan
+open_file.title=Buka Fail
+open_file_label=Buka
+print.title=Cetak
+print_label=Cetak
+
+# Secondary toolbar and context menu
+tools.title=Alatan
+tools_label=Alatan
+first_page.title=Pergi ke Halaman Pertama
+first_page_label=Pergi ke Halaman Pertama
+last_page.title=Pergi ke Halaman Terakhir
+last_page_label=Pergi ke Halaman Terakhir
+page_rotate_cw.title=Berputar ikut arah Jam
+page_rotate_cw_label=Berputar ikut arah Jam
+page_rotate_ccw.title=Pusing berlawan arah jam
+page_rotate_ccw_label=Pusing berlawan arah jam
+
+cursor_text_select_tool.title=Dayakan Alatan Pilihan Teks
+cursor_text_select_tool_label=Alatan Pilihan Teks
+cursor_hand_tool.title=Dayakan Alatan Tangan
+cursor_hand_tool_label=Alatan Tangan
+
+scroll_vertical.title=Guna Skrol Menegak
+scroll_vertical_label=Skrol Menegak
+scroll_horizontal.title=Guna Skrol Mengufuk
+scroll_horizontal_label=Skrol Mengufuk
+scroll_wrapped.title=Guna Skrol Berbalut
+scroll_wrapped_label=Skrol Berbalut
+
+spread_none.title=Jangan hubungkan hamparan halaman
+spread_none_label=Tanpa Hamparan
+spread_odd.title=Hubungkan hamparan halaman dengan halaman nombor ganjil
+spread_odd_label=Hamparan Ganjil
+spread_even.title=Hubungkan hamparan halaman dengan halaman nombor genap
+spread_even_label=Hamparan Seimbang
+
+# Document properties dialog box
+document_properties.title=Sifat Dokumen…
+document_properties_label=Sifat Dokumen…
+document_properties_file_name=Nama fail:
+document_properties_file_size=Saiz fail:
+# LOCALIZATION NOTE (document_properties_kb): "{{size_kb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in kilobytes, respectively in bytes.
+document_properties_kb={{size_kb}} KB ({{size_b}} bait)
+# LOCALIZATION NOTE (document_properties_mb): "{{size_mb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in megabytes, respectively in bytes.
+document_properties_mb={{size_mb}} MB ({{size_b}} bait)
+document_properties_title=Tajuk:
+document_properties_author=Pengarang:
+document_properties_subject=Subjek:
+document_properties_keywords=Kata kunci:
+document_properties_creation_date=Masa Dicipta:
+document_properties_modification_date=Tarikh Ubahsuai:
+# LOCALIZATION NOTE (document_properties_date_string): "{{date}}" and "{{time}}"
+# will be replaced by the creation/modification date, and time, of the PDF file.
+document_properties_date_string={{date}}, {{time}}
+document_properties_creator=Pencipta:
+document_properties_producer=Pengeluar PDF:
+document_properties_version=Versi PDF:
+document_properties_page_count=Kiraan Laman:
+document_properties_page_size=Saiz Halaman:
+document_properties_page_size_unit_inches=dalam
+document_properties_page_size_unit_millimeters=mm
+document_properties_page_size_orientation_portrait=potret
+document_properties_page_size_orientation_landscape=landskap
+document_properties_page_size_name_a3=A3
+document_properties_page_size_name_a4=A4
+document_properties_page_size_name_letter=Letter
+document_properties_page_size_name_legal=Legal
+# LOCALIZATION NOTE (document_properties_page_size_dimension_string):
+# "{{width}}", "{{height}}", {{unit}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement and orientation, of the (current) page.
+document_properties_page_size_dimension_string={{width}} × {{height}} {{unit}} ({{orientation}})
+# LOCALIZATION NOTE (document_properties_page_size_dimension_name_string):
+# "{{width}}", "{{height}}", {{unit}}, {{name}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement, name, and orientation, of the (current) page.
+document_properties_page_size_dimension_name_string={{width}} × {{height}} {{unit}} ({{name}}, {{orientation}})
+# LOCALIZATION NOTE (document_properties_linearized): The linearization status of
+# the document; usually called "Fast Web View" in English locales of Adobe software.
+document_properties_linearized=Paparan Web Pantas:
+document_properties_linearized_yes=Ya
+document_properties_linearized_no=Tidak
+document_properties_close=Tutup
+
+print_progress_message=Menyediakan dokumen untuk dicetak…
+# LOCALIZATION NOTE (print_progress_percent): "{{progress}}" will be replaced by
+# a numerical per cent value.
+print_progress_percent={{progress}}%
+print_progress_close=Batal
+
+# Tooltips and alt text for side panel toolbar buttons
+# (the _label strings are alt text for the buttons, the .title strings are
+# tooltips)
+toggle_sidebar.title=Togol Bar Sisi
+toggle_sidebar_label=Togol Bar Sisi
+document_outline.title=Papar Rangka Dokumen (klik-dua-kali untuk kembangkan/kolaps semua item)
+document_outline_label=Rangka Dokumen
+attachments.title=Papar Lampiran
+attachments_label=Lampiran
+thumbs.title=Papar Thumbnails
+thumbs_label=Imej kecil
+findbar.title=Cari didalam Dokumen
+findbar_label=Cari
+
+# Thumbnails panel item (tooltip and alt text for images)
+# LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
+# number.
+thumb_page_title=Halaman {{page}}
+# LOCALIZATION NOTE (thumb_page_canvas): "{{page}}" will be replaced by the page
+# number.
+thumb_page_canvas=Halaman Imej kecil {{page}}
+
+# Find panel button title and messages
+find_input.title=Cari
+find_input.placeholder=Cari dalam dokumen…
+find_previous.title=Cari teks frasa berkenaan yang terdahulu
+find_previous_label=Dahulu
+find_next.title=Cari teks frasa berkenaan yang berikut
+find_next_label=Berikut
+find_highlight=Serlahkan semua
+find_match_case_label=Huruf sepadan
+find_entire_word_label=Seluruh perkataan
+find_reached_top=Mencapai teratas daripada dokumen, sambungan daripada bawah
+find_reached_bottom=Mencapai terakhir daripada dokumen, sambungan daripada atas
+# LOCALIZATION NOTE (find_match_count): The supported plural forms are
+# [one|two|few|many|other], with [other] as the default value.
+# "{{current}}" and "{{total}}" will be replaced by a number representing the
+# index of the currently active find result, respectively a number representing
+# the total number of matches in the document.
+find_match_count={[ plural(total) ]}
+find_match_count[one]={{current}} daripada {{total}} padanan
+find_match_count[two]={{current}} daripada {{total}} padanan
+find_match_count[few]={{current}} daripada {{total}} padanan
+find_match_count[many]={{current}} daripada {{total}} padanan
+find_match_count[other]={{current}} daripada {{total}} padanan
+# LOCALIZATION NOTE (find_match_count_limit): The supported plural forms are
+# [zero|one|two|few|many|other], with [other] as the default value.
+# "{{limit}}" will be replaced by a numerical value.
+find_match_count_limit={[ plural(limit) ]}
+find_match_count_limit[zero]=Lebih daripada {{limit}} padanan
+find_match_count_limit[one]=Lebih daripada {{limit}} padanan
+find_match_count_limit[two]=Lebih daripada {{limit}} padanan
+find_match_count_limit[few]=Lebih daripada {{limit}} padanan
+find_match_count_limit[many]=Lebih daripada {{limit}} padanan
+find_match_count_limit[other]=Lebih daripada {{limit}} padanan
+find_not_found=Frasa tidak ditemui
+
+# Predefined zoom values
+page_scale_width=Lebar Halaman
+page_scale_fit=Muat Halaman
+page_scale_auto=Zoom Automatik
+page_scale_actual=Saiz Sebenar
+# LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
+# numerical scale value.
+page_scale_percent={{scale}}%
+
+loading_error=Masalah berlaku semasa menuatkan sebuah PDF.
+invalid_file_error=Tidak sah atau fail PDF rosak.
+missing_file_error=Fail PDF Hilang.
+unexpected_response_error=Respon pelayan yang tidak dijangka.
+
+rendering_error=Ralat berlaku ketika memberikan halaman.
+
+# LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
+# "{{type}}" will be replaced with an annotation type from a list defined in
+# the PDF spec (32000-1:2008 Table 169 – Annotation types).
+# Some common types are e.g.: "Check", "Text", "Comment", "Note"
+text_annotation_type.alt=[{{type}} Anotasi]
+password_label=Masukan kata kunci untuk membuka fail PDF ini.
+password_invalid=Kata laluan salah. Cuba lagi.
+password_ok=OK
+password_cancel=Batal
+
+printing_not_supported=Amaran: Cetakan ini tidak sepenuhnya disokong oleh pelayar ini.
+printing_not_ready=Amaran: PDF tidak sepenuhnya dimuatkan untuk dicetak.
+web_fonts_disabled=Fon web dinyahdayakan: tidak dapat menggunakan fon terbenam PDF.
+

--- a/js/pdfjs/web/locale/my/viewer.properties
+++ b/js/pdfjs/web/locale/my/viewer.properties
@@ -1,0 +1,170 @@
+# Copyright 2012 Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Main toolbar buttons (tooltips and alt text for images)
+previous.title=အရင် စာမျက်နှာ
+previous_label=အရင်နေရာ
+next.title=ရှေ့ စာမျက်နှာ
+next_label=နောက်တခု
+
+# LOCALIZATION NOTE (page.title): The tooltip for the pageNumber input.
+page.title=စာမျက်နှာ
+# LOCALIZATION NOTE (of_pages): "{{pagesCount}}" will be replaced by a number
+# representing the total number of pages in the document.
+of_pages={{pagesCount}} ၏
+# LOCALIZATION NOTE (page_of_pages): "{{pageNumber}}" and "{{pagesCount}}"
+# will be replaced by a number representing the currently visible page,
+# respectively a number representing the total number of pages in the document.
+page_of_pages=({{pagesCount}} ၏ {{pageNumber}})
+
+zoom_out.title=ချုံ့ပါ
+zoom_out_label=ချုံ့ပါ
+zoom_in.title=ချဲ့ပါ
+zoom_in_label=ချဲ့ပါ
+zoom.title=ချုံ့/ချဲ့ပါ
+presentation_mode.title=ဆွေးနွေးတင်ပြစနစ်သို့ ကူးပြောင်းပါ
+presentation_mode_label=ဆွေးနွေးတင်ပြစနစ်
+open_file.title=ဖိုင်အားဖွင့်ပါ။
+open_file_label=ဖွင့်ပါ
+print.title=ပုံနှိုပ်ပါ
+print_label=ပုံနှိုပ်ပါ
+
+# Secondary toolbar and context menu
+tools.title=ကိရိယာများ
+tools_label=ကိရိယာများ
+first_page.title=ပထမ စာမျက်နှာသို့
+first_page_label=ပထမ စာမျက်နှာသို့
+last_page.title=နောက်ဆုံး စာမျက်နှာသို့
+last_page_label=နောက်ဆုံး စာမျက်နှာသို့
+page_rotate_cw.title=နာရီလက်တံ အတိုင်း
+page_rotate_cw_label=နာရီလက်တံ အတိုင်း
+page_rotate_ccw.title=နာရီလက်တံ ပြောင်းပြန်
+page_rotate_ccw_label=နာရီလက်တံ ပြောင်းပြန်
+
+
+
+
+# Document properties dialog box
+document_properties.title=မှတ်တမ်းမှတ်ရာ ဂုဏ်သတ္တိများ
+document_properties_label=မှတ်တမ်းမှတ်ရာ ဂုဏ်သတ္တိများ
+document_properties_file_name=ဖိုင် :
+document_properties_file_size=ဖိုင်ဆိုဒ် :
+# LOCALIZATION NOTE (document_properties_kb): "{{size_kb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in kilobytes, respectively in bytes.
+document_properties_kb={{size_kb}} ကီလိုဘိုတ် ({{size_b}}ဘိုတ်)
+# LOCALIZATION NOTE (document_properties_mb): "{{size_mb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in megabytes, respectively in bytes.
+document_properties_mb={{size_mb}} MB ({{size_b}} bytes)
+document_properties_title=ခေါင်းစဉ်‌ -
+document_properties_author=ရေးသားသူ:
+document_properties_subject=အကြောင်းအရာ:\u0020
+document_properties_keywords=သော့ချက် စာလုံး:
+document_properties_creation_date=ထုတ်လုပ်ရက်စွဲ:
+document_properties_modification_date=ပြင်ဆင်ရက်စွဲ:
+# LOCALIZATION NOTE (document_properties_date_string): "{{date}}" and "{{time}}"
+# will be replaced by the creation/modification date, and time, of the PDF file.
+document_properties_date_string={{date}}, {{time}}
+document_properties_creator=ဖန်တီးသူ:
+document_properties_producer=PDF ထုတ်လုပ်သူ:
+document_properties_version=PDF ဗားရှင်း:
+document_properties_page_count=စာမျက်နှာအရေအတွက်:
+# LOCALIZATION NOTE (document_properties_page_size_dimension_string):
+# "{{width}}", "{{height}}", {{unit}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement and orientation, of the (current) page.
+# LOCALIZATION NOTE (document_properties_page_size_dimension_name_string):
+# "{{width}}", "{{height}}", {{unit}}, {{name}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement, name, and orientation, of the (current) page.
+# LOCALIZATION NOTE (document_properties_linearized): The linearization status of
+# the document; usually called "Fast Web View" in English locales of Adobe software.
+document_properties_close=ပိတ်
+
+print_progress_message=Preparing document for printing…
+# LOCALIZATION NOTE (print_progress_percent): "{{progress}}" will be replaced by
+# a numerical per cent value.
+print_progress_percent={{progress}}%
+print_progress_close=ပယ်​ဖျက်ပါ
+
+# Tooltips and alt text for side panel toolbar buttons
+# (the _label strings are alt text for the buttons, the .title strings are
+# tooltips)
+toggle_sidebar.title=ဘေးတန်းဖွင့်ပိတ်
+toggle_sidebar_label=ဖွင့်ပိတ် ဆလိုက်ဒါ
+document_outline.title=စာတမ်းအကျဉ်းချုပ်ကို ပြပါ (စာရင်းအားလုံးကို ချုံ့/ချဲ့ရန် ကလစ်နှစ်ချက်နှိပ်ပါ)
+document_outline_label=စာတမ်းအကျဉ်းချုပ်
+attachments.title=တွဲချက်များ ပြပါ
+attachments_label=တွဲထားချက်များ
+thumbs.title=ပုံရိပ်ငယ်များကို ပြပါ
+thumbs_label=ပုံရိပ်ငယ်များ
+findbar.title=Find in Document
+findbar_label=ရှာဖွေပါ
+
+# Thumbnails panel item (tooltip and alt text for images)
+# LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
+# number.
+thumb_page_title=စာမျက်နှာ {{page}}
+# LOCALIZATION NOTE (thumb_page_canvas): "{{page}}" will be replaced by the page
+# number.
+thumb_page_canvas=စာမျက်နှာရဲ့ ပုံရိပ်ငယ် {{page}}
+
+# Find panel button title and messages
+find_input.title=ရှာဖွေပါ
+find_input.placeholder=စာတမ်းထဲတွင် ရှာဖွေရန်…
+find_previous.title=စကားစုရဲ့ အရင် ​ဖြစ်ပွားမှုကို ရှာဖွေပါ
+find_previous_label=နောက်သို့
+find_next.title=စကားစုရဲ့ နောက်ထပ် ​ဖြစ်ပွားမှုကို ရှာဖွေပါ
+find_next_label=ရှေ့သို့
+find_highlight=အားလုံးကို မျဉ်းသားပါ
+find_match_case_label=စာလုံး တိုက်ဆိုင်ပါ
+find_reached_top=စာမျက်နှာထိပ် ရောက်နေပြီ၊ အဆုံးကနေ ပြန်စပါ
+find_reached_bottom=စာမျက်နှာအဆုံး ရောက်နေပြီ၊ ထိပ်ကနေ ပြန်စပါ
+# LOCALIZATION NOTE (find_match_count): The supported plural forms are
+# [one|two|few|many|other], with [other] as the default value.
+# "{{current}}" and "{{total}}" will be replaced by a number representing the
+# index of the currently active find result, respectively a number representing
+# the total number of matches in the document.
+# LOCALIZATION NOTE (find_match_count_limit): The supported plural forms are
+# [zero|one|two|few|many|other], with [other] as the default value.
+# "{{limit}}" will be replaced by a numerical value.
+find_not_found=စကားစု မတွေ့ရဘူး
+
+# Predefined zoom values
+page_scale_width=စာမျက်နှာ အကျယ်
+page_scale_fit=စာမျက်နှာ ကွက်တိ
+page_scale_auto=အလိုအလျောက် ချုံ့ချဲ့
+page_scale_actual=အမှန်တကယ်ရှိတဲ့ အရွယ်
+# LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
+# numerical scale value.
+page_scale_percent={{scale}}%
+
+loading_error=PDF ဖိုင် ကိုဆွဲတင်နေချိန်မှာ အမှားတစ်ခုတွေ့ရပါတယ်။
+invalid_file_error=မရသော သို့ ပျက်နေသော PDF ဖိုင်
+missing_file_error=PDF ပျောက်ဆုံး
+unexpected_response_error=မမျှော်လင့်ထားသော ဆာဗာမှ ပြန်ကြားချက်
+
+rendering_error=စာမျက်နှာကို ပုံဖော်နေချိန်မှာ အမှားတစ်ခုတွေ့ရပါတယ်။
+
+# LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
+# "{{type}}" will be replaced with an annotation type from a list defined in
+# the PDF spec (32000-1:2008 Table 169 – Annotation types).
+# Some common types are e.g.: "Check", "Text", "Comment", "Note"
+text_annotation_type.alt=[{{type}} အဓိပ္ပာယ်ဖွင့်ဆိုချက်]
+password_label=ယခု PDF ကို ဖွင့်ရန် စကားဝှက်ကို ရိုက်ပါ။
+password_invalid=စာဝှက် မှားသည်။ ထပ်ကြိုးစားကြည့်ပါ။
+password_ok=OK
+password_cancel=ပယ်​ဖျက်ပါ
+
+printing_not_supported=သတိပေးချက်၊ပရင့်ထုတ်ခြင်းကိုဤဘယောက်ဆာသည် ပြည့်ဝစွာထောက်ပံ့မထားပါ ။
+printing_not_ready=သတိပေးချက်: ယခု PDF ဖိုင်သည် ပုံနှိပ်ရန် မပြည့်စုံပါ
+web_fonts_disabled=Web fonts are disabled: unable to use embedded PDF fonts.
+

--- a/js/pdfjs/web/locale/nb-NO/viewer.properties
+++ b/js/pdfjs/web/locale/nb-NO/viewer.properties
@@ -1,0 +1,259 @@
+# Copyright 2012 Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Main toolbar buttons (tooltips and alt text for images)
+previous.title=Forrige side
+previous_label=Forrige
+next.title=Neste side
+next_label=Neste
+
+# LOCALIZATION NOTE (page.title): The tooltip for the pageNumber input.
+page.title=Side
+# LOCALIZATION NOTE (of_pages): "{{pagesCount}}" will be replaced by a number
+# representing the total number of pages in the document.
+of_pages=av {{pagesCount}}
+# LOCALIZATION NOTE (page_of_pages): "{{pageNumber}}" and "{{pagesCount}}"
+# will be replaced by a number representing the currently visible page,
+# respectively a number representing the total number of pages in the document.
+page_of_pages=({{pageNumber}} av {{pagesCount}})
+
+zoom_out.title=Zoom ut
+zoom_out_label=Zoom ut
+zoom_in.title=Zoom inn
+zoom_in_label=Zoom inn
+zoom.title=Zoom
+presentation_mode.title=Bytt til presentasjonsmodus
+presentation_mode_label=Presentasjonsmodus
+open_file.title=Åpne fil
+open_file_label=Åpne
+print.title=Skriv ut
+print_label=Skriv ut
+save.title=Lagre
+save_label=Lagre
+bookmark1.title=Gjeldende side (se URL fra gjeldende side)
+bookmark1_label=Gjeldende side
+# LOCALIZATION NOTE (open_in_app.title): This string is used in Firefox for Android.
+open_in_app.title=Åpne i app
+# LOCALIZATION NOTE (open_in_app_label): This string is used in Firefox for Android. Length of the translation matters since we are in a mobile context, with limited screen estate.
+open_in_app_label=Åpne i app
+
+# Secondary toolbar and context menu
+tools.title=Verktøy
+tools_label=Verktøy
+first_page.title=Gå til første side
+first_page_label=Gå til første side
+last_page.title=Gå til siste side
+last_page_label=Gå til siste side
+page_rotate_cw.title=Roter med klokken
+page_rotate_cw_label=Roter med klokken
+page_rotate_ccw.title=Roter mot klokken
+page_rotate_ccw_label=Roter mot klokken
+
+cursor_text_select_tool.title=Aktiver tekstmarkeringsverktøy
+cursor_text_select_tool_label=Tekstmarkeringsverktøy
+cursor_hand_tool.title=Aktiver handverktøy
+cursor_hand_tool_label=Handverktøy
+
+scroll_page.title=Bruk siderulling
+scroll_page_label=Siderulling
+scroll_vertical.title=Bruk vertikal rulling
+scroll_vertical_label=Vertikal rulling
+scroll_horizontal.title=Bruk horisontal rulling
+scroll_horizontal_label=Horisontal rulling
+scroll_wrapped.title=Bruk flersiderulling
+scroll_wrapped_label=Flersiderulling
+
+spread_none.title=Vis enkeltsider
+spread_none_label=Enkeltsider
+spread_odd.title=Vis oppslag med ulike sidenumre til venstre
+spread_odd_label=Oppslag med forside
+spread_even.title=Vis oppslag med like sidenumre til venstre
+spread_even_label=Oppslag uten forside
+
+# Document properties dialog box
+document_properties.title=Dokumentegenskaper …
+document_properties_label=Dokumentegenskaper …
+document_properties_file_name=Filnavn:
+document_properties_file_size=Filstørrelse:
+# LOCALIZATION NOTE (document_properties_kb): "{{size_kb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in kilobytes, respectively in bytes.
+document_properties_kb={{size_kb}} KB ({{size_b}} bytes)
+# LOCALIZATION NOTE (document_properties_mb): "{{size_mb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in megabytes, respectively in bytes.
+document_properties_mb={{size_mb}} MB ({{size_b}} bytes)
+document_properties_title=Dokumentegenskaper …
+document_properties_author=Forfatter:
+document_properties_subject=Emne:
+document_properties_keywords=Nøkkelord:
+document_properties_creation_date=Opprettet dato:
+document_properties_modification_date=Endret dato:
+# LOCALIZATION NOTE (document_properties_date_string): "{{date}}" and "{{time}}"
+# will be replaced by the creation/modification date, and time, of the PDF file.
+document_properties_date_string={{date}}, {{time}}
+document_properties_creator=Opprettet av:
+document_properties_producer=PDF-verktøy:
+document_properties_version=PDF-versjon:
+document_properties_page_count=Sideantall:
+document_properties_page_size=Sidestørrelse:
+document_properties_page_size_unit_inches=in
+document_properties_page_size_unit_millimeters=mm
+document_properties_page_size_orientation_portrait=stående
+document_properties_page_size_orientation_landscape=liggende
+document_properties_page_size_name_a3=A3
+document_properties_page_size_name_a4=A4
+document_properties_page_size_name_letter=Letter
+document_properties_page_size_name_legal=Legal
+# LOCALIZATION NOTE (document_properties_page_size_dimension_string):
+# "{{width}}", "{{height}}", {{unit}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement and orientation, of the (current) page.
+document_properties_page_size_dimension_string={{width}} × {{height}} {{unit}} ({{orientation}})
+# LOCALIZATION NOTE (document_properties_page_size_dimension_name_string):
+# "{{width}}", "{{height}}", {{unit}}, {{name}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement, name, and orientation, of the (current) page.
+document_properties_page_size_dimension_name_string={{width}} × {{height}} {{unit}} ({{name}}, {{orientation}})
+# LOCALIZATION NOTE (document_properties_linearized): The linearization status of
+# the document; usually called "Fast Web View" in English locales of Adobe software.
+document_properties_linearized=Hurtig nettvisning:
+document_properties_linearized_yes=Ja
+document_properties_linearized_no=Nei
+document_properties_close=Lukk
+
+print_progress_message=Forbereder dokument for utskrift …
+# LOCALIZATION NOTE (print_progress_percent): "{{progress}}" will be replaced by
+# a numerical per cent value.
+print_progress_percent={{progress}}%
+print_progress_close=Avbryt
+
+# Tooltips and alt text for side panel toolbar buttons
+# (the _label strings are alt text for the buttons, the .title strings are
+# tooltips)
+toggle_sidebar.title=Slå av/på sidestolpe
+toggle_sidebar_notification2.title=Vis/gjem sidestolpe (dokumentet inneholder oversikt/vedlegg/lag)
+toggle_sidebar_label=Slå av/på sidestolpe
+document_outline.title=Vis dokumentdisposisjonen (dobbeltklikk for å utvide/skjule alle elementer)
+document_outline_label=Dokumentdisposisjon
+attachments.title=Vis vedlegg
+attachments_label=Vedlegg
+layers.title=Vis lag (dobbeltklikk for å tilbakestille alle lag til standardtilstand)
+layers_label=Lag
+thumbs.title=Vis miniatyrbilde
+thumbs_label=Miniatyrbilde
+current_outline_item.title=Finn gjeldende disposisjonselement
+current_outline_item_label=Gjeldende disposisjonselement
+findbar.title=Finn i dokumentet
+findbar_label=Finn
+
+additional_layers=Ytterligere lag
+# LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
+page_landmark=Side {{page}}
+# Thumbnails panel item (tooltip and alt text for images)
+# LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
+# number.
+thumb_page_title=Side {{page}}
+# LOCALIZATION NOTE (thumb_page_canvas): "{{page}}" will be replaced by the page
+# number.
+thumb_page_canvas=Miniatyrbilde av side {{page}}
+
+# Find panel button title and messages
+find_input.title=Søk
+find_input.placeholder=Søk i dokument…
+find_previous.title=Finn forrige forekomst av frasen
+find_previous_label=Forrige
+find_next.title=Finn neste forekomst av frasen
+find_next_label=Neste
+find_highlight=Uthev alle
+find_match_case_label=Skill store/små bokstaver
+find_match_diacritics_label=Samsvar diakritiske tegn
+find_entire_word_label=Hele ord
+find_reached_top=Nådde toppen av dokumentet, fortsetter fra bunnen
+find_reached_bottom=Nådde bunnen av dokumentet, fortsetter fra toppen
+# LOCALIZATION NOTE (find_match_count): The supported plural forms are
+# [one|two|few|many|other], with [other] as the default value.
+# "{{current}}" and "{{total}}" will be replaced by a number representing the
+# index of the currently active find result, respectively a number representing
+# the total number of matches in the document.
+find_match_count={[ plural(total) ]}
+find_match_count[one]={{current}} av {{total}} treff
+find_match_count[two]={{current}} av {{total}} treff
+find_match_count[few]={{current}} av {{total}} treff
+find_match_count[many]={{current}} av {{total}} treff
+find_match_count[other]={{current}} av {{total}} treff
+# LOCALIZATION NOTE (find_match_count_limit): The supported plural forms are
+# [zero|one|two|few|many|other], with [other] as the default value.
+# "{{limit}}" will be replaced by a numerical value.
+find_match_count_limit={[ plural(limit) ]}
+find_match_count_limit[zero]=Mer enn {{limit}} treff
+find_match_count_limit[one]=Mer enn {{limit}} treff
+find_match_count_limit[two]=Mer enn {{limit}} treff
+find_match_count_limit[few]=Mer enn {{limit}} treff
+find_match_count_limit[many]=Mer enn {{limit}} treff
+find_match_count_limit[other]=Mer enn {{limit}} treff
+find_not_found=Fant ikke teksten
+
+# Predefined zoom values
+page_scale_width=Sidebredde
+page_scale_fit=Tilpass til siden
+page_scale_auto=Automatisk zoom
+page_scale_actual=Virkelig størrelse
+# LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
+# numerical scale value.
+page_scale_percent={{scale}} %
+
+# Loading indicator messages
+loading_error=En feil oppstod ved lasting av PDF.
+invalid_file_error=Ugyldig eller skadet PDF-fil.
+missing_file_error=Manglende PDF-fil.
+unexpected_response_error=Uventet serverrespons.
+rendering_error=En feil oppstod ved opptegning av siden.
+
+# LOCALIZATION NOTE (annotation_date_string): "{{date}}" and "{{time}}" will be
+# replaced by the modification date, and time, of the annotation.
+annotation_date_string={{date}}, {{time}}
+
+# LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
+# "{{type}}" will be replaced with an annotation type from a list defined in
+# the PDF spec (32000-1:2008 Table 169 – Annotation types).
+# Some common types are e.g.: "Check", "Text", "Comment", "Note"
+text_annotation_type.alt=[{{type}} annotasjon]
+password_label=Skriv inn passordet for å åpne denne PDF-filen.
+password_invalid=Ugyldig passord. Prøv igjen.
+password_ok=OK
+password_cancel=Avbryt
+
+printing_not_supported=Advarsel: Utskrift er ikke fullstendig støttet av denne nettleseren.
+printing_not_ready=Advarsel: PDF er ikke fullstendig innlastet for utskrift.
+web_fonts_disabled=Web-fonter er avslått: Kan ikke bruke innbundne PDF-fonter.
+
+# Editor
+editor_free_text2.title=Tekst
+editor_free_text2_label=Tekst
+editor_ink2.title=Tegn
+editor_ink2_label=Tegn
+
+editor_stamp.title=Legg til et bilde
+editor_stamp_label=Legg til et bilde
+
+free_text2_default_content=Begynn å skrive…
+
+# Editor Parameters
+editor_free_text_color=Farge
+editor_free_text_size=Størrelse
+editor_ink_color=Farge
+editor_ink_thickness=Tykkelse
+editor_ink_opacity=Ugjennomsiktighet
+
+# Editor aria
+editor_free_text2_aria_label=Tekstredigering
+editor_ink2_aria_label=Tegneredigering
+editor_ink_canvas_aria_label=Brukerskapt bilde

--- a/js/pdfjs/web/locale/ne-NP/viewer.properties
+++ b/js/pdfjs/web/locale/ne-NP/viewer.properties
@@ -1,0 +1,197 @@
+# Copyright 2012 Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Main toolbar buttons (tooltips and alt text for images)
+previous.title=अघिल्लो पृष्ठ
+previous_label=अघिल्लो
+next.title=पछिल्लो पृष्ठ
+next_label=पछिल्लो
+
+# LOCALIZATION NOTE (page.title): The tooltip for the pageNumber input.
+page.title=पृष्ठ
+# LOCALIZATION NOTE (of_pages): "{{pagesCount}}" will be replaced by a number
+# representing the total number of pages in the document.
+of_pages={{pagesCount}} मध्ये
+# LOCALIZATION NOTE (page_of_pages): "{{pageNumber}}" and "{{pagesCount}}"
+# will be replaced by a number representing the currently visible page,
+# respectively a number representing the total number of pages in the document.
+page_of_pages=({{pagesCount}} को {{pageNumber}})
+
+zoom_out.title=जुम घटाउनुहोस्
+zoom_out_label=जुम घटाउनुहोस्
+zoom_in.title=जुम बढाउनुहोस्
+zoom_in_label=जुम बढाउनुहोस्
+zoom.title=जुम गर्नुहोस्
+presentation_mode.title=प्रस्तुति मोडमा जानुहोस्
+presentation_mode_label=प्रस्तुति मोड
+open_file.title=फाइल खोल्नुहोस्
+open_file_label=खोल्नुहोस्
+print.title=मुद्रण गर्नुहोस्
+print_label=मुद्रण गर्नुहोस्
+
+# Secondary toolbar and context menu
+tools.title=औजारहरू
+tools_label=औजारहरू
+first_page.title=पहिलो पृष्ठमा जानुहोस्
+first_page_label=पहिलो पृष्ठमा जानुहोस्
+last_page.title=पछिल्लो पृष्ठमा जानुहोस्
+last_page_label=पछिल्लो पृष्ठमा जानुहोस्
+page_rotate_cw.title=घडीको दिशामा घुमाउनुहोस्
+page_rotate_cw_label=घडीको दिशामा घुमाउनुहोस्
+page_rotate_ccw.title=घडीको विपरित दिशामा घुमाउनुहोस्
+page_rotate_ccw_label=घडीको विपरित दिशामा घुमाउनुहोस्
+
+cursor_text_select_tool.title=पाठ चयन उपकरण सक्षम गर्नुहोस्
+cursor_text_select_tool_label=पाठ चयन उपकरण
+cursor_hand_tool.title=हाते उपकरण सक्षम गर्नुहोस्
+cursor_hand_tool_label=हाते उपकरण
+
+scroll_vertical.title=ठाडो स्क्रोलिङ्ग प्रयोग गर्नुहोस्
+scroll_vertical_label=ठाडो स्क्र्रोलिङ्ग
+scroll_horizontal.title=तेर्सो स्क्रोलिङ्ग प्रयोग गर्नुहोस्
+scroll_horizontal_label=तेर्सो स्क्रोलिङ्ग
+scroll_wrapped.title=लिपि स्क्रोलिङ्ग प्रयोग गर्नुहोस्
+scroll_wrapped_label=लिपि स्क्रोलिङ्ग
+
+spread_none.title=पृष्ठ स्प्रेडमा सामेल हुनुहुन्न
+spread_none_label=स्प्रेड छैन
+
+# Document properties dialog box
+document_properties.title=कागजात विशेषताहरू...
+document_properties_label=कागजात विशेषताहरू...
+document_properties_file_name=फाइल नाम:
+document_properties_file_size=फाइल आकार:
+# LOCALIZATION NOTE (document_properties_kb): "{{size_kb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in kilobytes, respectively in bytes.
+document_properties_kb={{size_kb}} KB ({{size_b}} bytes)
+# LOCALIZATION NOTE (document_properties_mb): "{{size_mb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in megabytes, respectively in bytes.
+document_properties_mb={{size_mb}} MB ({{size_b}} bytes)
+document_properties_title=शीर्षक:
+document_properties_author=लेखक:
+document_properties_subject=विषयः
+document_properties_keywords=शब्दकुञ्जीः
+document_properties_creation_date=सिर्जना गरिएको मिति:
+document_properties_modification_date=परिमार्जित मिति:
+# LOCALIZATION NOTE (document_properties_date_string): "{{date}}" and "{{time}}"
+# will be replaced by the creation/modification date, and time, of the PDF file.
+document_properties_date_string={{date}}, {{time}}
+document_properties_creator=सर्जक:
+document_properties_producer=PDF निर्माता:
+document_properties_version=PDF संस्करण
+document_properties_page_count=पृष्ठ गणना:
+document_properties_page_size=पृष्ठ आकार:
+document_properties_page_size_unit_inches=इन्च
+document_properties_page_size_unit_millimeters=मि.मि.
+document_properties_page_size_orientation_portrait=पोट्रेट
+document_properties_page_size_orientation_landscape=परिदृश्य
+document_properties_page_size_name_letter=अक्षर
+document_properties_page_size_name_legal=कानूनी
+# LOCALIZATION NOTE (document_properties_page_size_dimension_string):
+# "{{width}}", "{{height}}", {{unit}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement and orientation, of the (current) page.
+# LOCALIZATION NOTE (document_properties_page_size_dimension_name_string):
+# "{{width}}", "{{height}}", {{unit}}, {{name}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement, name, and orientation, of the (current) page.
+# LOCALIZATION NOTE (document_properties_linearized): The linearization status of
+# the document; usually called "Fast Web View" in English locales of Adobe software.
+document_properties_linearized_yes=हो
+document_properties_linearized_no=होइन
+document_properties_close=बन्द गर्नुहोस्
+
+print_progress_message=मुद्रणका लागि कागजात तयारी गरिदै…
+# LOCALIZATION NOTE (print_progress_percent): "{{progress}}" will be replaced by
+# a numerical per cent value.
+print_progress_percent={{progress}}%
+print_progress_close=रद्द गर्नुहोस्
+
+# Tooltips and alt text for side panel toolbar buttons
+# (the _label strings are alt text for the buttons, the .title strings are
+# tooltips)
+toggle_sidebar.title=टगल साइडबार
+toggle_sidebar_label=टगल साइडबार
+document_outline.title=कागजातको रूपरेखा देखाउनुहोस् (सबै वस्तुहरू विस्तार/पतन गर्न डबल-क्लिक गर्नुहोस्)
+document_outline_label=दस्तावेजको रूपरेखा
+attachments.title=संलग्नहरू देखाउनुहोस्
+attachments_label=संलग्नकहरू
+thumbs.title=थम्बनेलहरू देखाउनुहोस्
+thumbs_label=थम्बनेलहरू
+findbar.title=कागजातमा फेला पार्नुहोस्
+findbar_label=फेला पार्नुहोस्
+
+# LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
+# Thumbnails panel item (tooltip and alt text for images)
+# LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
+# number.
+thumb_page_title=पृष्ठ {{page}}
+# LOCALIZATION NOTE (thumb_page_canvas): "{{page}}" will be replaced by the page
+# number.
+thumb_page_canvas={{page}} पृष्ठको थम्बनेल
+
+# Find panel button title and messages
+find_input.title=फेला पार्नुहोस्
+find_input.placeholder=कागजातमा फेला पार्नुहोस्…
+find_previous.title=यस वाक्यांशको अघिल्लो घटना फेला पार्नुहोस्
+find_previous_label=अघिल्लो
+find_next.title=यस वाक्यांशको पछिल्लो घटना फेला पार्नुहोस्
+find_next_label=अर्को
+find_highlight=सबै हाइलाइट गर्ने
+find_match_case_label=केस जोडा मिलाउनुहोस्
+find_entire_word_label=पुरा शब्दहरु
+find_reached_top=पृष्ठको शिर्षमा पुगीयो, तलबाट जारी गरिएको थियो
+find_reached_bottom=पृष्ठको अन्त्यमा पुगीयो, शिर्षबाट जारी गरिएको थियो
+# LOCALIZATION NOTE (find_match_count): The supported plural forms are
+# [one|two|few|many|other], with [other] as the default value.
+# "{{current}}" and "{{total}}" will be replaced by a number representing the
+# index of the currently active find result, respectively a number representing
+# the total number of matches in the document.
+# LOCALIZATION NOTE (find_match_count_limit): The supported plural forms are
+# [zero|one|two|few|many|other], with [other] as the default value.
+# "{{limit}}" will be replaced by a numerical value.
+find_not_found=वाक्यांश फेला परेन
+
+# Predefined zoom values
+page_scale_width=पृष्ठ चौडाइ
+page_scale_fit=पृष्ठ ठिक्क मिल्ने
+page_scale_auto=स्वचालित जुम
+page_scale_actual=वास्तविक आकार
+# LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
+# numerical scale value.
+page_scale_percent={{scale}}%
+
+# Loading indicator messages
+loading_error=यो PDF लोड गर्दा एउटा त्रुटि देखापर्‍यो।
+invalid_file_error=अवैध वा दुषित PDF फाइल।
+missing_file_error=हराईरहेको PDF फाइल।
+unexpected_response_error=अप्रत्याशित सर्भर प्रतिक्रिया।
+
+# LOCALIZATION NOTE (annotation_date_string): "{{date}}" and "{{time}}" will be
+# replaced by the modification date, and time, of the annotation.
+
+rendering_error=पृष्ठ प्रतिपादन गर्दा एउटा त्रुटि देखापर्‍यो।
+
+# LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
+# "{{type}}" will be replaced with an annotation type from a list defined in
+# the PDF spec (32000-1:2008 Table 169 – Annotation types).
+# Some common types are e.g.: "Check", "Text", "Comment", "Note"
+text_annotation_type.alt=[{{type}} Annotation]
+password_label=यस PDF फाइललाई खोल्न गोप्यशब्द प्रविष्ट गर्नुहोस्।
+password_invalid=अवैध गोप्यशब्द। पुनः प्रयास गर्नुहोस्।
+password_ok=ठिक छ
+password_cancel=रद्द गर्नुहोस्
+
+printing_not_supported=चेतावनी: यो ब्राउजरमा मुद्रण पूर्णतया समर्थित छैन।
+printing_not_ready=चेतावनी: PDF मुद्रणका लागि पूर्णतया लोड भएको छैन।
+web_fonts_disabled=वेब फन्ट असक्षम छन्: एम्बेडेड PDF फन्ट प्रयोग गर्न असमर्थ।
+

--- a/js/pdfjs/web/locale/nl/viewer.properties
+++ b/js/pdfjs/web/locale/nl/viewer.properties
@@ -1,0 +1,259 @@
+# Copyright 2012 Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Main toolbar buttons (tooltips and alt text for images)
+previous.title=Vorige pagina
+previous_label=Vorige
+next.title=Volgende pagina
+next_label=Volgende
+
+# LOCALIZATION NOTE (page.title): The tooltip for the pageNumber input.
+page.title=Pagina
+# LOCALIZATION NOTE (of_pages): "{{pagesCount}}" will be replaced by a number
+# representing the total number of pages in the document.
+of_pages=van {{pagesCount}}
+# LOCALIZATION NOTE (page_of_pages): "{{pageNumber}}" and "{{pagesCount}}"
+# will be replaced by a number representing the currently visible page,
+# respectively a number representing the total number of pages in the document.
+page_of_pages=({{pageNumber}} van {{pagesCount}})
+
+zoom_out.title=Uitzoomen
+zoom_out_label=Uitzoomen
+zoom_in.title=Inzoomen
+zoom_in_label=Inzoomen
+zoom.title=Zoomen
+presentation_mode.title=Wisselen naar presentatiemodus
+presentation_mode_label=Presentatiemodus
+open_file.title=Bestand openen
+open_file_label=Openen
+print.title=Afdrukken
+print_label=Afdrukken
+save.title=Opslaan
+save_label=Opslaan
+bookmark1.title=Huidige pagina (URL van huidige pagina bekijken)
+bookmark1_label=Huidige pagina
+# LOCALIZATION NOTE (open_in_app.title): This string is used in Firefox for Android.
+open_in_app.title=Openen in app
+# LOCALIZATION NOTE (open_in_app_label): This string is used in Firefox for Android. Length of the translation matters since we are in a mobile context, with limited screen estate.
+open_in_app_label=Openen in app
+
+# Secondary toolbar and context menu
+tools.title=Hulpmiddelen
+tools_label=Hulpmiddelen
+first_page.title=Naar eerste pagina gaan
+first_page_label=Naar eerste pagina gaan
+last_page.title=Naar laatste pagina gaan
+last_page_label=Naar laatste pagina gaan
+page_rotate_cw.title=Rechtsom draaien
+page_rotate_cw_label=Rechtsom draaien
+page_rotate_ccw.title=Linksom draaien
+page_rotate_ccw_label=Linksom draaien
+
+cursor_text_select_tool.title=Tekstselectiehulpmiddel inschakelen
+cursor_text_select_tool_label=Tekstselectiehulpmiddel
+cursor_hand_tool.title=Handhulpmiddel inschakelen
+cursor_hand_tool_label=Handhulpmiddel
+
+scroll_page.title=Paginascrollen gebruiken
+scroll_page_label=Paginascrollen
+scroll_vertical.title=Verticaal scrollen gebruiken
+scroll_vertical_label=Verticaal scrollen
+scroll_horizontal.title=Horizontaal scrollen gebruiken
+scroll_horizontal_label=Horizontaal scrollen
+scroll_wrapped.title=Scrollen met terugloop gebruiken
+scroll_wrapped_label=Scrollen met terugloop
+
+spread_none.title=Dubbele pagina’s niet samenvoegen
+spread_none_label=Geen dubbele pagina’s
+spread_odd.title=Dubbele pagina’s samenvoegen vanaf oneven pagina’s
+spread_odd_label=Oneven dubbele pagina’s
+spread_even.title=Dubbele pagina’s samenvoegen vanaf even pagina’s
+spread_even_label=Even dubbele pagina’s
+
+# Document properties dialog box
+document_properties.title=Documenteigenschappen…
+document_properties_label=Documenteigenschappen…
+document_properties_file_name=Bestandsnaam:
+document_properties_file_size=Bestandsgrootte:
+# LOCALIZATION NOTE (document_properties_kb): "{{size_kb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in kilobytes, respectively in bytes.
+document_properties_kb={{size_kb}} KB ({{size_b}} bytes)
+# LOCALIZATION NOTE (document_properties_mb): "{{size_mb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in megabytes, respectively in bytes.
+document_properties_mb={{size_mb}} MB ({{size_b}} bytes)
+document_properties_title=Titel:
+document_properties_author=Auteur:
+document_properties_subject=Onderwerp:
+document_properties_keywords=Sleutelwoorden:
+document_properties_creation_date=Aanmaakdatum:
+document_properties_modification_date=Wijzigingsdatum:
+# LOCALIZATION NOTE (document_properties_date_string): "{{date}}" and "{{time}}"
+# will be replaced by the creation/modification date, and time, of the PDF file.
+document_properties_date_string={{date}}, {{time}}
+document_properties_creator=Maker:
+document_properties_producer=PDF-producent:
+document_properties_version=PDF-versie:
+document_properties_page_count=Aantal pagina’s:
+document_properties_page_size=Paginagrootte:
+document_properties_page_size_unit_inches=in
+document_properties_page_size_unit_millimeters=mm
+document_properties_page_size_orientation_portrait=staand
+document_properties_page_size_orientation_landscape=liggend
+document_properties_page_size_name_a3=A3
+document_properties_page_size_name_a4=A4
+document_properties_page_size_name_letter=Letter
+document_properties_page_size_name_legal=Legal
+# LOCALIZATION NOTE (document_properties_page_size_dimension_string):
+# "{{width}}", "{{height}}", {{unit}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement and orientation, of the (current) page.
+document_properties_page_size_dimension_string={{width}} × {{height}} {{unit}} ({{orientation}})
+# LOCALIZATION NOTE (document_properties_page_size_dimension_name_string):
+# "{{width}}", "{{height}}", {{unit}}, {{name}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement, name, and orientation, of the (current) page.
+document_properties_page_size_dimension_name_string={{width}} × {{height}} {{unit}} ({{name}}, {{orientation}})
+# LOCALIZATION NOTE (document_properties_linearized): The linearization status of
+# the document; usually called "Fast Web View" in English locales of Adobe software.
+document_properties_linearized=Snelle webweergave:
+document_properties_linearized_yes=Ja
+document_properties_linearized_no=Nee
+document_properties_close=Sluiten
+
+print_progress_message=Document voorbereiden voor afdrukken…
+# LOCALIZATION NOTE (print_progress_percent): "{{progress}}" will be replaced by
+# a numerical per cent value.
+print_progress_percent={{progress}}%
+print_progress_close=Annuleren
+
+# Tooltips and alt text for side panel toolbar buttons
+# (the _label strings are alt text for the buttons, the .title strings are
+# tooltips)
+toggle_sidebar.title=Zijbalk in-/uitschakelen
+toggle_sidebar_notification2.title=Zijbalk in-/uitschakelen (document bevat overzicht/bijlagen/lagen)
+toggle_sidebar_label=Zijbalk in-/uitschakelen
+document_outline.title=Documentoverzicht tonen (dubbelklik om alle items uit/samen te vouwen)
+document_outline_label=Documentoverzicht
+attachments.title=Bijlagen tonen
+attachments_label=Bijlagen
+layers.title=Lagen tonen (dubbelklik om alle lagen naar de standaardstatus terug te zetten)
+layers_label=Lagen
+thumbs.title=Miniaturen tonen
+thumbs_label=Miniaturen
+current_outline_item.title=Huidig item in inhoudsopgave zoeken
+current_outline_item_label=Huidig item in inhoudsopgave
+findbar.title=Zoeken in document
+findbar_label=Zoeken
+
+additional_layers=Aanvullende lagen
+# LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
+page_landmark=Pagina {{page}}
+# Thumbnails panel item (tooltip and alt text for images)
+# LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
+# number.
+thumb_page_title=Pagina {{page}}
+# LOCALIZATION NOTE (thumb_page_canvas): "{{page}}" will be replaced by the page
+# number.
+thumb_page_canvas=Miniatuur van pagina {{page}}
+
+# Find panel button title and messages
+find_input.title=Zoeken
+find_input.placeholder=Zoeken in document…
+find_previous.title=De vorige overeenkomst van de tekst zoeken
+find_previous_label=Vorige
+find_next.title=De volgende overeenkomst van de tekst zoeken
+find_next_label=Volgende
+find_highlight=Alles markeren
+find_match_case_label=Hoofdlettergevoelig
+find_match_diacritics_label=Diakritische tekens gebruiken
+find_entire_word_label=Hele woorden
+find_reached_top=Bovenkant van document bereikt, doorgegaan vanaf onderkant
+find_reached_bottom=Onderkant van document bereikt, doorgegaan vanaf bovenkant
+# LOCALIZATION NOTE (find_match_count): The supported plural forms are
+# [one|two|few|many|other], with [other] as the default value.
+# "{{current}}" and "{{total}}" will be replaced by a number representing the
+# index of the currently active find result, respectively a number representing
+# the total number of matches in the document.
+find_match_count={[ plural(total) ]}
+find_match_count[one]={{current}} van {{total}} overeenkomst
+find_match_count[two]={{current}} van {{total}} overeenkomsten
+find_match_count[few]={{current}} van {{total}} overeenkomsten
+find_match_count[many]={{current}} van {{total}} overeenkomsten
+find_match_count[other]={{current}} van {{total}} overeenkomsten
+# LOCALIZATION NOTE (find_match_count_limit): The supported plural forms are
+# [zero|one|two|few|many|other], with [other] as the default value.
+# "{{limit}}" will be replaced by a numerical value.
+find_match_count_limit={[ plural(limit) ]}
+find_match_count_limit[zero]=Meer dan {{limit}} overeenkomsten
+find_match_count_limit[one]=Meer dan {{limit}} overeenkomst
+find_match_count_limit[two]=Meer dan {{limit}} overeenkomsten
+find_match_count_limit[few]=Meer dan {{limit}} overeenkomsten
+find_match_count_limit[many]=Meer dan {{limit}} overeenkomsten
+find_match_count_limit[other]=Meer dan {{limit}} overeenkomsten
+find_not_found=Tekst niet gevonden
+
+# Predefined zoom values
+page_scale_width=Paginabreedte
+page_scale_fit=Hele pagina
+page_scale_auto=Automatisch zoomen
+page_scale_actual=Werkelijke grootte
+# LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
+# numerical scale value.
+page_scale_percent={{scale}}%
+
+# Loading indicator messages
+loading_error=Er is een fout opgetreden bij het laden van de PDF.
+invalid_file_error=Ongeldig of beschadigd PDF-bestand.
+missing_file_error=PDF-bestand ontbreekt. 
+unexpected_response_error=Onverwacht serverantwoord.
+rendering_error=Er is een fout opgetreden bij het weergeven van de pagina.
+
+# LOCALIZATION NOTE (annotation_date_string): "{{date}}" and "{{time}}" will be
+# replaced by the modification date, and time, of the annotation.
+annotation_date_string={{date}}, {{time}}
+
+# LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
+# "{{type}}" will be replaced with an annotation type from a list defined in
+# the PDF spec (32000-1:2008 Table 169 – Annotation types).
+# Some common types are e.g.: "Check", "Text", "Comment", "Note"
+text_annotation_type.alt=[{{type}}-aantekening]
+password_label=Voer het wachtwoord in om dit PDF-bestand te openen.
+password_invalid=Ongeldig wachtwoord. Probeer het opnieuw.
+password_ok=OK
+password_cancel=Annuleren
+
+printing_not_supported=Waarschuwing: afdrukken wordt niet volledig ondersteund door deze browser.
+printing_not_ready=Waarschuwing: de PDF is niet volledig geladen voor afdrukken.
+web_fonts_disabled=Weblettertypen zijn uitgeschakeld: gebruik van ingebedde PDF-lettertypen is niet mogelijk.
+
+# Editor
+editor_free_text2.title=Tekst
+editor_free_text2_label=Tekst
+editor_ink2.title=Tekenen
+editor_ink2_label=Tekenen
+
+editor_stamp.title=Afbeelding toevoegen
+editor_stamp_label=Afbeelding toevoegen
+
+free_text2_default_content=Begin met typen…
+
+# Editor Parameters
+editor_free_text_color=Kleur
+editor_free_text_size=Grootte
+editor_ink_color=Kleur
+editor_ink_thickness=Dikte
+editor_ink_opacity=Opaciteit
+
+# Editor aria
+editor_free_text2_aria_label=Tekstbewerker
+editor_ink2_aria_label=Tekeningbewerker
+editor_ink_canvas_aria_label=Door gebruiker gemaakte afbeelding

--- a/js/pdfjs/web/locale/nn-NO/viewer.properties
+++ b/js/pdfjs/web/locale/nn-NO/viewer.properties
@@ -1,0 +1,257 @@
+# Copyright 2012 Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Main toolbar buttons (tooltips and alt text for images)
+previous.title=Føregåande side
+previous_label=Føregåande
+next.title=Neste side
+next_label=Neste
+
+# LOCALIZATION NOTE (page.title): The tooltip for the pageNumber input.
+page.title=Side
+# LOCALIZATION NOTE (of_pages): "{{pagesCount}}" will be replaced by a number
+# representing the total number of pages in the document.
+of_pages=av {{pagesCount}}
+# LOCALIZATION NOTE (page_of_pages): "{{pageNumber}}" and "{{pagesCount}}"
+# will be replaced by a number representing the currently visible page,
+# respectively a number representing the total number of pages in the document.
+page_of_pages=({{pageNumber}} av {{pagesCount}})
+
+zoom_out.title=Zoom ut
+zoom_out_label=Zoom ut
+zoom_in.title=Zoom inn
+zoom_in_label=Zoom inn
+zoom.title=Zoom
+presentation_mode.title=Byt til presentasjonsmodus
+presentation_mode_label=Presentasjonsmodus
+open_file.title=Opne fil
+open_file_label=Opne
+print.title=Skriv ut
+print_label=Skriv ut
+
+save.title=Lagre
+save_label=Lagre
+bookmark1.title=Gjeldande side (sjå URL frå gjeldande side)
+bookmark1_label=Gjeldande side
+
+open_in_app.title=Opne i app
+open_in_app_label=Opne i app
+
+# Secondary toolbar and context menu
+tools.title=Verktøy
+tools_label=Verktøy
+first_page.title=Gå til første side
+first_page_label=Gå til første side
+last_page.title=Gå til siste side
+last_page_label=Gå til siste side
+page_rotate_cw.title=Roter med klokka
+page_rotate_cw_label=Roter med klokka
+page_rotate_ccw.title=Roter mot klokka
+page_rotate_ccw_label=Roter mot klokka
+
+cursor_text_select_tool.title=Aktiver tekstmarkeringsverktøy
+cursor_text_select_tool_label=Tekstmarkeringsverktøy
+cursor_hand_tool.title=Aktiver handverktøy
+cursor_hand_tool_label=Handverktøy
+
+scroll_page.title=Bruk siderulling
+scroll_page_label=Siderulling
+scroll_vertical.title=Bruk vertikal rulling
+scroll_vertical_label=Vertikal rulling
+scroll_horizontal.title=Bruk horisontal rulling
+scroll_horizontal_label=Horisontal rulling
+scroll_wrapped.title=Bruk fleirsiderulling
+scroll_wrapped_label=Fleirsiderulling
+
+spread_none.title=Vis enkeltsider
+spread_none_label=Enkeltside
+spread_odd.title=Vis oppslag med ulike sidenummer til venstre
+spread_odd_label=Oppslag med framside
+spread_even.title=Vis oppslag med like sidenummmer til venstre
+spread_even_label=Oppslag utan framside
+
+# Document properties dialog box
+document_properties.title=Dokumenteigenskapar…
+document_properties_label=Dokumenteigenskapar…
+document_properties_file_name=Filnamn:
+document_properties_file_size=Filstorleik:
+# LOCALIZATION NOTE (document_properties_kb): "{{size_kb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in kilobytes, respectively in bytes.
+document_properties_kb={{size_kb}} KB ({{size_b}} bytes)
+# LOCALIZATION NOTE (document_properties_mb): "{{size_mb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in megabytes, respectively in bytes.
+document_properties_mb={{size_mb}} MB ({{size_b}} bytes)
+document_properties_title=Tittel:
+document_properties_author=Forfattar:
+document_properties_subject=Emne:
+document_properties_keywords=Stikkord:
+document_properties_creation_date=Dato oppretta:
+document_properties_modification_date=Dato endra:
+# LOCALIZATION NOTE (document_properties_date_string): "{{date}}" and "{{time}}"
+# will be replaced by the creation/modification date, and time, of the PDF file.
+document_properties_date_string={{date}}, {{time}}
+document_properties_creator=Oppretta av:
+document_properties_producer=PDF-verktøy:
+document_properties_version=PDF-versjon:
+document_properties_page_count=Sidetal:
+document_properties_page_size=Sidestørrelse:
+document_properties_page_size_unit_inches=in
+document_properties_page_size_unit_millimeters=mm
+document_properties_page_size_orientation_portrait=ståande
+document_properties_page_size_orientation_landscape=liggande
+document_properties_page_size_name_a3=A3
+document_properties_page_size_name_a4=A4
+document_properties_page_size_name_letter=Brev
+document_properties_page_size_name_legal=Legal
+# LOCALIZATION NOTE (document_properties_page_size_dimension_string):
+# "{{width}}", "{{height}}", {{unit}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement and orientation, of the (current) page.
+document_properties_page_size_dimension_string={{width}} × {{height}} {{unit}} ({{orientation}})
+# LOCALIZATION NOTE (document_properties_page_size_dimension_name_string):
+# "{{width}}", "{{height}}", {{unit}}, {{name}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement, name, and orientation, of the (current) page.
+document_properties_page_size_dimension_name_string={{width}} × {{height}} {{unit}} ({{name}}, {{orientation}})
+# LOCALIZATION NOTE (document_properties_linearized): The linearization status of
+# the document; usually called "Fast Web View" in English locales of Adobe software.
+document_properties_linearized=Rask nettvising:
+document_properties_linearized_yes=Ja
+document_properties_linearized_no=Nei
+document_properties_close=Lat att
+
+print_progress_message=Førebur dokumentet for utskrift…
+# LOCALIZATION NOTE (print_progress_percent): "{{progress}}" will be replaced by
+# a numerical per cent value.
+print_progress_percent={{progress}}%
+print_progress_close=Avbryt
+
+# Tooltips and alt text for side panel toolbar buttons
+# (the _label strings are alt text for the buttons, the .title strings are
+# tooltips)
+toggle_sidebar.title=Slå av/på sidestolpe
+toggle_sidebar_notification2.title=Vis/gøym sidestolpe (dokumentet inneheld oversikt/vedlegg/lag)
+toggle_sidebar_label=Slå av/på sidestolpe
+document_outline.title=Vis dokumentdisposisjonen (dobbelklikk for å utvide/gøyme alle elementa)
+document_outline_label=Dokumentdisposisjon
+attachments.title=Vis vedlegg
+attachments_label=Vedlegg
+layers.title=Vis lag (dobbeltklikk for å tilbakestille alle lag til standardtilstand)
+layers_label=Lag
+thumbs.title=Vis miniatyrbilde
+thumbs_label=Miniatyrbilde
+current_outline_item.title=Finn gjeldande disposisjonselement
+current_outline_item_label=Gjeldande disposisjonselement
+findbar.title=Finn i dokumentet
+findbar_label=Finn
+
+additional_layers=Ytterlegare lag
+# LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
+page_landmark=Side {{page}}
+# Thumbnails panel item (tooltip and alt text for images)
+# LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
+# number.
+thumb_page_title=Side {{page}}
+# LOCALIZATION NOTE (thumb_page_canvas): "{{page}}" will be replaced by the page
+# number.
+thumb_page_canvas=Miniatyrbilde av side {{page}}
+
+# Find panel button title and messages
+find_input.title=Søk
+find_input.placeholder=Søk i dokument…
+find_previous.title=Finn førre førekomst av frasen
+find_previous_label=Førre
+find_next.title=Finn neste førekomst av frasen
+find_next_label=Neste
+find_highlight=Uthev alle
+find_match_case_label=Skil store/små bokstavar
+find_match_diacritics_label=Samsvar diakritiske teikn
+find_entire_word_label=Heile ord
+find_reached_top=Nådde toppen av dokumentet, fortset frå botnen
+find_reached_bottom=Nådde botnen av dokumentet, fortset frå toppen
+# LOCALIZATION NOTE (find_match_count): The supported plural forms are
+# [one|two|few|many|other], with [other] as the default value.
+# "{{current}}" and "{{total}}" will be replaced by a number representing the
+# index of the currently active find result, respectively a number representing
+# the total number of matches in the document.
+find_match_count={[ plural(total) ]}
+find_match_count[one]={{current}} av {{total}} treff
+find_match_count[two]={{current}} av {{total}} treff
+find_match_count[few]={{current}} av {{total}} treff
+find_match_count[many]={{current}} av {{total}} treff
+find_match_count[other]={{current}} av {{total}} treff
+# LOCALIZATION NOTE (find_match_count_limit): The supported plural forms are
+# [zero|one|two|few|many|other], with [other] as the default value.
+# "{{limit}}" will be replaced by a numerical value.
+find_match_count_limit={[ plural(limit) ]}
+find_match_count_limit[zero]=Meir enn {{limit}} treff
+find_match_count_limit[one]=Meir enn {{limit}} treff
+find_match_count_limit[two]=Meir enn {{limit}} treff
+find_match_count_limit[few]=Meir enn {{limit}} treff
+find_match_count_limit[many]=Meir enn {{limit}} treff
+find_match_count_limit[other]=Meir enn {{limit}} treff
+find_not_found=Fann ikkje teksten
+
+# Predefined zoom values
+page_scale_width=Sidebreidde
+page_scale_fit=Tilpass til sida
+page_scale_auto=Automatisk skalering
+page_scale_actual=Verkeleg storleik
+# LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
+# numerical scale value.
+page_scale_percent={{scale}}%
+
+# Loading indicator messages
+loading_error=Ein feil oppstod ved lasting av PDF.
+invalid_file_error=Ugyldig eller korrupt PDF-fil.
+missing_file_error=Manglande PDF-fil.
+unexpected_response_error=Uventa tenarrespons.
+
+rendering_error=Ein feil oppstod under vising av sida.
+
+# LOCALIZATION NOTE (annotation_date_string): "{{date}}" and "{{time}}" will be
+# replaced by the modification date, and time, of the annotation.
+annotation_date_string={{date}} {{time}}
+
+# LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
+# "{{type}}" will be replaced with an annotation type from a list defined in
+# the PDF spec (32000-1:2008 Table 169 – Annotation types).
+# Some common types are e.g.: "Check", "Text", "Comment", "Note"
+text_annotation_type.alt=[{{type}} annotasjon]
+password_label=Skriv inn passordet for å opne denne PDF-fila.
+password_invalid=Ugyldig passord. Prøv på nytt.
+password_ok=OK
+password_cancel=Avbryt
+
+printing_not_supported=Åtvaring: Utskrift er ikkje fullstendig støtta av denne nettlesaren.
+printing_not_ready=Åtvaring: PDF ikkje fullstendig innlasta for utskrift.
+web_fonts_disabled=Web-skrifter er slått av: Kan ikkje bruke innbundne PDF-skrifter.
+
+# Editor
+editor_free_text2.title=Tekst
+editor_free_text2_label=Tekst
+editor_ink2.title=Teikne
+editor_ink2_label=Teikne
+
+free_text2_default_content=Byrje å skrive…
+
+# Editor Parameters
+editor_free_text_color=Farge
+editor_free_text_size=Storleik
+editor_ink_color=Farge
+editor_ink_thickness=Tjukkleik
+editor_ink_opacity=Ugjennomskinleg
+
+# Editor aria
+editor_free_text2_aria_label=Tekstredigering
+editor_ink2_aria_label=Teikneredigering
+editor_ink_canvas_aria_label=Brukarskapt bilde

--- a/js/pdfjs/web/locale/oc/viewer.properties
+++ b/js/pdfjs/web/locale/oc/viewer.properties
@@ -1,0 +1,257 @@
+# Copyright 2012 Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Main toolbar buttons (tooltips and alt text for images)
+previous.title=Pagina precedenta
+previous_label=Precedent
+next.title=Pagina seguenta
+next_label=Seguent
+
+# LOCALIZATION NOTE (page.title): The tooltip for the pageNumber input.
+page.title=Pagina
+# LOCALIZATION NOTE (of_pages): "{{pagesCount}}" will be replaced by a number
+# representing the total number of pages in the document.
+of_pages=sus {{pagesCount}}
+# LOCALIZATION NOTE (page_of_pages): "{{pageNumber}}" and "{{pagesCount}}"
+# will be replaced by a number representing the currently visible page,
+# respectively a number representing the total number of pages in the document.
+page_of_pages=({{pageNumber}} de {{pagesCount}})
+
+zoom_out.title=Zoom arrièr
+zoom_out_label=Zoom arrièr
+zoom_in.title=Zoom avant
+zoom_in_label=Zoom avant
+zoom.title=Zoom
+presentation_mode.title=Bascular en mòde presentacion
+presentation_mode_label=Mòde Presentacion
+open_file.title=Dobrir lo fichièr
+open_file_label=Dobrir
+print.title=Imprimir
+print_label=Imprimir
+
+save.title=Enregistrar
+save_label=Enregistrar
+bookmark1.title=Pagina actuala (mostrar l’adreça de la pagina actuala)
+bookmark1_label=Pagina actuala
+
+open_in_app.title=Dobrir amb l’aplicacion
+open_in_app_label=Dobrir amb l’aplicacion
+
+# Secondary toolbar and context menu
+tools.title=Aisinas
+tools_label=Aisinas
+first_page.title=Anar a la primièra pagina
+first_page_label=Anar a la primièra pagina
+last_page.title=Anar a la darrièra pagina
+last_page_label=Anar a la darrièra pagina
+page_rotate_cw.title=Rotacion orària
+page_rotate_cw_label=Rotacion orària
+page_rotate_ccw.title=Rotacion antiorària
+page_rotate_ccw_label=Rotacion antiorària
+
+cursor_text_select_tool.title=Activar l'aisina de seleccion de tèxte
+cursor_text_select_tool_label=Aisina de seleccion de tèxte
+cursor_hand_tool.title=Activar l’aisina man
+cursor_hand_tool_label=Aisina man
+
+scroll_page.title=Activar lo defilament per pagina
+scroll_page_label=Defilament per pagina
+scroll_vertical.title=Utilizar lo defilament vertical
+scroll_vertical_label=Defilament vertical
+scroll_horizontal.title=Utilizar lo defilament orizontal
+scroll_horizontal_label=Defilament orizontal
+scroll_wrapped.title=Activar lo defilament continú
+scroll_wrapped_label=Defilament continú
+
+spread_none.title=Agropar pas las paginas doas a doas
+spread_none_label=Una sola pagina
+spread_odd.title=Mostrar doas paginas en començant per las paginas imparas a esquèrra
+spread_odd_label=Dobla pagina, impara a drecha
+spread_even.title=Mostrar doas paginas en començant per las paginas paras a esquèrra
+spread_even_label=Dobla pagina, para a drecha
+
+# Document properties dialog box
+document_properties.title=Proprietats del document…
+document_properties_label=Proprietats del document…
+document_properties_file_name=Nom del fichièr :
+document_properties_file_size=Talha del fichièr :
+# LOCALIZATION NOTE (document_properties_kb): "{{size_kb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in kilobytes, respectively in bytes.
+document_properties_kb={{size_kb}} Ko ({{size_b}} octets)
+# LOCALIZATION NOTE (document_properties_mb): "{{size_mb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in megabytes, respectively in bytes.
+document_properties_mb={{size_mb}} Mo ({{size_b}} octets)
+document_properties_title=Títol :
+document_properties_author=Autor :
+document_properties_subject=Subjècte :
+document_properties_keywords=Mots claus :
+document_properties_creation_date=Data de creacion :
+document_properties_modification_date=Data de modificacion :
+# LOCALIZATION NOTE (document_properties_date_string): "{{date}}" and "{{time}}"
+# will be replaced by the creation/modification date, and time, of the PDF file.
+document_properties_date_string={{date}}, a {{time}}
+document_properties_creator=Creator :
+document_properties_producer=Aisina de conversion PDF :
+document_properties_version=Version PDF :
+document_properties_page_count=Nombre de paginas :
+document_properties_page_size=Talha de la pagina :
+document_properties_page_size_unit_inches=in
+document_properties_page_size_unit_millimeters=mm
+document_properties_page_size_orientation_portrait=retrach
+document_properties_page_size_orientation_landscape=païsatge
+document_properties_page_size_name_a3=A3
+document_properties_page_size_name_a4=A4
+document_properties_page_size_name_letter=Letra
+document_properties_page_size_name_legal=Document juridic
+# LOCALIZATION NOTE (document_properties_page_size_dimension_string):
+# "{{width}}", "{{height}}", {{unit}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement and orientation, of the (current) page.
+document_properties_page_size_dimension_string={{width}} × {{height}} {{unit}} ({{orientation}})
+# LOCALIZATION NOTE (document_properties_page_size_dimension_name_string):
+# "{{width}}", "{{height}}", {{unit}}, {{name}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement, name, and orientation, of the (current) page.
+document_properties_page_size_dimension_name_string={{width}} × {{height}} {{unit}} ({{name}}, {{orientation}})
+# LOCALIZATION NOTE (document_properties_linearized): The linearization status of
+# the document; usually called "Fast Web View" in English locales of Adobe software.
+document_properties_linearized=Vista web rapida :
+document_properties_linearized_yes=Òc
+document_properties_linearized_no=Non
+document_properties_close=Tampar
+
+print_progress_message=Preparacion del document per l’impression…
+# LOCALIZATION NOTE (print_progress_percent): "{{progress}}" will be replaced by
+# a numerical per cent value.
+print_progress_percent={{progress}}%
+print_progress_close=Anullar
+
+# Tooltips and alt text for side panel toolbar buttons
+# (the _label strings are alt text for the buttons, the .title strings are
+# tooltips)
+toggle_sidebar.title=Afichar/amagar lo panèl lateral
+toggle_sidebar_notification2.title=Afichar/amagar lo panèl lateral (lo document conten esquèmas/pèças juntas/calques)
+toggle_sidebar_label=Afichar/amagar lo panèl lateral
+document_outline.title=Mostrar los esquèmas del document (dobleclicar per espandre/reduire totes los elements)
+document_outline_label=Marcapaginas del document
+attachments.title=Visualizar las pèças juntas
+attachments_label=Pèças juntas
+layers.title=Afichar los calques (doble-clicar per reïnicializar totes los calques a l’estat per defaut)
+layers_label=Calques
+thumbs.title=Afichar las vinhetas
+thumbs_label=Vinhetas
+current_outline_item.title=Trobar l’element de plan actual
+current_outline_item_label=Element de plan actual
+findbar.title=Cercar dins lo document
+findbar_label=Recercar
+
+additional_layers=Calques suplementaris
+# LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
+page_landmark=Pagina {{page}}
+# Thumbnails panel item (tooltip and alt text for images)
+# LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
+# number.
+thumb_page_title=Pagina {{page}}
+# LOCALIZATION NOTE (thumb_page_canvas): "{{page}}" will be replaced by the page
+# number.
+thumb_page_canvas=Vinheta de la pagina {{page}}
+
+# Find panel button title and messages
+find_input.title=Recercar
+find_input.placeholder=Cercar dins lo document…
+find_previous.title=Tròba l'ocurréncia precedenta de la frasa
+find_previous_label=Precedent
+find_next.title=Tròba l'ocurréncia venenta de la frasa
+find_next_label=Seguent
+find_highlight=Suslinhar tot
+find_match_case_label=Respectar la cassa
+find_match_diacritics_label=Respectar los diacritics
+find_entire_word_label=Mots entièrs
+find_reached_top=Naut de la pagina atenh, perseguida del bas
+find_reached_bottom=Bas de la pagina atench, perseguida al començament
+# LOCALIZATION NOTE (find_match_count): The supported plural forms are
+# [one|two|few|many|other], with [other] as the default value.
+# "{{current}}" and "{{total}}" will be replaced by a number representing the
+# index of the currently active find result, respectively a number representing
+# the total number of matches in the document.
+find_match_count={[ plural(total) ]}
+find_match_count[one]=Ocuréncia {{current}} sus {{total}}
+find_match_count[two]=Ocuréncia {{current}} sus {{total}}
+find_match_count[few]=Ocuréncia {{current}} sus {{total}}
+find_match_count[many]=Ocuréncia {{current}} sus {{total}}
+find_match_count[other]=Ocuréncia {{current}} sus {{total}}
+# LOCALIZATION NOTE (find_match_count_limit): The supported plural forms are
+# [zero|one|two|few|many|other], with [other] as the default value.
+# "{{limit}}" will be replaced by a numerical value.
+find_match_count_limit={[ plural(limit) ]}
+find_match_count_limit[zero]=Mai de {{limit}} ocuréncias
+find_match_count_limit[one]=Mai de {{limit}} ocuréncia
+find_match_count_limit[two]=Mai de {{limit}} ocuréncias
+find_match_count_limit[few]=Mai de {{limit}} ocuréncias
+find_match_count_limit[many]=Mai de {{limit}} ocuréncias
+find_match_count_limit[other]=Mai de {{limit}} ocuréncias
+find_not_found=Frasa pas trobada
+
+# Predefined zoom values
+page_scale_width=Largor plena
+page_scale_fit=Pagina entièra
+page_scale_auto=Zoom automatic
+page_scale_actual=Talha vertadièra
+# LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
+# numerical scale value.
+page_scale_percent={{scale}}%
+
+# Loading indicator messages
+loading_error=Una error s'es producha pendent lo cargament del fichièr PDF.
+invalid_file_error=Fichièr PDF invalid o corromput.
+missing_file_error=Fichièr PDF mancant.
+unexpected_response_error=Responsa de servidor imprevista.
+
+rendering_error=Una error s'es producha pendent l'afichatge de la pagina.
+
+# LOCALIZATION NOTE (annotation_date_string): "{{date}}" and "{{time}}" will be
+# replaced by the modification date, and time, of the annotation.
+annotation_date_string={{date}} a {{time}}
+
+# LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
+# "{{type}}" will be replaced with an annotation type from a list defined in
+# the PDF spec (32000-1:2008 Table 169 – Annotation types).
+# Some common types are e.g.: "Check", "Text", "Comment", "Note"
+text_annotation_type.alt=[Anotacion {{type}}]
+password_label=Picatz lo senhal per dobrir aqueste fichièr PDF.
+password_invalid=Senhal incorrècte. Tornatz ensajar.
+password_ok=D'acòrdi
+password_cancel=Anullar
+
+printing_not_supported=Atencion : l'impression es pas complètament gerida per aqueste navegador.
+printing_not_ready=Atencion : lo PDF es pas entièrament cargat per lo poder imprimir.
+web_fonts_disabled=Las polissas web son desactivadas : impossible d'utilizar las polissas integradas al PDF.
+
+# Editor
+editor_free_text2.title=Tèxte
+editor_free_text2_label=Tèxte
+editor_ink2.title=Dessenhar
+editor_ink2_label=Dessenhar
+
+free_text2_default_content=Començatz d’escriure…
+
+# Editor Parameters
+editor_free_text_color=Color
+editor_free_text_size=Talha
+editor_ink_color=Color
+editor_ink_thickness=Espessor
+editor_ink_opacity=Opacitat
+
+# Editor aria
+editor_free_text2_aria_label=Editor de tèxte
+editor_ink2_aria_label=Editor de dessenh
+editor_ink_canvas_aria_label=Imatge creat per l’utilizaire

--- a/js/pdfjs/web/locale/pa-IN/viewer.properties
+++ b/js/pdfjs/web/locale/pa-IN/viewer.properties
@@ -1,0 +1,257 @@
+# Copyright 2012 Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Main toolbar buttons (tooltips and alt text for images)
+previous.title=ਪਿਛਲਾ ਸਫ਼ਾ
+previous_label=ਪਿੱਛੇ
+next.title=ਅਗਲਾ ਸਫ਼ਾ
+next_label=ਅੱਗੇ
+
+# LOCALIZATION NOTE (page.title): The tooltip for the pageNumber input.
+page.title=ਸਫ਼ਾ
+# LOCALIZATION NOTE (of_pages): "{{pagesCount}}" will be replaced by a number
+# representing the total number of pages in the document.
+of_pages={{pagesCount}} ਵਿੱਚੋਂ
+# LOCALIZATION NOTE (page_of_pages): "{{pageNumber}}" and "{{pagesCount}}"
+# will be replaced by a number representing the currently visible page,
+# respectively a number representing the total number of pages in the document.
+page_of_pages={{pagesCount}}) ਵਿੱਚੋਂ ({{pageNumber}}
+
+zoom_out.title=ਜ਼ੂਮ ਆਉਟ
+zoom_out_label=ਜ਼ੂਮ ਆਉਟ
+zoom_in.title=ਜ਼ੂਮ ਇਨ
+zoom_in_label=ਜ਼ੂਮ ਇਨ
+zoom.title=ਜ਼ੂਨ
+presentation_mode.title=ਪਰਿਜੈਂਟੇਸ਼ਨ ਮੋਡ ਵਿੱਚ ਜਾਓ
+presentation_mode_label=ਪਰਿਜੈਂਟੇਸ਼ਨ ਮੋਡ
+open_file.title=ਫਾਈਲ ਨੂੰ ਖੋਲ੍ਹੋ
+open_file_label=ਖੋਲ੍ਹੋ
+print.title=ਪਰਿੰਟ
+print_label=ਪਰਿੰਟ
+
+save.title=ਸੰਭਾਲੋ
+save_label=ਸੰਭਾਲੋ
+bookmark1.title=ਮੌਜੂਦਾ ਸਫ਼਼ਾ (ਮੌਜੂਦਾ ਸਫ਼ੇ ਤੋਂ URL ਵੇਖੋ)
+bookmark1_label=ਮੌਜੂਦਾ ਸਫ਼਼ਾ
+
+open_in_app.title=ਐਪ ਵਿੱਚ ਖੋਲ੍ਹੋ
+open_in_app_label=ਐਪ ਵਿੱਚ ਖੋਲ੍ਹੋ
+
+# Secondary toolbar and context menu
+tools.title=ਟੂਲ
+tools_label=ਟੂਲ
+first_page.title=ਪਹਿਲੇ ਸਫ਼ੇ ਉੱਤੇ ਜਾਓ
+first_page_label=ਪਹਿਲੇ ਸਫ਼ੇ ਉੱਤੇ ਜਾਓ
+last_page.title=ਆਖਰੀ ਸਫ਼ੇ ਉੱਤੇ ਜਾਓ
+last_page_label=ਆਖਰੀ ਸਫ਼ੇ ਉੱਤੇ ਜਾਓ
+page_rotate_cw.title=ਸੱਜੇ ਦਾਅ ਘੁੰਮਾਓ
+page_rotate_cw_label=ਸੱਜੇ ਦਾਅ ਘੁੰਮਾਓ
+page_rotate_ccw.title=ਖੱਬੇ ਦਾਅ ਘੁੰਮਾਓ
+page_rotate_ccw_label=ਖੱਬੇ ਦਾਅ ਘੁੰਮਾਓ
+
+cursor_text_select_tool.title=ਲਿਖਤ ਚੋਣ ਟੂਲ ਸਮਰੱਥ ਕਰੋ
+cursor_text_select_tool_label=ਲਿਖਤ ਚੋਣ ਟੂਲ
+cursor_hand_tool.title=ਹੱਥ ਟੂਲ ਸਮਰੱਥ ਕਰੋ
+cursor_hand_tool_label=ਹੱਥ ਟੂਲ
+
+scroll_page.title=ਸਫ਼ਾ ਖਿਸਕਾਉਣ ਨੂੰ ਵਰਤੋਂ
+scroll_page_label=ਸਫ਼ਾ ਖਿਸਕਾਉਣਾ
+scroll_vertical.title=ਖੜ੍ਹਵੇਂ ਸਕਰਾਉਣ ਨੂੰ ਵਰਤੋਂ
+scroll_vertical_label=ਖੜ੍ਹਵਾਂ ਸਰਕਾਉਣਾ
+scroll_horizontal.title=ਲੇਟਵੇਂ ਸਰਕਾਉਣ ਨੂੰ ਵਰਤੋਂ
+scroll_horizontal_label=ਲੇਟਵਾਂ ਸਰਕਾਉਣਾ
+scroll_wrapped.title=ਸਮੇਟੇ ਸਰਕਾਉਣ ਨੂੰ ਵਰਤੋਂ
+scroll_wrapped_label=ਸਮੇਟਿਆ ਸਰਕਾਉਣਾ
+
+spread_none.title=ਸਫ਼ਾ ਫੈਲਾਅ ਵਿੱਚ ਸ਼ਾਮਲ ਨਾ ਹੋਵੋ
+spread_none_label=ਕੋਈ ਫੈਲਾਅ ਨਹੀਂ
+spread_odd.title=ਟਾਂਕ ਅੰਕ ਵਾਲੇ ਸਫ਼ਿਆਂ ਨਾਲ ਸ਼ੁਰੂ ਹੋਣ ਵਾਲੇ ਸਫਿਆਂ ਵਿੱਚ ਸ਼ਾਮਲ ਹੋਵੋ
+spread_odd_label=ਟਾਂਕ ਫੈਲਾਅ
+spread_even.title=ਜਿਸਤ ਅੰਕ ਵਾਲੇ ਸਫ਼ਿਆਂ ਨਾਲ ਸ਼ੁਰੂ ਹੋਣ ਵਾਲੇ ਸਫਿਆਂ ਵਿੱਚ ਸ਼ਾਮਲ ਹੋਵੋ
+spread_even_label=ਜਿਸਤ ਫੈਲਾਅ
+
+# Document properties dialog box
+document_properties.title=…ਦਸਤਾਵੇਜ਼ ਦੀ ਵਿਸ਼ੇਸ਼ਤਾ
+document_properties_label=…ਦਸਤਾਵੇਜ਼ ਦੀ ਵਿਸ਼ੇਸ਼ਤਾ
+document_properties_file_name=ਫਾਈਲ ਦਾ ਨਾਂ:
+document_properties_file_size=ਫਾਈਲ ਦਾ ਆਕਾਰ:
+# LOCALIZATION NOTE (document_properties_kb): "{{size_kb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in kilobytes, respectively in bytes.
+document_properties_kb={{size_kb}} KB ({{size_b}} ਬਾਈਟ)
+# LOCALIZATION NOTE (document_properties_mb): "{{size_mb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in megabytes, respectively in bytes.
+document_properties_mb={{size_mb}} MB ({{size_b}} ਬਾਈਟ)
+document_properties_title=ਟਾਈਟਲ:
+document_properties_author=ਲੇਖਕ:
+document_properties_subject=ਵਿਸ਼ਾ:
+document_properties_keywords=ਸ਼ਬਦ:
+document_properties_creation_date=ਬਣਾਉਣ ਦੀ ਮਿਤੀ:
+document_properties_modification_date=ਸੋਧ ਦੀ ਮਿਤੀ:
+# LOCALIZATION NOTE (document_properties_date_string): "{{date}}" and "{{time}}"
+# will be replaced by the creation/modification date, and time, of the PDF file.
+document_properties_date_string={{date}}, {{time}}
+document_properties_creator=ਨਿਰਮਾਤਾ:
+document_properties_producer=PDF ਪ੍ਰੋਡਿਊਸਰ:
+document_properties_version=PDF ਵਰਜਨ:
+document_properties_page_count=ਸਫ਼ੇ ਦੀ ਗਿਣਤੀ:
+document_properties_page_size=ਸਫ਼ਾ ਆਕਾਰ:
+document_properties_page_size_unit_inches=ਇੰਚ
+document_properties_page_size_unit_millimeters=ਮਿਮੀ
+document_properties_page_size_orientation_portrait=ਪੋਰਟਰੇਟ
+document_properties_page_size_orientation_landscape=ਲੈਂਡਸਕੇਪ
+document_properties_page_size_name_a3=A3
+document_properties_page_size_name_a4=A4
+document_properties_page_size_name_letter=ਲੈਟਰ
+document_properties_page_size_name_legal=ਕਨੂੰਨੀ
+# LOCALIZATION NOTE (document_properties_page_size_dimension_string):
+# "{{width}}", "{{height}}", {{unit}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement and orientation, of the (current) page.
+document_properties_page_size_dimension_string={{width}} × {{height}} {{unit}} ({{orientation}})
+# LOCALIZATION NOTE (document_properties_page_size_dimension_name_string):
+# "{{width}}", "{{height}}", {{unit}}, {{name}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement, name, and orientation, of the (current) page.
+document_properties_page_size_dimension_name_string={{width}} × {{height}} {{unit}} ({{name}}, {{orientation}})
+# LOCALIZATION NOTE (document_properties_linearized): The linearization status of
+# the document; usually called "Fast Web View" in English locales of Adobe software.
+document_properties_linearized=ਤੇਜ਼ ਵੈੱਬ ਝਲਕ:
+document_properties_linearized_yes=ਹਾਂ
+document_properties_linearized_no=ਨਹੀਂ
+document_properties_close=ਬੰਦ ਕਰੋ
+
+print_progress_message=…ਪਰਿੰਟ ਕਰਨ ਲਈ ਦਸਤਾਵੇਜ਼ ਨੂੰ ਤਿਆਰ ਕੀਤਾ ਜਾ ਰਿਹਾ ਹੈ
+# LOCALIZATION NOTE (print_progress_percent): "{{progress}}" will be replaced by
+# a numerical per cent value.
+print_progress_percent={{progress}}%
+print_progress_close=ਰੱਦ ਕਰੋ
+
+# Tooltips and alt text for side panel toolbar buttons
+# (the _label strings are alt text for the buttons, the .title strings are
+# tooltips)
+toggle_sidebar.title=ਬਾਹੀ ਬਦਲੋ
+toggle_sidebar_notification2.title=ਬਾਹੀ ਨੂੰ ਬਦਲੋ (ਦਸਤਾਵੇਜ਼ ਖਾਕਾ/ਅਟੈਚਮੈਂਟ/ਪਰਤਾਂ ਰੱਖਦਾ ਹੈ)
+toggle_sidebar_label=ਬਾਹੀ ਬਦਲੋ
+document_outline.title=ਦਸਤਾਵੇਜ਼ ਖਾਕਾ ਦਿਖਾਓ (ਸਾਰੀਆਂ ਆਈਟਮਾਂ ਨੂੰ ਫੈਲਾਉਣ/ਸਮੇਟਣ ਲਈ ਦੋ ਵਾਰ ਕਲਿੱਕ ਕਰੋ)
+document_outline_label=ਦਸਤਾਵੇਜ਼ ਖਾਕਾ
+attachments.title=ਅਟੈਚਮੈਂਟ ਵੇਖਾਓ
+attachments_label=ਅਟੈਚਮੈਂਟਾਂ
+layers.title=ਪਰਤਾਂ ਵੇਖਾਓ (ਸਾਰੀਆਂ ਪਰਤਾਂ ਨੂੰ ਮੂਲ ਹਾਲਤ ਉੱਤੇ ਮੁੜ-ਸੈੱਟ ਕਰਨ ਲਈ ਦੋ ਵਾਰ ਕਲਿੱਕ ਕਰੋ)
+layers_label=ਪਰਤਾਂ
+thumbs.title=ਥੰਮਨੇਲ ਨੂੰ ਵੇਖਾਓ
+thumbs_label=ਥੰਮਨੇਲ
+current_outline_item.title=ਮੌੌਜੂਦਾ ਖਾਕਾ ਚੀਜ਼ ਲੱਭੋ
+current_outline_item_label=ਮੌਜੂਦਾ ਖਾਕਾ ਚੀਜ਼
+findbar.title=ਦਸਤਾਵੇਜ਼ ਵਿੱਚ ਲੱਭੋ
+findbar_label=ਲੱਭੋ
+
+additional_layers=ਵਾਧੂ ਪਰਤਾਂ
+# LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
+page_landmark=ਸਫ਼ਾ {{page}}
+# Thumbnails panel item (tooltip and alt text for images)
+# LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
+# number.
+thumb_page_title=ਸਫ਼ਾ {{page}}
+# LOCALIZATION NOTE (thumb_page_canvas): "{{page}}" will be replaced by the page
+# number.
+thumb_page_canvas={{page}} ਸਫ਼ੇ ਦਾ ਥੰਮਨੇਲ
+
+# Find panel button title and messages
+find_input.title=ਲੱਭੋ
+find_input.placeholder=…ਦਸਤਾਵੇਜ਼ 'ਚ ਲੱਭੋ
+find_previous.title=ਵਾਕ ਦੀ ਪਿਛਲੀ ਮੌਜੂਦਗੀ ਲੱਭੋ
+find_previous_label=ਪਿੱਛੇ
+find_next.title=ਵਾਕ ਦੀ ਅਗਲੀ ਮੌਜੂਦਗੀ ਲੱਭੋ
+find_next_label=ਅੱਗੇ
+find_highlight=ਸਭ ਉਭਾਰੋ
+find_match_case_label=ਅੱਖਰ ਆਕਾਰ ਨੂੰ ਮਿਲਾਉ
+find_match_diacritics_label=ਭੇਦਸੂਚਕ ਮੇਲ
+find_entire_word_label=ਪੂਰੇ ਸ਼ਬਦ
+find_reached_top=ਦਸਤਾਵੇਜ਼ ਦੇ ਉੱਤੇ ਆ ਗਏ ਹਾਂ, ਥੱਲੇ ਤੋਂ ਜਾਰੀ ਰੱਖਿਆ ਹੈ
+find_reached_bottom=ਦਸਤਾਵੇਜ਼ ਦੇ ਅੰਤ ਉੱਤੇ ਆ ਗਏ ਹਾਂ, ਉੱਤੇ ਤੋਂ ਜਾਰੀ ਰੱਖਿਆ ਹੈ
+# LOCALIZATION NOTE (find_match_count): The supported plural forms are
+# [one|two|few|many|other], with [other] as the default value.
+# "{{current}}" and "{{total}}" will be replaced by a number representing the
+# index of the currently active find result, respectively a number representing
+# the total number of matches in the document.
+find_match_count={[ plural(total) ]}
+find_match_count[one]={{total}} ਵਿੱਚੋਂ {{current}} ਮੇਲ
+find_match_count[two]={{total}} ਵਿੱਚੋਂ {{current}} ਮੇਲ
+find_match_count[few]={{total}} ਵਿੱਚੋਂ {{current}} ਮੇਲ
+find_match_count[many]={{total}} ਵਿੱਚੋਂ {{current}} ਮੇਲ
+find_match_count[other]={{total}} ਵਿੱਚੋਂ {{current}} ਮੇਲ
+# LOCALIZATION NOTE (find_match_count_limit): The supported plural forms are
+# [zero|one|two|few|many|other], with [other] as the default value.
+# "{{limit}}" will be replaced by a numerical value.
+find_match_count_limit={[ plural(limit) ]}
+find_match_count_limit[zero]={{limit}} ਮੇਲਾਂ ਤੋਂ ਵੱਧ
+find_match_count_limit[one]={{limit}} ਮੇਲ ਤੋਂ ਵੱਧ
+find_match_count_limit[two]={{limit}} ਮੇਲਾਂ ਤੋਂ ਵੱਧ
+find_match_count_limit[few]={{limit}} ਮੇਲਾਂ ਤੋਂ ਵੱਧ
+find_match_count_limit[many]={{limit}} ਮੇਲਾਂ ਤੋਂ ਵੱਧ
+find_match_count_limit[other]={{limit}} ਮੇਲਾਂ ਤੋਂ ਵੱਧ
+find_not_found=ਵਾਕ ਨਹੀਂ ਲੱਭਿਆ
+
+# Predefined zoom values
+page_scale_width=ਸਫ਼ੇ ਦੀ ਚੌੜਾਈ
+page_scale_fit=ਸਫ਼ਾ ਫਿੱਟ
+page_scale_auto=ਆਟੋਮੈਟਿਕ ਜ਼ੂਮ ਕਰੋ
+page_scale_actual=ਆਟੋਮੈਟਿਕ ਆਕਾਰ
+# LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
+# numerical scale value.
+page_scale_percent={{scale}}%
+
+# Loading indicator messages
+loading_error=PDF ਲੋਡ ਕਰਨ ਦੇ ਦੌਰਾਨ ਗਲਤੀ ਆਈ ਹੈ।
+invalid_file_error=ਗਲਤ ਜਾਂ ਨਿਕਾਰਾ PDF ਫਾਈਲ ਹੈ।
+missing_file_error=ਨਾ-ਮੌਜੂਦ PDF ਫਾਈਲ।
+unexpected_response_error=ਅਣਜਾਣ ਸਰਵਰ ਜਵਾਬ।
+
+rendering_error=ਸਫ਼ਾ ਰੈਡਰ ਕਰਨ ਦੇ ਦੌਰਾਨ ਗਲਤੀ ਆਈ ਹੈ।
+
+# LOCALIZATION NOTE (annotation_date_string): "{{date}}" and "{{time}}" will be
+# replaced by the modification date, and time, of the annotation.
+annotation_date_string={{date}}, {{time}}
+
+# LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
+# "{{type}}" will be replaced with an annotation type from a list defined in
+# the PDF spec (32000-1:2008 Table 169 – Annotation types).
+# Some common types are e.g.: "Check", "Text", "Comment", "Note"
+text_annotation_type.alt=[{{type}} ਵਿਆਖਿਆ]
+password_label=ਇਹ PDF ਫਾਈਲ ਨੂੰ ਖੋਲ੍ਹਣ ਲਈ ਪਾਸਵਰਡ ਦਿਉ।
+password_invalid=ਗਲਤ ਪਾਸਵਰਡ। ਫੇਰ ਕੋਸ਼ਿਸ਼ ਕਰੋ ਜੀ।
+password_ok=ਠੀਕ ਹੈ
+password_cancel=ਰੱਦ ਕਰੋ
+
+printing_not_supported=ਸਾਵਧਾਨ: ਇਹ ਬਰਾਊਜ਼ਰ ਪਰਿੰਟ ਕਰਨ ਲਈ ਪੂਰੀ ਤਰ੍ਹਾਂ ਸਹਾਇਕ ਨਹੀਂ ਹੈ।
+printing_not_ready=ਸਾਵਧਾਨ: PDF ਨੂੰ ਪਰਿੰਟ ਕਰਨ ਲਈ ਪੂਰੀ ਤਰ੍ਹਾਂ ਲੋਡ ਨਹੀਂ ਹੈ।
+web_fonts_disabled=ਵੈਬ ਫੋਂਟ ਬੰਦ ਹਨ: ਇੰਬੈਡ PDF ਫੋਂਟ ਨੂੰ ਵਰਤਣ ਲਈ ਅਸਮਰੱਥ ਹੈ।
+
+# Editor
+editor_free_text2.title=ਲਿਖਤ
+editor_free_text2_label=ਲਿਖਤ
+editor_ink2.title=ਵਾਹੋ
+editor_ink2_label=ਵਾਹੋ
+
+free_text2_default_content=…ਲਿਖਣਾ ਸ਼ੁਰੂ ਕਰੋ
+
+# Editor Parameters
+editor_free_text_color=ਰੰਗ
+editor_free_text_size=ਆਕਾਰ
+editor_ink_color=ਰੰਗ
+editor_ink_thickness=ਮੋਟਾਈ
+editor_ink_opacity=ਧੁੰਦਲਾਪਨ
+
+# Editor aria
+editor_free_text2_aria_label=ਲਿਖਤ ਐਡੀਟਰ
+editor_ink2_aria_label=ਵਹਾਉਣ ਐਡੀਟਰ
+editor_ink_canvas_aria_label=ਵਰਤੋਂਕਾਰ ਵਲੋਂ ਬਣਾਇਆ ਚਿੱਤਰ

--- a/js/pdfjs/web/locale/pl/viewer.properties
+++ b/js/pdfjs/web/locale/pl/viewer.properties
@@ -1,0 +1,259 @@
+# Copyright 2012 Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Main toolbar buttons (tooltips and alt text for images)
+previous.title=Poprzednia strona
+previous_label=Poprzednia
+next.title=Następna strona
+next_label=Następna
+
+# LOCALIZATION NOTE (page.title): The tooltip for the pageNumber input.
+page.title=Strona
+# LOCALIZATION NOTE (of_pages): "{{pagesCount}}" will be replaced by a number
+# representing the total number of pages in the document.
+of_pages=z {{pagesCount}}
+# LOCALIZATION NOTE (page_of_pages): "{{pageNumber}}" and "{{pagesCount}}"
+# will be replaced by a number representing the currently visible page,
+# respectively a number representing the total number of pages in the document.
+page_of_pages=({{pageNumber}} z {{pagesCount}})
+
+zoom_out.title=Pomniejsz
+zoom_out_label=Pomniejsz
+zoom_in.title=Powiększ
+zoom_in_label=Powiększ
+zoom.title=Skala
+presentation_mode.title=Przełącz na tryb prezentacji
+presentation_mode_label=Tryb prezentacji
+open_file.title=Otwórz plik
+open_file_label=Otwórz
+print.title=Drukuj
+print_label=Drukuj
+
+save.title=Zapisz
+save_label=Zapisz
+bookmark1.title=Bieżąca strona (adres do otwarcia na bieżącej stronie)
+bookmark1_label=Bieżąca strona
+
+# LOCALIZATION NOTE (open_in_app.title): This string is used in Firefox for Android.
+open_in_app.title=Otwórz w aplikacji
+# LOCALIZATION NOTE (open_in_app_label): This string is used in Firefox for Android. Length of the translation matters since we are in a mobile context, with limited screen estate.
+open_in_app_label=Otwórz w aplikacji
+
+# Secondary toolbar and context menu
+tools.title=Narzędzia
+tools_label=Narzędzia
+first_page.title=Przejdź do pierwszej strony
+first_page_label=Przejdź do pierwszej strony
+last_page.title=Przejdź do ostatniej strony
+last_page_label=Przejdź do ostatniej strony
+page_rotate_cw.title=Obróć zgodnie z ruchem wskazówek zegara
+page_rotate_cw_label=Obróć zgodnie z ruchem wskazówek zegara
+page_rotate_ccw.title=Obróć przeciwnie do ruchu wskazówek zegara
+page_rotate_ccw_label=Obróć przeciwnie do ruchu wskazówek zegara
+
+cursor_text_select_tool.title=Włącz narzędzie zaznaczania tekstu
+cursor_text_select_tool_label=Narzędzie zaznaczania tekstu
+cursor_hand_tool.title=Włącz narzędzie rączka
+cursor_hand_tool_label=Narzędzie rączka
+
+scroll_page.title=Przewijaj strony
+scroll_page_label=Przewijanie stron
+scroll_vertical.title=Przewijaj dokument w pionie
+scroll_vertical_label=Przewijanie pionowe
+scroll_horizontal.title=Przewijaj dokument w poziomie
+scroll_horizontal_label=Przewijanie poziome
+scroll_wrapped.title=Strony dokumentu wyświetlaj i przewijaj w kolumnach
+scroll_wrapped_label=Widok dwóch stron
+
+spread_none.title=Nie ustawiaj stron obok siebie
+spread_none_label=Brak kolumn
+spread_odd.title=Strony nieparzyste ustawiaj na lewo od parzystych
+spread_odd_label=Nieparzyste po lewej
+spread_even.title=Strony parzyste ustawiaj na lewo od nieparzystych
+spread_even_label=Parzyste po lewej
+
+# Document properties dialog box
+document_properties.title=Właściwości dokumentu…
+document_properties_label=Właściwości dokumentu…
+document_properties_file_name=Nazwa pliku:
+document_properties_file_size=Rozmiar pliku:
+# LOCALIZATION NOTE (document_properties_kb): "{{size_kb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in kilobytes, respectively in bytes.
+document_properties_kb={{size_kb}} KB ({{size_b}} B)
+# LOCALIZATION NOTE (document_properties_mb): "{{size_mb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in megabytes, respectively in bytes.
+document_properties_mb={{size_mb}} MB ({{size_b}} B)
+document_properties_title=Tytuł:
+document_properties_author=Autor:
+document_properties_subject=Temat:
+document_properties_keywords=Słowa kluczowe:
+document_properties_creation_date=Data utworzenia:
+document_properties_modification_date=Data modyfikacji:
+# LOCALIZATION NOTE (document_properties_date_string): "{{date}}" and "{{time}}"
+# will be replaced by the creation/modification date, and time, of the PDF file.
+document_properties_date_string={{date}}, {{time}}
+document_properties_creator=Utworzony przez:
+document_properties_producer=PDF wyprodukowany przez:
+document_properties_version=Wersja PDF:
+document_properties_page_count=Liczba stron:
+document_properties_page_size=Wymiary strony:
+document_properties_page_size_unit_inches=in
+document_properties_page_size_unit_millimeters=mm
+document_properties_page_size_orientation_portrait=pionowa
+document_properties_page_size_orientation_landscape=pozioma
+document_properties_page_size_name_a3=A3
+document_properties_page_size_name_a4=A4
+document_properties_page_size_name_letter=US Letter
+document_properties_page_size_name_legal=US Legal
+# LOCALIZATION NOTE (document_properties_page_size_dimension_string):
+# "{{width}}", "{{height}}", {{unit}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement and orientation, of the (current) page.
+document_properties_page_size_dimension_string={{width}}×{{height}} {{unit}} (orientacja {{orientation}})
+# LOCALIZATION NOTE (document_properties_page_size_dimension_name_string):
+# "{{width}}", "{{height}}", {{unit}}, {{name}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement, name, and orientation, of the (current) page.
+document_properties_page_size_dimension_name_string={{width}}×{{height}} {{unit}} ({{name}}, orientacja {{orientation}})
+# LOCALIZATION NOTE (document_properties_linearized): The linearization status of
+# the document; usually called "Fast Web View" in English locales of Adobe software.
+document_properties_linearized=Szybki podgląd w Internecie:
+document_properties_linearized_yes=tak
+document_properties_linearized_no=nie
+document_properties_close=Zamknij
+
+print_progress_message=Przygotowywanie dokumentu do druku…
+# LOCALIZATION NOTE (print_progress_percent): "{{progress}}" will be replaced by
+# a numerical per cent value.
+print_progress_percent={{progress}}%
+print_progress_close=Anuluj
+
+# Tooltips and alt text for side panel toolbar buttons
+# (the _label strings are alt text for the buttons, the .title strings are
+# tooltips)
+toggle_sidebar.title=Przełącz panel boczny
+toggle_sidebar_notification2.title=Przełącz panel boczny (dokument zawiera konspekt/załączniki/warstwy)
+toggle_sidebar_label=Przełącz panel boczny
+document_outline.title=Konspekt dokumentu (podwójne kliknięcie rozwija lub zwija wszystkie pozycje)
+document_outline_label=Konspekt dokumentu
+attachments.title=Załączniki
+attachments_label=Załączniki
+layers.title=Warstwy (podwójne kliknięcie przywraca wszystkie warstwy do stanu domyślnego)
+layers_label=Warstwy
+thumbs.title=Miniatury
+thumbs_label=Miniatury
+current_outline_item.title=Znajdź bieżący element konspektu
+current_outline_item_label=Bieżący element konspektu
+findbar.title=Znajdź w dokumencie
+findbar_label=Znajdź
+
+additional_layers=Dodatkowe warstwy
+# LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
+page_landmark={{page}}. strona
+# Thumbnails panel item (tooltip and alt text for images)
+# LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
+# number.
+thumb_page_title={{page}}. strona
+# LOCALIZATION NOTE (thumb_page_canvas): "{{page}}" will be replaced by the page
+# number.
+thumb_page_canvas=Miniatura {{page}}. strony
+
+# Find panel button title and messages
+find_input.title=Znajdź
+find_input.placeholder=Znajdź w dokumencie…
+find_previous.title=Znajdź poprzednie wystąpienie tekstu
+find_previous_label=Poprzednie
+find_next.title=Znajdź następne wystąpienie tekstu
+find_next_label=Następne
+find_highlight=Wyróżnianie wszystkich
+find_match_case_label=Rozróżnianie wielkości liter
+find_match_diacritics_label=Rozróżnianie liter diakrytyzowanych
+find_entire_word_label=Całe słowa
+find_reached_top=Początek dokumentu. Wyszukiwanie od końca.
+find_reached_bottom=Koniec dokumentu. Wyszukiwanie od początku.
+# LOCALIZATION NOTE (find_match_count): The supported plural forms are
+# [one|two|few|many|other], with [other] as the default value.
+# "{{current}}" and "{{total}}" will be replaced by a number representing the
+# index of the currently active find result, respectively a number representing
+# the total number of matches in the document.
+find_match_count={[ plural(total) ]}
+find_match_count[one]=Pierwsze z {{total}} trafień
+find_match_count[two]=Drugie z {{total}} trafień
+find_match_count[few]={{current}}. z {{total}} trafień
+find_match_count[many]={{current}}. z {{total}} trafień
+find_match_count[other]={{current}}. z {{total}} trafień
+# LOCALIZATION NOTE (find_match_count_limit): The supported plural forms are
+# [zero|one|two|few|many|other], with [other] as the default value.
+# "{{limit}}" will be replaced by a numerical value.
+find_match_count_limit={[ plural(limit) ]}
+find_match_count_limit[zero]=Brak trafień.
+find_match_count_limit[one]=Więcej niż jedno trafienie.
+find_match_count_limit[two]=Więcej niż dwa trafienia.
+find_match_count_limit[few]=Więcej niż {{limit}} trafienia.
+find_match_count_limit[many]=Więcej niż {{limit}} trafień.
+find_match_count_limit[other]=Więcej niż {{limit}} trafień.
+find_not_found=Nie znaleziono tekstu
+
+# Predefined zoom values
+page_scale_width=Szerokość strony
+page_scale_fit=Dopasowanie strony
+page_scale_auto=Skala automatyczna
+page_scale_actual=Rozmiar oryginalny
+# LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
+# numerical scale value.
+page_scale_percent={{scale}}%
+
+# Loading indicator messages
+loading_error=Podczas wczytywania dokumentu PDF wystąpił błąd.
+invalid_file_error=Nieprawidłowy lub uszkodzony plik PDF.
+missing_file_error=Brak pliku PDF.
+unexpected_response_error=Nieoczekiwana odpowiedź serwera.
+
+rendering_error=Podczas renderowania strony wystąpił błąd.
+
+# LOCALIZATION NOTE (annotation_date_string): "{{date}}" and "{{time}}" will be
+# replaced by the modification date, and time, of the annotation.
+annotation_date_string={{date}}, {{time}}
+
+# LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
+# "{{type}}" will be replaced with an annotation type from a list defined in
+# the PDF spec (32000-1:2008 Table 169 – Annotation types).
+# Some common types are e.g.: "Check", "Text", "Comment", "Note"
+text_annotation_type.alt=[Przypis: {{type}}]
+password_label=Wprowadź hasło, aby otworzyć ten dokument PDF.
+password_invalid=Nieprawidłowe hasło. Proszę spróbować ponownie.
+password_ok=OK
+password_cancel=Anuluj
+
+printing_not_supported=Ostrzeżenie: drukowanie nie jest w pełni obsługiwane przez tę przeglądarkę.
+printing_not_ready=Ostrzeżenie: dokument PDF nie jest całkowicie wczytany, więc nie można go wydrukować.
+web_fonts_disabled=Czcionki sieciowe są wyłączone: nie można użyć osadzonych czcionek PDF.
+
+# Editor
+editor_free_text2.title=Tekst
+editor_free_text2_label=Tekst
+editor_ink2.title=Rysunek
+editor_ink2_label=Rysunek
+
+free_text2_default_content=Zacznij pisać…
+
+# Editor Parameters
+editor_free_text_color=Kolor
+editor_free_text_size=Rozmiar
+editor_ink_color=Kolor
+editor_ink_thickness=Grubość
+editor_ink_opacity=Nieprzezroczystość
+
+# Editor aria
+editor_free_text2_aria_label=Edytor tekstu
+editor_ink2_aria_label=Edytor rysunku
+editor_ink_canvas_aria_label=Obraz utworzony przez użytkownika

--- a/js/pdfjs/web/locale/pt-BR/viewer.properties
+++ b/js/pdfjs/web/locale/pt-BR/viewer.properties
@@ -1,0 +1,259 @@
+# Copyright 2012 Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Main toolbar buttons (tooltips and alt text for images)
+previous.title=Página anterior
+previous_label=Anterior
+next.title=Próxima página
+next_label=Próxima
+
+# LOCALIZATION NOTE (page.title): The tooltip for the pageNumber input.
+page.title=Página
+# LOCALIZATION NOTE (of_pages): "{{pagesCount}}" will be replaced by a number
+# representing the total number of pages in the document.
+of_pages=de {{pagesCount}}
+# LOCALIZATION NOTE (page_of_pages): "{{pageNumber}}" and "{{pagesCount}}"
+# will be replaced by a number representing the currently visible page,
+# respectively a number representing the total number of pages in the document.
+page_of_pages=({{pageNumber}} de {{pagesCount}})
+
+zoom_out.title=Reduzir
+zoom_out_label=Reduzir
+zoom_in.title=Ampliar
+zoom_in_label=Ampliar
+zoom.title=Zoom
+presentation_mode.title=Mudar para o modo de apresentação
+presentation_mode_label=Modo de apresentação
+open_file.title=Abrir arquivo
+open_file_label=Abrir
+print.title=Imprimir
+print_label=Imprimir
+save.title=Salvar
+save_label=Salvar
+bookmark1.title=Página atual (ver URL da página atual)
+bookmark1_label=Pagina atual
+# LOCALIZATION NOTE (open_in_app.title): This string is used in Firefox for Android.
+open_in_app.title=Abrir em um aplicativo
+# LOCALIZATION NOTE (open_in_app_label): This string is used in Firefox for Android. Length of the translation matters since we are in a mobile context, with limited screen estate.
+open_in_app_label=Abrir em um aplicativo
+
+# Secondary toolbar and context menu
+tools.title=Ferramentas
+tools_label=Ferramentas
+first_page.title=Ir para a primeira página
+first_page_label=Ir para a primeira página
+last_page.title=Ir para a última página
+last_page_label=Ir para a última página
+page_rotate_cw.title=Girar no sentido horário
+page_rotate_cw_label=Girar no sentido horário
+page_rotate_ccw.title=Girar no sentido anti-horário
+page_rotate_ccw_label=Girar no sentido anti-horário
+
+cursor_text_select_tool.title=Ativar a ferramenta de seleção de texto
+cursor_text_select_tool_label=Ferramenta de seleção de texto
+cursor_hand_tool.title=Ativar ferramenta de deslocamento
+cursor_hand_tool_label=Ferramenta de deslocamento
+
+scroll_page.title=Usar rolagem de página
+scroll_page_label=Rolagem de página
+scroll_vertical.title=Usar deslocamento vertical
+scroll_vertical_label=Deslocamento vertical
+scroll_horizontal.title=Usar deslocamento horizontal
+scroll_horizontal_label=Deslocamento horizontal
+scroll_wrapped.title=Usar deslocamento contido
+scroll_wrapped_label=Deslocamento contido
+
+spread_none.title=Não reagrupar páginas
+spread_none_label=Não estender
+spread_odd.title=Agrupar páginas começando em páginas com números ímpares
+spread_odd_label=Estender ímpares
+spread_even.title=Agrupar páginas começando em páginas com números pares
+spread_even_label=Estender pares
+
+# Document properties dialog box
+document_properties.title=Propriedades do documento…
+document_properties_label=Propriedades do documento…
+document_properties_file_name=Nome do arquivo:
+document_properties_file_size=Tamanho do arquivo:
+# LOCALIZATION NOTE (document_properties_kb): "{{size_kb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in kilobytes, respectively in bytes.
+document_properties_kb={{size_kb}} KB ({{size_b}} bytes)
+# LOCALIZATION NOTE (document_properties_mb): "{{size_mb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in megabytes, respectively in bytes.
+document_properties_mb={{size_mb}} MB ({{size_b}} bytes)
+document_properties_title=Título:
+document_properties_author=Autor:
+document_properties_subject=Assunto:
+document_properties_keywords=Palavras-chave:
+document_properties_creation_date=Data da criação:
+document_properties_modification_date=Data da modificação:
+# LOCALIZATION NOTE (document_properties_date_string): "{{date}}" and "{{time}}"
+# will be replaced by the creation/modification date, and time, of the PDF file.
+document_properties_date_string={{date}}, {{time}}
+document_properties_creator=Criação:
+document_properties_producer=Criador do PDF:
+document_properties_version=Versão do PDF:
+document_properties_page_count=Número de páginas:
+document_properties_page_size=Tamanho da página:
+document_properties_page_size_unit_inches=pol.
+document_properties_page_size_unit_millimeters=mm
+document_properties_page_size_orientation_portrait=retrato
+document_properties_page_size_orientation_landscape=paisagem
+document_properties_page_size_name_a3=A3
+document_properties_page_size_name_a4=A4
+document_properties_page_size_name_letter=Carta
+document_properties_page_size_name_legal=Jurídico
+# LOCALIZATION NOTE (document_properties_page_size_dimension_string):
+# "{{width}}", "{{height}}", {{unit}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement and orientation, of the (current) page.
+document_properties_page_size_dimension_string={{width}} × {{height}} {{unit}} ({{orientation}})
+# LOCALIZATION NOTE (document_properties_page_size_dimension_name_string):
+# "{{width}}", "{{height}}", {{unit}}, {{name}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement, name, and orientation, of the (current) page.
+document_properties_page_size_dimension_name_string={{width}} × {{height}} {{unit}} ({{name}}, {{orientation}})
+# LOCALIZATION NOTE (document_properties_linearized): The linearization status of
+# the document; usually called "Fast Web View" in English locales of Adobe software.
+document_properties_linearized=Exibição web rápida:
+document_properties_linearized_yes=Sim
+document_properties_linearized_no=Não
+document_properties_close=Fechar
+
+print_progress_message=Preparando documento para impressão…
+# LOCALIZATION NOTE (print_progress_percent): "{{progress}}" will be replaced by
+# a numerical per cent value.
+print_progress_percent={{progress}} %
+print_progress_close=Cancelar
+
+# Tooltips and alt text for side panel toolbar buttons
+# (the _label strings are alt text for the buttons, the .title strings are
+# tooltips)
+toggle_sidebar.title=Exibir/ocultar painel lateral
+toggle_sidebar_notification2.title=Exibir/ocultar painel (documento contém estrutura/anexos/camadas)
+toggle_sidebar_label=Exibir/ocultar painel
+document_outline.title=Mostrar estrutura do documento (duplo-clique expande/recolhe todos os itens)
+document_outline_label=Estrutura do documento
+attachments.title=Mostrar anexos
+attachments_label=Anexos
+layers.title=Mostrar camadas (duplo-clique redefine todas as camadas ao estado predefinido)
+layers_label=Camadas
+thumbs.title=Mostrar miniaturas
+thumbs_label=Miniaturas
+current_outline_item.title=Encontrar item atual da estrutura
+current_outline_item_label=Item atual da estrutura
+findbar.title=Procurar no documento
+findbar_label=Procurar
+
+additional_layers=Camadas adicionais
+# LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
+page_landmark=Página {{page}}
+# Thumbnails panel item (tooltip and alt text for images)
+# LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
+# number.
+thumb_page_title=Página {{page}}
+# LOCALIZATION NOTE (thumb_page_canvas): "{{page}}" will be replaced by the page
+# number.
+thumb_page_canvas=Miniatura da página {{page}}
+
+# Find panel button title and messages
+find_input.title=Procurar
+find_input.placeholder=Procurar no documento…
+find_previous.title=Procurar a ocorrência anterior da frase
+find_previous_label=Anterior
+find_next.title=Procurar a próxima ocorrência da frase
+find_next_label=Próxima
+find_highlight=Destacar tudo
+find_match_case_label=Diferenciar maiúsculas/minúsculas
+find_match_diacritics_label=Considerar acentuação
+find_entire_word_label=Palavras completas
+find_reached_top=Início do documento alcançado, continuando do fim
+find_reached_bottom=Fim do documento alcançado, continuando do início
+# LOCALIZATION NOTE (find_match_count): The supported plural forms are
+# [one|two|few|many|other], with [other] as the default value.
+# "{{current}}" and "{{total}}" will be replaced by a number representing the
+# index of the currently active find result, respectively a number representing
+# the total number of matches in the document.
+find_match_count={[ plural(total) ]}
+find_match_count[one]={{current}} de {{total}} ocorrência
+find_match_count[two]={{current}} de {{total}} ocorrências
+find_match_count[few]={{current}} de {{total}} ocorrências
+find_match_count[many]={{current}} de {{total}} ocorrências
+find_match_count[other]={{current}} de {{total}} ocorrências
+# LOCALIZATION NOTE (find_match_count_limit): The supported plural forms are
+# [zero|one|two|few|many|other], with [other] as the default value.
+# "{{limit}}" will be replaced by a numerical value.
+find_match_count_limit={[ plural(limit) ]}
+find_match_count_limit[zero]=Mais de {{limit}} ocorrências
+find_match_count_limit[one]=Mais de {{limit}} ocorrência
+find_match_count_limit[two]=Mais de {{limit}} ocorrências
+find_match_count_limit[few]=Mais de {{limit}} ocorrências
+find_match_count_limit[many]=Mais de {{limit}} ocorrências
+find_match_count_limit[other]=Mais de {{limit}} ocorrências
+find_not_found=Frase não encontrada
+
+# Predefined zoom values
+page_scale_width=Largura da página
+page_scale_fit=Ajustar à janela
+page_scale_auto=Zoom automático
+page_scale_actual=Tamanho real
+# LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
+# numerical scale value.
+page_scale_percent={{scale}}%
+
+# Loading indicator messages
+loading_error=Ocorreu um erro ao carregar o PDF.
+invalid_file_error=Arquivo PDF corrompido ou inválido.
+missing_file_error=Arquivo PDF ausente.
+unexpected_response_error=Resposta inesperada do servidor.
+rendering_error=Ocorreu um erro ao renderizar a página.
+
+# LOCALIZATION NOTE (annotation_date_string): "{{date}}" and "{{time}}" will be
+# replaced by the modification date, and time, of the annotation.
+annotation_date_string={{date}}, {{time}}
+
+# LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
+# "{{type}}" will be replaced with an annotation type from a list defined in
+# the PDF spec (32000-1:2008 Table 169 – Annotation types).
+# Some common types are e.g.: "Check", "Text", "Comment", "Note"
+text_annotation_type.alt=[Anotação {{type}}]
+password_label=Forneça a senha para abrir este arquivo PDF.
+password_invalid=Senha inválida. Tente novamente.
+password_ok=OK
+password_cancel=Cancelar
+
+printing_not_supported=Aviso: a impressão não é totalmente suportada neste navegador.
+printing_not_ready=Aviso: o PDF não está totalmente carregado para impressão.
+web_fonts_disabled=As fontes web estão desativadas: não foi possível usar fontes incorporadas do PDF.
+
+# Editor
+editor_free_text2.title=Texto
+editor_free_text2_label=Texto
+editor_ink2.title=Desenho
+editor_ink2_label=Desenho
+
+editor_stamp.title=Adicionar uma imagem
+editor_stamp_label=Adicionar uma imagem
+
+free_text2_default_content=Comece digitando…
+
+# Editor Parameters
+editor_free_text_color=Cor
+editor_free_text_size=Tamanho
+editor_ink_color=Cor
+editor_ink_thickness=Espessura
+editor_ink_opacity=Opacidade
+
+# Editor aria
+editor_free_text2_aria_label=Editor de texto
+editor_ink2_aria_label=Editor de desenho
+editor_ink_canvas_aria_label=Imagem criada pelo usuário

--- a/js/pdfjs/web/locale/pt-PT/viewer.properties
+++ b/js/pdfjs/web/locale/pt-PT/viewer.properties
@@ -1,0 +1,259 @@
+# Copyright 2012 Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Main toolbar buttons (tooltips and alt text for images)
+previous.title=Página anterior
+previous_label=Anterior
+next.title=Página seguinte
+next_label=Seguinte
+
+# LOCALIZATION NOTE (page.title): The tooltip for the pageNumber input.
+page.title=Página
+# LOCALIZATION NOTE (of_pages): "{{pagesCount}}" will be replaced by a number
+# representing the total number of pages in the document.
+of_pages=de {{pagesCount}}
+# LOCALIZATION NOTE (page_of_pages): "{{pageNumber}}" and "{{pagesCount}}"
+# will be replaced by a number representing the currently visible page,
+# respectively a number representing the total number of pages in the document.
+page_of_pages=({{pageNumber}} de {{pagesCount}})
+
+zoom_out.title=Reduzir
+zoom_out_label=Reduzir
+zoom_in.title=Ampliar
+zoom_in_label=Ampliar
+zoom.title=Zoom
+presentation_mode.title=Trocar para o modo de apresentação
+presentation_mode_label=Modo de apresentação
+open_file.title=Abrir ficheiro
+open_file_label=Abrir
+print.title=Imprimir
+print_label=Imprimir
+save.title=Guardar
+save_label=Guardar
+bookmark1.title=Página atual (ver URL da página atual)
+bookmark1_label=Pagina atual
+# LOCALIZATION NOTE (open_in_app.title): This string is used in Firefox for Android.
+open_in_app.title=Abrir na aplicação
+# LOCALIZATION NOTE (open_in_app_label): This string is used in Firefox for Android. Length of the translation matters since we are in a mobile context, with limited screen estate.
+open_in_app_label=Abrir na aplicação
+
+# Secondary toolbar and context menu
+tools.title=Ferramentas
+tools_label=Ferramentas
+first_page.title=Ir para a primeira página
+first_page_label=Ir para a primeira página
+last_page.title=Ir para a última página
+last_page_label=Ir para a última página
+page_rotate_cw.title=Rodar à direita
+page_rotate_cw_label=Rodar à direita
+page_rotate_ccw.title=Rodar à esquerda
+page_rotate_ccw_label=Rodar à esquerda
+
+cursor_text_select_tool.title=Ativar ferramenta de seleção de texto
+cursor_text_select_tool_label=Ferramenta de seleção de texto
+cursor_hand_tool.title=Ativar ferramenta de mão
+cursor_hand_tool_label=Ferramenta de mão
+
+scroll_page.title=Utilizar deslocamento da página
+scroll_page_label=Deslocamento da página
+scroll_vertical.title=Utilizar deslocação vertical
+scroll_vertical_label=Deslocação vertical
+scroll_horizontal.title=Utilizar deslocação horizontal
+scroll_horizontal_label=Deslocação horizontal
+scroll_wrapped.title=Utilizar deslocação encapsulada
+scroll_wrapped_label=Deslocação encapsulada
+
+spread_none.title=Não juntar páginas dispersas
+spread_none_label=Sem spreads
+spread_odd.title=Juntar páginas dispersas a partir de páginas com números ímpares
+spread_odd_label=Spreads ímpares
+spread_even.title=Juntar páginas dispersas a partir de páginas com números pares
+spread_even_label=Spreads pares
+
+# Document properties dialog box
+document_properties.title=Propriedades do documento…
+document_properties_label=Propriedades do documento…
+document_properties_file_name=Nome do ficheiro:
+document_properties_file_size=Tamanho do ficheiro:
+# LOCALIZATION NOTE (document_properties_kb): "{{size_kb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in kilobytes, respectively in bytes.
+document_properties_kb={{size_kb}} KB ({{size_b}} bytes)
+# LOCALIZATION NOTE (document_properties_mb): "{{size_mb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in megabytes, respectively in bytes.
+document_properties_mb={{size_mb}} MB ({{size_b}} bytes)
+document_properties_title=Título:
+document_properties_author=Autor:
+document_properties_subject=Assunto:
+document_properties_keywords=Palavras-chave:
+document_properties_creation_date=Data de criação:
+document_properties_modification_date=Data de modificação:
+# LOCALIZATION NOTE (document_properties_date_string): "{{date}}" and "{{time}}"
+# will be replaced by the creation/modification date, and time, of the PDF file.
+document_properties_date_string={{date}}, {{time}}
+document_properties_creator=Criador:
+document_properties_producer=Produtor de PDF:
+document_properties_version=Versão do PDF:
+document_properties_page_count=N.º de páginas:
+document_properties_page_size=Tamanho da página:
+document_properties_page_size_unit_inches=in
+document_properties_page_size_unit_millimeters=mm
+document_properties_page_size_orientation_portrait=retrato
+document_properties_page_size_orientation_landscape=paisagem
+document_properties_page_size_name_a3=A3
+document_properties_page_size_name_a4=A4
+document_properties_page_size_name_letter=Carta
+document_properties_page_size_name_legal=Legal
+# LOCALIZATION NOTE (document_properties_page_size_dimension_string):
+# "{{width}}", "{{height}}", {{unit}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement and orientation, of the (current) page.
+document_properties_page_size_dimension_string={{width}} × {{height}} {{unit}} ({{orientation}})
+# LOCALIZATION NOTE (document_properties_page_size_dimension_name_string):
+# "{{width}}", "{{height}}", {{unit}}, {{name}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement, name, and orientation, of the (current) page.
+document_properties_page_size_dimension_name_string={{width}} × {{height}} {{unit}} ({{name}}, {{orientation}})
+# LOCALIZATION NOTE (document_properties_linearized): The linearization status of
+# the document; usually called "Fast Web View" in English locales of Adobe software.
+document_properties_linearized=Vista rápida web:
+document_properties_linearized_yes=Sim
+document_properties_linearized_no=Não
+document_properties_close=Fechar
+
+print_progress_message=A preparar o documento para impressão…
+# LOCALIZATION NOTE (print_progress_percent): "{{progress}}" will be replaced by
+# a numerical per cent value.
+print_progress_percent={{progress}}%
+print_progress_close=Cancelar
+
+# Tooltips and alt text for side panel toolbar buttons
+# (the _label strings are alt text for the buttons, the .title strings are
+# tooltips)
+toggle_sidebar.title=Alternar barra lateral
+toggle_sidebar_notification2.title=Alternar barra lateral (o documento contém contornos/anexos/camadas)
+toggle_sidebar_label=Alternar barra lateral
+document_outline.title=Mostrar esquema do documento (duplo clique para expandir/colapsar todos os itens)
+document_outline_label=Esquema do documento
+attachments.title=Mostrar anexos
+attachments_label=Anexos
+layers.title=Mostrar camadas (clique duas vezes para repor todas as camadas para o estado predefinido)
+layers_label=Camadas
+thumbs.title=Mostrar miniaturas
+thumbs_label=Miniaturas
+current_outline_item.title=Encontrar o item atualmente destacado
+current_outline_item_label=Item atualmente destacado
+findbar.title=Localizar em documento
+findbar_label=Localizar
+
+additional_layers=Camadas adicionais
+# LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
+page_landmark=Página {{page}}
+# Thumbnails panel item (tooltip and alt text for images)
+# LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
+# number.
+thumb_page_title=Página {{page}}
+# LOCALIZATION NOTE (thumb_page_canvas): "{{page}}" will be replaced by the page
+# number.
+thumb_page_canvas=Miniatura da página {{page}}
+
+# Find panel button title and messages
+find_input.title=Localizar
+find_input.placeholder=Localizar em documento…
+find_previous.title=Localizar ocorrência anterior da frase
+find_previous_label=Anterior
+find_next.title=Localizar ocorrência seguinte da frase
+find_next_label=Seguinte
+find_highlight=Destacar tudo
+find_match_case_label=Correspondência
+find_match_diacritics_label=Corresponder diacríticos
+find_entire_word_label=Palavras completas
+find_reached_top=Topo do documento atingido, a continuar a partir do fundo
+find_reached_bottom=Fim do documento atingido, a continuar a partir do topo
+# LOCALIZATION NOTE (find_match_count): The supported plural forms are
+# [one|two|few|many|other], with [other] as the default value.
+# "{{current}}" and "{{total}}" will be replaced by a number representing the
+# index of the currently active find result, respectively a number representing
+# the total number of matches in the document.
+find_match_count={[ plural(total) ]}
+find_match_count[one]={{current}} de {{total}} correspondência
+find_match_count[two]={{current}} de {{total}} correspondências
+find_match_count[few]={{current}} de {{total}} correspondências
+find_match_count[many]={{current}} de {{total}} correspondências
+find_match_count[other]={{current}} de {{total}} correspondências
+# LOCALIZATION NOTE (find_match_count_limit): The supported plural forms are
+# [zero|one|two|few|many|other], with [other] as the default value.
+# "{{limit}}" will be replaced by a numerical value.
+find_match_count_limit={[ plural(limit) ]}
+find_match_count_limit[zero]=Mais de {{limit}} correspondências
+find_match_count_limit[one]=Mais de {{limit}} correspondência
+find_match_count_limit[two]=Mais de {{limit}} correspondências
+find_match_count_limit[few]=Mais de {{limit}} correspondências
+find_match_count_limit[many]=Mais de {{limit}} correspondências
+find_match_count_limit[other]=Mais de {{limit}} correspondências
+find_not_found=Frase não encontrada
+
+# Predefined zoom values
+page_scale_width=Ajustar à largura
+page_scale_fit=Ajustar à página
+page_scale_auto=Zoom automático
+page_scale_actual=Tamanho real
+# LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
+# numerical scale value.
+page_scale_percent={{scale}}%
+
+# Loading indicator messages
+loading_error=Ocorreu um erro ao carregar o PDF.
+invalid_file_error=Ficheiro PDF inválido ou danificado.
+missing_file_error=Ficheiro PDF inexistente.
+unexpected_response_error=Resposta inesperada do servidor.
+rendering_error=Ocorreu um erro ao processar a página.
+
+# LOCALIZATION NOTE (annotation_date_string): "{{date}}" and "{{time}}" will be
+# replaced by the modification date, and time, of the annotation.
+annotation_date_string={{date}}, {{time}}
+
+# LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
+# "{{type}}" will be replaced with an annotation type from a list defined in
+# the PDF spec (32000-1:2008 Table 169 – Annotation types).
+# Some common types are e.g.: "Check", "Text", "Comment", "Note"
+text_annotation_type.alt=[Anotação {{type}}]
+password_label=Introduza a palavra-passe para abrir este ficheiro PDF.
+password_invalid=Palavra-passe inválida. Por favor, tente novamente.
+password_ok=OK
+password_cancel=Cancelar
+
+printing_not_supported=Aviso: a impressão não é totalmente suportada por este navegador.
+printing_not_ready=Aviso: o PDF ainda não está totalmente carregado.
+web_fonts_disabled=Os tipos de letra web estão desativados: não é possível utilizar os tipos de letra PDF embutidos.
+
+# Editor
+editor_free_text2.title=Texto
+editor_free_text2_label=Texto
+editor_ink2.title=Desenhar
+editor_ink2_label=Desenhar
+
+editor_stamp.title=Adicionar uma imagem
+editor_stamp_label=Adicionar uma imagem
+
+free_text2_default_content=Começar a digitar…
+
+# Editor Parameters
+editor_free_text_color=Cor
+editor_free_text_size=Tamanho
+editor_ink_color=Cor
+editor_ink_thickness=Espessura
+editor_ink_opacity=Opacidade
+
+# Editor aria
+editor_free_text2_aria_label=Editor de texto
+editor_ink2_aria_label=Editor de desenho
+editor_ink_canvas_aria_label=Imagem criada pelo utilizador

--- a/js/pdfjs/web/locale/rm/viewer.properties
+++ b/js/pdfjs/web/locale/rm/viewer.properties
@@ -1,0 +1,257 @@
+# Copyright 2012 Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Main toolbar buttons (tooltips and alt text for images)
+previous.title=Pagina precedenta
+previous_label=Enavos
+next.title=Proxima pagina
+next_label=Enavant
+
+# LOCALIZATION NOTE (page.title): The tooltip for the pageNumber input.
+page.title=Pagina
+# LOCALIZATION NOTE (of_pages): "{{pagesCount}}" will be replaced by a number
+# representing the total number of pages in the document.
+of_pages=da {{pagesCount}}
+# LOCALIZATION NOTE (page_of_pages): "{{pageNumber}}" and "{{pagesCount}}"
+# will be replaced by a number representing the currently visible page,
+# respectively a number representing the total number of pages in the document.
+page_of_pages=({{pageNumber}} da {{pagesCount}})
+
+zoom_out.title=Empitschnir
+zoom_out_label=Empitschnir
+zoom_in.title=Engrondir
+zoom_in_label=Engrondir
+zoom.title=Zoom
+presentation_mode.title=Midar en il modus da preschentaziun
+presentation_mode_label=Modus da preschentaziun
+open_file.title=Avrir datoteca
+open_file_label=Avrir
+print.title=Stampar
+print_label=Stampar
+
+save.title=Memorisar
+save_label=Memorisar
+bookmark1.title=Pagina actuala (mussar l'URL da la pagina actuala)
+bookmark1_label=Pagina actuala
+
+open_in_app.title=Avrir en ina app
+open_in_app_label=Avrir en ina app
+
+# Secondary toolbar and context menu
+tools.title=Utensils
+tools_label=Utensils
+first_page.title=Siglir a l'emprima pagina
+first_page_label=Siglir a l'emprima pagina
+last_page.title=Siglir a la davosa pagina
+last_page_label=Siglir a la davosa pagina
+page_rotate_cw.title=Rotar en direcziun da l'ura
+page_rotate_cw_label=Rotar en direcziun da l'ura
+page_rotate_ccw.title=Rotar en direcziun cuntraria a l'ura
+page_rotate_ccw_label=Rotar en direcziun cuntraria a l'ura
+
+cursor_text_select_tool.title=Activar l'utensil per selecziunar text
+cursor_text_select_tool_label=Utensil per selecziunar text
+cursor_hand_tool.title=Activar l'utensil da maun
+cursor_hand_tool_label=Utensil da maun
+
+scroll_page.title=Utilisar la defilada per pagina
+scroll_page_label=Defilada per pagina
+scroll_vertical.title=Utilisar il defilar vertical
+scroll_vertical_label=Defilar vertical
+scroll_horizontal.title=Utilisar il defilar orizontal
+scroll_horizontal_label=Defilar orizontal
+scroll_wrapped.title=Utilisar il defilar en colonnas
+scroll_wrapped_label=Defilar en colonnas
+
+spread_none.title=Betg parallelisar las paginas
+spread_none_label=Betg parallel
+spread_odd.title=Parallelisar las paginas cun cumenzar cun paginas spèras
+spread_odd_label=Parallel spèr
+spread_even.title=Parallelisar las paginas cun cumenzar cun paginas pèras
+spread_even_label=Parallel pèr
+
+# Document properties dialog box
+document_properties.title=Caracteristicas dal document…
+document_properties_label=Caracteristicas dal document…
+document_properties_file_name=Num da la datoteca:
+document_properties_file_size=Grondezza da la datoteca:
+# LOCALIZATION NOTE (document_properties_kb): "{{size_kb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in kilobytes, respectively in bytes.
+document_properties_kb={{size_kb}} KB ({{size_b}} bytes)
+# LOCALIZATION NOTE (document_properties_mb): "{{size_mb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in megabytes, respectively in bytes.
+document_properties_mb={{size_mb}} MB ({{size_b}} bytes)
+document_properties_title=Titel:
+document_properties_author=Autur:
+document_properties_subject=Tema:
+document_properties_keywords=Chavazzins:
+document_properties_creation_date=Data da creaziun:
+document_properties_modification_date=Data da modificaziun:
+# LOCALIZATION NOTE (document_properties_date_string): "{{date}}" and "{{time}}"
+# will be replaced by the creation/modification date, and time, of the PDF file.
+document_properties_date_string={{date}} {{time}}
+document_properties_creator=Creà da:
+document_properties_producer=Creà il PDF cun:
+document_properties_version=Versiun da PDF:
+document_properties_page_count=Dumber da paginas:
+document_properties_page_size=Grondezza da la pagina:
+document_properties_page_size_unit_inches=in
+document_properties_page_size_unit_millimeters=mm
+document_properties_page_size_orientation_portrait=vertical
+document_properties_page_size_orientation_landscape=orizontal
+document_properties_page_size_name_a3=A3
+document_properties_page_size_name_a4=A4
+document_properties_page_size_name_letter=Letter
+document_properties_page_size_name_legal=Legal
+# LOCALIZATION NOTE (document_properties_page_size_dimension_string):
+# "{{width}}", "{{height}}", {{unit}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement and orientation, of the (current) page.
+document_properties_page_size_dimension_string={{width}} × {{height}} {{unit}} ({{orientation}})
+# LOCALIZATION NOTE (document_properties_page_size_dimension_name_string):
+# "{{width}}", "{{height}}", {{unit}}, {{name}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement, name, and orientation, of the (current) page.
+document_properties_page_size_dimension_name_string={{width}} × {{height}} {{unit}} ({{name}}, {{orientation}})
+# LOCALIZATION NOTE (document_properties_linearized): The linearization status of
+# the document; usually called "Fast Web View" in English locales of Adobe software.
+document_properties_linearized=Fast Web View:
+document_properties_linearized_yes=Gea
+document_properties_linearized_no=Na
+document_properties_close=Serrar
+
+print_progress_message=Preparar il document per stampar…
+# LOCALIZATION NOTE (print_progress_percent): "{{progress}}" will be replaced by
+# a numerical per cent value.
+print_progress_percent={{progress}}%
+print_progress_close=Interrumper
+
+# Tooltips and alt text for side panel toolbar buttons
+# (the _label strings are alt text for the buttons, the .title strings are
+# tooltips)
+toggle_sidebar.title=Activar/deactivar la trav laterala
+toggle_sidebar_notification2.title=Activar/deactivar la trav laterala (il document cuntegna structura dal document/agiuntas/nivels)
+toggle_sidebar_label=Activar/deactivar la trav laterala
+document_outline.title=Mussar la structura dal document (cliccar duas giadas per extender/cumprimer tut ils elements)
+document_outline_label=Structura dal document
+attachments.title=Mussar agiuntas
+attachments_label=Agiuntas
+layers.title=Mussar ils nivels (cliccar dubel per restaurar il stadi da standard da tut ils nivels)
+layers_label=Nivels
+thumbs.title=Mussar las miniaturas
+thumbs_label=Miniaturas
+current_outline_item.title=Tschertgar l'element da structura actual
+current_outline_item_label=Element da structura actual
+findbar.title=Tschertgar en il document
+findbar_label=Tschertgar
+
+additional_layers=Nivels supplementars
+# LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
+page_landmark=Pagina {{page}}
+# Thumbnails panel item (tooltip and alt text for images)
+# LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
+# number.
+thumb_page_title=Pagina {{page}}
+# LOCALIZATION NOTE (thumb_page_canvas): "{{page}}" will be replaced by the page
+# number.
+thumb_page_canvas=Miniatura da la pagina {{page}}
+
+# Find panel button title and messages
+find_input.title=Tschertgar
+find_input.placeholder=Tschertgar en il document…
+find_previous.title=Tschertgar la posiziun precedenta da l'expressiun
+find_previous_label=Enavos
+find_next.title=Tschertgar la proxima posiziun da l'expressiun
+find_next_label=Enavant
+find_highlight=Relevar tuts
+find_match_case_label=Resguardar maiusclas/minusclas
+find_match_diacritics_label=Resguardar ils segns diacritics
+find_entire_word_label=Pleds entirs
+find_reached_top=Il cumenzament dal document è cuntanschì, la tschertga cuntinuescha a la fin dal document
+find_reached_bottom=La fin dal document è cuntanschì, la tschertga cuntinuescha al cumenzament dal document
+# LOCALIZATION NOTE (find_match_count): The supported plural forms are
+# [one|two|few|many|other], with [other] as the default value.
+# "{{current}}" and "{{total}}" will be replaced by a number representing the
+# index of the currently active find result, respectively a number representing
+# the total number of matches in the document.
+find_match_count={[ plural(total) ]}
+find_match_count[one]={{current}} dad {{total}} correspundenza
+find_match_count[two]={{current}} da {{total}} correspundenzas
+find_match_count[few]={{current}} da {{total}} correspundenzas
+find_match_count[many]={{current}} da {{total}} correspundenzas
+find_match_count[other]={{current}} da {{total}} correspundenzas
+# LOCALIZATION NOTE (find_match_count_limit): The supported plural forms are
+# [zero|one|two|few|many|other], with [other] as the default value.
+# "{{limit}}" will be replaced by a numerical value.
+find_match_count_limit={[ plural(limit) ]}
+find_match_count_limit[zero]=Dapli che {{limit}} correspundenzas
+find_match_count_limit[one]=Dapli che {{limit}} correspundenza
+find_match_count_limit[two]=Dapli che {{limit}} correspundenzas
+find_match_count_limit[few]=Dapli che {{limit}} correspundenzas
+find_match_count_limit[many]=Dapli che {{limit}} correspundenzas
+find_match_count_limit[other]=Dapli che {{limit}} correspundenzas
+find_not_found=Impussibel da chattar l'expressiun
+
+# Predefined zoom values
+page_scale_width=Ladezza da la pagina
+page_scale_fit=Entira pagina
+page_scale_auto=Zoom automatic
+page_scale_actual=Grondezza actuala
+# LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
+# numerical scale value.
+page_scale_percent={{scale}}%
+
+# Loading indicator messages
+loading_error=Ina errur è cumparida cun chargiar il PDF.
+invalid_file_error=Datoteca PDF nunvalida u donnegiada.
+missing_file_error=Datoteca PDF manconta.
+unexpected_response_error=Resposta nunspetgada dal server.
+
+rendering_error=Ina errur è cumparida cun visualisar questa pagina.
+
+# LOCALIZATION NOTE (annotation_date_string): "{{date}}" and "{{time}}" will be
+# replaced by the modification date, and time, of the annotation.
+annotation_date_string={{date}}, {{time}}
+
+# LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
+# "{{type}}" will be replaced with an annotation type from a list defined in
+# the PDF spec (32000-1:2008 Table 169 – Annotation types).
+# Some common types are e.g.: "Check", "Text", "Comment", "Note"
+text_annotation_type.alt=[Annotaziun da {{type}}]
+password_label=Endatescha il pled-clav per avrir questa datoteca da PDF.
+password_invalid=Pled-clav nunvalid. Emprova anc ina giada.
+password_ok=OK
+password_cancel=Interrumper
+
+printing_not_supported=Attenziun: Il stampar na funcziunescha anc betg dal tut en quest navigatur.
+printing_not_ready=Attenziun: Il PDF n'è betg chargià cumplettamain per stampar.
+web_fonts_disabled=Scrittiras dal web èn deactivadas: impussibel dad utilisar las scrittiras integradas en il PDF.
+
+# Editor
+editor_free_text2.title=Text
+editor_free_text2_label=Text
+editor_ink2.title=Dissegnar
+editor_ink2_label=Dissegnar
+
+free_text2_default_content=Cumenzar a tippar…
+
+# Editor Parameters
+editor_free_text_color=Colur
+editor_free_text_size=Grondezza
+editor_ink_color=Colur
+editor_ink_thickness=Grossezza
+editor_ink_opacity=Opacitad
+
+# Editor aria
+editor_free_text2_aria_label=Editur da text
+editor_ink2_aria_label=Editur dissegn
+editor_ink_canvas_aria_label=Maletg creà da l'utilisader

--- a/js/pdfjs/web/locale/ro/viewer.properties
+++ b/js/pdfjs/web/locale/ro/viewer.properties
@@ -1,0 +1,220 @@
+# Copyright 2012 Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Main toolbar buttons (tooltips and alt text for images)
+previous.title=Pagina precedentă
+previous_label=Înapoi
+next.title=Pagina următoare
+next_label=Înainte
+
+# LOCALIZATION NOTE (page.title): The tooltip for the pageNumber input.
+page.title=Pagina
+# LOCALIZATION NOTE (of_pages): "{{pagesCount}}" will be replaced by a number
+# representing the total number of pages in the document.
+of_pages=din {{pagesCount}}
+# LOCALIZATION NOTE (page_of_pages): "{{pageNumber}}" and "{{pagesCount}}"
+# will be replaced by a number representing the currently visible page,
+# respectively a number representing the total number of pages in the document.
+page_of_pages=({{pageNumber}} din {{pagesCount}})
+
+zoom_out.title=Micșorează
+zoom_out_label=Micșorează
+zoom_in.title=Mărește
+zoom_in_label=Mărește
+zoom.title=Zoom
+presentation_mode.title=Comută la modul de prezentare
+presentation_mode_label=Mod de prezentare
+open_file.title=Deschide un fișier
+open_file_label=Deschide
+print.title=Tipărește
+print_label=Tipărește
+
+# Secondary toolbar and context menu
+tools.title=Instrumente
+tools_label=Instrumente
+first_page.title=Mergi la prima pagină
+first_page_label=Mergi la prima pagină
+last_page.title=Mergi la ultima pagină
+last_page_label=Mergi la ultima pagină
+page_rotate_cw.title=Rotește în sensul acelor de ceas
+page_rotate_cw_label=Rotește în sensul acelor de ceas
+page_rotate_ccw.title=Rotește în sens invers al acelor de ceas
+page_rotate_ccw_label=Rotește în sens invers al acelor de ceas
+
+cursor_text_select_tool.title=Activează instrumentul de selecție a textului
+cursor_text_select_tool_label=Instrumentul de selecție a textului
+cursor_hand_tool.title=Activează instrumentul mână
+cursor_hand_tool_label=Unealta mână
+
+scroll_vertical.title=Folosește derularea verticală
+scroll_vertical_label=Derulare verticală
+scroll_horizontal.title=Folosește derularea orizontală
+scroll_horizontal_label=Derulare orizontală
+scroll_wrapped.title=Folosește derularea încadrată
+scroll_wrapped_label=Derulare încadrată
+
+spread_none.title=Nu uni paginile broșate
+spread_none_label=Fără pagini broșate
+spread_odd.title=Unește paginile broșate începând cu cele impare
+spread_odd_label=Broșare pagini impare
+spread_even.title=Unește paginile broșate începând cu cele pare
+spread_even_label=Broșare pagini pare
+
+# Document properties dialog box
+document_properties.title=Proprietățile documentului…
+document_properties_label=Proprietățile documentului…
+document_properties_file_name=Numele fișierului:
+document_properties_file_size=Mărimea fișierului:
+# LOCALIZATION NOTE (document_properties_kb): "{{size_kb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in kilobytes, respectively in bytes.
+document_properties_kb={{size_kb}} KB ({{size_b}} byți)
+# LOCALIZATION NOTE (document_properties_mb): "{{size_mb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in megabytes, respectively in bytes.
+document_properties_mb={{size_mb}} MB ({{size_b}} byți)
+document_properties_title=Titlu:
+document_properties_author=Autor:
+document_properties_subject=Subiect:
+document_properties_keywords=Cuvinte cheie:
+document_properties_creation_date=Data creării:
+document_properties_modification_date=Data modificării:
+# LOCALIZATION NOTE (document_properties_date_string): "{{date}}" and "{{time}}"
+# will be replaced by the creation/modification date, and time, of the PDF file.
+document_properties_date_string={{date}}, {{time}}
+document_properties_creator=Autor:
+document_properties_producer=Producător PDF:
+document_properties_version=Versiune PDF:
+document_properties_page_count=Număr de pagini:
+document_properties_page_size=Mărimea paginii:
+document_properties_page_size_unit_inches=in
+document_properties_page_size_unit_millimeters=mm
+document_properties_page_size_orientation_portrait=verticală
+document_properties_page_size_orientation_landscape=orizontală
+document_properties_page_size_name_a3=A3
+document_properties_page_size_name_a4=A4
+document_properties_page_size_name_letter=Literă
+document_properties_page_size_name_legal=Legal
+# LOCALIZATION NOTE (document_properties_page_size_dimension_string):
+# "{{width}}", "{{height}}", {{unit}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement and orientation, of the (current) page.
+document_properties_page_size_dimension_string={{width}} × {{height}} {{unit}} ({{orientation}})
+# LOCALIZATION NOTE (document_properties_page_size_dimension_name_string):
+# "{{width}}", "{{height}}", {{unit}}, {{name}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement, name, and orientation, of the (current) page.
+document_properties_page_size_dimension_name_string={{width}} × {{height}} {{unit}} ({{name}}, {{orientation}})
+# LOCALIZATION NOTE (document_properties_linearized): The linearization status of
+# the document; usually called "Fast Web View" in English locales of Adobe software.
+document_properties_linearized=Vizualizare web rapidă:
+document_properties_linearized_yes=Da
+document_properties_linearized_no=Nu
+document_properties_close=Închide
+
+print_progress_message=Se pregătește documentul pentru tipărire…
+# LOCALIZATION NOTE (print_progress_percent): "{{progress}}" will be replaced by
+# a numerical per cent value.
+print_progress_percent={{progress}}%
+print_progress_close=Renunță
+
+# Tooltips and alt text for side panel toolbar buttons
+# (the _label strings are alt text for the buttons, the .title strings are
+# tooltips)
+toggle_sidebar.title=Comută bara laterală
+toggle_sidebar_label=Comută bara laterală
+document_outline.title=Afișează schița documentului (dublu-clic pentru a extinde/restrânge toate elementele)
+document_outline_label=Schița documentului
+attachments.title=Afișează atașamentele
+attachments_label=Atașamente
+thumbs.title=Afișează miniaturi
+thumbs_label=Miniaturi
+findbar.title=Caută în document
+findbar_label=Caută
+
+# LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
+# Thumbnails panel item (tooltip and alt text for images)
+# LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
+# number.
+thumb_page_title=Pagina {{page}}
+# LOCALIZATION NOTE (thumb_page_canvas): "{{page}}" will be replaced by the page
+# number.
+thumb_page_canvas=Miniatura paginii {{page}}
+
+# Find panel button title and messages
+find_input.title=Caută
+find_input.placeholder=Caută în document…
+find_previous.title=Mergi la apariția anterioară a textului
+find_previous_label=Înapoi
+find_next.title=Mergi la apariția următoare a textului
+find_next_label=Înainte
+find_highlight=Evidențiază toate aparițiile
+find_match_case_label=Ține cont de majuscule și minuscule
+find_entire_word_label=Cuvinte întregi
+find_reached_top=Am ajuns la începutul documentului, continuă de la sfârșit
+find_reached_bottom=Am ajuns la sfârșitul documentului, continuă de la început
+# LOCALIZATION NOTE (find_match_count): The supported plural forms are
+# [one|two|few|many|other], with [other] as the default value.
+# "{{current}}" and "{{total}}" will be replaced by a number representing the
+# index of the currently active find result, respectively a number representing
+# the total number of matches in the document.
+find_match_count={[ plural(total) ]}
+find_match_count[one]={{current}} din {{total}} rezultat
+find_match_count[two]={{current}} din {{total}} rezultate
+find_match_count[few]={{current}} din {{total}} rezultate
+find_match_count[many]={{current}} din {{total}} de rezultate
+find_match_count[other]={{current}} din {{total}} de rezultate
+# LOCALIZATION NOTE (find_match_count_limit): The supported plural forms are
+# [zero|one|two|few|many|other], with [other] as the default value.
+# "{{limit}}" will be replaced by a numerical value.
+find_match_count_limit={[ plural(limit) ]}
+find_match_count_limit[zero]=Peste {{limit}} rezultate
+find_match_count_limit[one]=Peste {{limit}} rezultat
+find_match_count_limit[two]=Peste {{limit}} rezultate
+find_match_count_limit[few]=Peste {{limit}} rezultate
+find_match_count_limit[many]=Peste {{limit}} de rezultate
+find_match_count_limit[other]=Peste {{limit}} de rezultate
+find_not_found=Nu s-a găsit textul
+
+# Predefined zoom values
+page_scale_width=Lățime pagină
+page_scale_fit=Potrivire la pagină
+page_scale_auto=Zoom automat
+page_scale_actual=Mărime reală
+# LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
+# numerical scale value.
+page_scale_percent={{scale}}%
+
+# Loading indicator messages
+loading_error=A intervenit o eroare la încărcarea PDF-ului.
+invalid_file_error=Fișier PDF nevalid sau corupt.
+missing_file_error=Fișier PDF lipsă.
+unexpected_response_error=Răspuns neașteptat de la server.
+
+rendering_error=A intervenit o eroare la randarea paginii.
+
+# LOCALIZATION NOTE (annotation_date_string): "{{date}}" and "{{time}}" will be
+# replaced by the modification date, and time, of the annotation.
+annotation_date_string={{date}}, {{time}}
+
+# LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
+# "{{type}}" will be replaced with an annotation type from a list defined in
+# the PDF spec (32000-1:2008 Table 169 – Annotation types).
+# Some common types are e.g.: "Check", "Text", "Comment", "Note"
+text_annotation_type.alt=[Adnotare {{type}}]
+password_label=Introdu parola pentru a deschide acest fișier PDF.
+password_invalid=Parolă nevalidă. Te rugăm să încerci din nou.
+password_ok=OK
+password_cancel=Renunță
+
+printing_not_supported=Avertisment: Tipărirea nu este suportată în totalitate de acest browser.
+printing_not_ready=Avertisment: PDF-ul nu este încărcat complet pentru tipărire.
+web_fonts_disabled=Fonturile web sunt dezactivate: nu se pot folosi fonturile PDF încorporate.
+

--- a/js/pdfjs/web/locale/ru/viewer.properties
+++ b/js/pdfjs/web/locale/ru/viewer.properties
@@ -1,0 +1,259 @@
+# Copyright 2012 Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Main toolbar buttons (tooltips and alt text for images)
+previous.title=Предыдущая страница
+previous_label=Предыдущая
+next.title=Следующая страница
+next_label=Следующая
+
+# LOCALIZATION NOTE (page.title): The tooltip for the pageNumber input.
+page.title=Страница
+# LOCALIZATION NOTE (of_pages): "{{pagesCount}}" will be replaced by a number
+# representing the total number of pages in the document.
+of_pages=из {{pagesCount}}
+# LOCALIZATION NOTE (page_of_pages): "{{pageNumber}}" and "{{pagesCount}}"
+# will be replaced by a number representing the currently visible page,
+# respectively a number representing the total number of pages in the document.
+page_of_pages=({{pageNumber}} из {{pagesCount}})
+
+zoom_out.title=Уменьшить
+zoom_out_label=Уменьшить
+zoom_in.title=Увеличить
+zoom_in_label=Увеличить
+zoom.title=Масштаб
+presentation_mode.title=Перейти в режим презентации
+presentation_mode_label=Режим презентации
+open_file.title=Открыть файл
+open_file_label=Открыть
+print.title=Печать
+print_label=Печать
+save.title=Сохранить
+save_label=Сохранить
+bookmark1.title=Текущая страница (просмотр URL-адреса с текущей страницы)
+bookmark1_label=Текущая страница
+# LOCALIZATION NOTE (open_in_app.title): This string is used in Firefox for Android.
+open_in_app.title=Открыть в приложении
+# LOCALIZATION NOTE (open_in_app_label): This string is used in Firefox for Android. Length of the translation matters since we are in a mobile context, with limited screen estate.
+open_in_app_label=Открыть в программе
+
+# Secondary toolbar and context menu
+tools.title=Инструменты
+tools_label=Инструменты
+first_page.title=Перейти на первую страницу
+first_page_label=Перейти на первую страницу
+last_page.title=Перейти на последнюю страницу
+last_page_label=Перейти на последнюю страницу
+page_rotate_cw.title=Повернуть по часовой стрелке
+page_rotate_cw_label=Повернуть по часовой стрелке
+page_rotate_ccw.title=Повернуть против часовой стрелки
+page_rotate_ccw_label=Повернуть против часовой стрелки
+
+cursor_text_select_tool.title=Включить Инструмент «Выделение текста»
+cursor_text_select_tool_label=Инструмент «Выделение текста»
+cursor_hand_tool.title=Включить Инструмент «Рука»
+cursor_hand_tool_label=Инструмент «Рука»
+
+scroll_page.title=Использовать прокрутку страниц
+scroll_page_label=Прокрутка страниц
+scroll_vertical.title=Использовать вертикальную прокрутку
+scroll_vertical_label=Вертикальная прокрутка
+scroll_horizontal.title=Использовать горизонтальную прокрутку
+scroll_horizontal_label=Горизонтальная прокрутка
+scroll_wrapped.title=Использовать масштабируемую прокрутку
+scroll_wrapped_label=Масштабируемая прокрутка
+
+spread_none.title=Не использовать режим разворотов страниц
+spread_none_label=Без разворотов страниц
+spread_odd.title=Развороты начинаются с нечётных номеров страниц
+spread_odd_label=Нечётные страницы слева
+spread_even.title=Развороты начинаются с чётных номеров страниц
+spread_even_label=Чётные страницы слева
+
+# Document properties dialog box
+document_properties.title=Свойства документа…
+document_properties_label=Свойства документа…
+document_properties_file_name=Имя файла:
+document_properties_file_size=Размер файла:
+# LOCALIZATION NOTE (document_properties_kb): "{{size_kb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in kilobytes, respectively in bytes.
+document_properties_kb={{size_kb}} КБ ({{size_b}} байт)
+# LOCALIZATION NOTE (document_properties_mb): "{{size_mb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in megabytes, respectively in bytes.
+document_properties_mb={{size_mb}} МБ ({{size_b}} байт)
+document_properties_title=Заголовок:
+document_properties_author=Автор:
+document_properties_subject=Тема:
+document_properties_keywords=Ключевые слова:
+document_properties_creation_date=Дата создания:
+document_properties_modification_date=Дата изменения:
+# LOCALIZATION NOTE (document_properties_date_string): "{{date}}" and "{{time}}"
+# will be replaced by the creation/modification date, and time, of the PDF file.
+document_properties_date_string={{date}}, {{time}}
+document_properties_creator=Приложение:
+document_properties_producer=Производитель PDF:
+document_properties_version=Версия PDF:
+document_properties_page_count=Число страниц:
+document_properties_page_size=Размер страницы:
+document_properties_page_size_unit_inches=дюймов
+document_properties_page_size_unit_millimeters=мм
+document_properties_page_size_orientation_portrait=книжная
+document_properties_page_size_orientation_landscape=альбомная
+document_properties_page_size_name_a3=A3
+document_properties_page_size_name_a4=A4
+document_properties_page_size_name_letter=Letter
+document_properties_page_size_name_legal=Legal
+# LOCALIZATION NOTE (document_properties_page_size_dimension_string):
+# "{{width}}", "{{height}}", {{unit}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement and orientation, of the (current) page.
+document_properties_page_size_dimension_string={{width}} × {{height}} {{unit}} ({{orientation}})
+# LOCALIZATION NOTE (document_properties_page_size_dimension_name_string):
+# "{{width}}", "{{height}}", {{unit}}, {{name}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement, name, and orientation, of the (current) page.
+document_properties_page_size_dimension_name_string={{width}} × {{height}} {{unit}} ({{name}}, {{orientation}})
+# LOCALIZATION NOTE (document_properties_linearized): The linearization status of
+# the document; usually called "Fast Web View" in English locales of Adobe software.
+document_properties_linearized=Быстрый просмотр в Web:
+document_properties_linearized_yes=Да
+document_properties_linearized_no=Нет
+document_properties_close=Закрыть
+
+print_progress_message=Подготовка документа к печати…
+# LOCALIZATION NOTE (print_progress_percent): "{{progress}}" will be replaced by
+# a numerical per cent value.
+print_progress_percent={{progress}}%
+print_progress_close=Отмена
+
+# Tooltips and alt text for side panel toolbar buttons
+# (the _label strings are alt text for the buttons, the .title strings are
+# tooltips)
+toggle_sidebar.title=Показать/скрыть боковую панель
+toggle_sidebar_notification2.title=Показать/скрыть боковую панель (документ имеет содержание/вложения/слои)
+toggle_sidebar_label=Показать/скрыть боковую панель
+document_outline.title=Показать содержание документа (двойной щелчок, чтобы развернуть/свернуть все элементы)
+document_outline_label=Содержание документа
+attachments.title=Показать вложения
+attachments_label=Вложения
+layers.title=Показать слои (дважды щёлкните, чтобы сбросить все слои к состоянию по умолчанию)
+layers_label=Слои
+thumbs.title=Показать миниатюры
+thumbs_label=Миниатюры
+current_outline_item.title=Найти текущий элемент структуры
+current_outline_item_label=Текущий элемент структуры
+findbar.title=Найти в документе
+findbar_label=Найти
+
+additional_layers=Дополнительные слои
+# LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
+page_landmark=Страница {{page}}
+# Thumbnails panel item (tooltip and alt text for images)
+# LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
+# number.
+thumb_page_title=Страница {{page}}
+# LOCALIZATION NOTE (thumb_page_canvas): "{{page}}" will be replaced by the page
+# number.
+thumb_page_canvas=Миниатюра страницы {{page}}
+
+# Find panel button title and messages
+find_input.title=Найти
+find_input.placeholder=Найти в документе…
+find_previous.title=Найти предыдущее вхождение фразы в текст
+find_previous_label=Назад
+find_next.title=Найти следующее вхождение фразы в текст
+find_next_label=Далее
+find_highlight=Подсветить все
+find_match_case_label=С учётом регистра
+find_match_diacritics_label=С учётом диакритических знаков
+find_entire_word_label=Слова целиком
+find_reached_top=Достигнут верх документа, продолжено снизу
+find_reached_bottom=Достигнут конец документа, продолжено сверху
+# LOCALIZATION NOTE (find_match_count): The supported plural forms are
+# [one|two|few|many|other], with [other] as the default value.
+# "{{current}}" and "{{total}}" will be replaced by a number representing the
+# index of the currently active find result, respectively a number representing
+# the total number of matches in the document.
+find_match_count={[ plural(total) ]}
+find_match_count[one]={{current}} из {{total}} совпадения
+find_match_count[two]={{current}} из {{total}} совпадений
+find_match_count[few]={{current}} из {{total}} совпадений
+find_match_count[many]={{current}} из {{total}} совпадений
+find_match_count[other]={{current}} из {{total}} совпадений
+# LOCALIZATION NOTE (find_match_count_limit): The supported plural forms are
+# [zero|one|two|few|many|other], with [other] as the default value.
+# "{{limit}}" will be replaced by a numerical value.
+find_match_count_limit={[ plural(limit) ]}
+find_match_count_limit[zero]=Более {{limit}} совпадений
+find_match_count_limit[one]=Более {{limit}} совпадения
+find_match_count_limit[two]=Более {{limit}} совпадений
+find_match_count_limit[few]=Более {{limit}} совпадений
+find_match_count_limit[many]=Более {{limit}} совпадений
+find_match_count_limit[other]=Более {{limit}} совпадений
+find_not_found=Фраза не найдена
+
+# Predefined zoom values
+page_scale_width=По ширине страницы
+page_scale_fit=По размеру страницы
+page_scale_auto=Автоматически
+page_scale_actual=Реальный размер
+# LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
+# numerical scale value.
+page_scale_percent={{scale}}%
+
+# Loading indicator messages
+loading_error=При загрузке PDF произошла ошибка.
+invalid_file_error=Некорректный или повреждённый PDF-файл.
+missing_file_error=PDF-файл отсутствует.
+unexpected_response_error=Неожиданный ответ сервера.
+rendering_error=При создании страницы произошла ошибка.
+
+# LOCALIZATION NOTE (annotation_date_string): "{{date}}" and "{{time}}" will be
+# replaced by the modification date, and time, of the annotation.
+annotation_date_string={{date}}, {{time}}
+
+# LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
+# "{{type}}" will be replaced with an annotation type from a list defined in
+# the PDF spec (32000-1:2008 Table 169 – Annotation types).
+# Some common types are e.g.: "Check", "Text", "Comment", "Note"
+text_annotation_type.alt=[Аннотация {{type}}]
+password_label=Введите пароль, чтобы открыть этот PDF-файл.
+password_invalid=Неверный пароль. Пожалуйста, попробуйте снова.
+password_ok=OK
+password_cancel=Отмена
+
+printing_not_supported=Предупреждение: В этом браузере не полностью поддерживается печать.
+printing_not_ready=Предупреждение: PDF не полностью загружен для печати.
+web_fonts_disabled=Веб-шрифты отключены: не удалось задействовать встроенные PDF-шрифты.
+
+# Editor
+editor_free_text2.title=Текст
+editor_free_text2_label=Текст
+editor_ink2.title=Рисовать
+editor_ink2_label=Рисовать
+
+editor_stamp.title=Добавить изображение
+editor_stamp_label=Добавить изображение
+
+free_text2_default_content=Начните вводить…
+
+# Editor Parameters
+editor_free_text_color=Цвет
+editor_free_text_size=Размер
+editor_ink_color=Цвет
+editor_ink_thickness=Толщина
+editor_ink_opacity=Прозрачность
+
+# Editor aria
+editor_free_text2_aria_label=Текстовый редактор
+editor_ink2_aria_label=Редактор рисования
+editor_ink_canvas_aria_label=Созданное пользователем изображение

--- a/js/pdfjs/web/locale/sat/viewer.properties
+++ b/js/pdfjs/web/locale/sat/viewer.properties
@@ -1,0 +1,259 @@
+# Copyright 2012 Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Main toolbar buttons (tooltips and alt text for images)
+previous.title=ᱢᱟᱲᱟᱝ ᱥᱟᱦᱴᱟ
+previous_label=ᱢᱟᱲᱟᱝᱟᱜ
+next.title=ᱤᱱᱟᱹ ᱛᱟᱭᱚᱢ ᱥᱟᱦᱴᱟ
+next_label=ᱤᱱᱟᱹ ᱛᱟᱭᱚᱢ
+
+# LOCALIZATION NOTE (page.title): The tooltip for the pageNumber input.
+page.title=ᱥᱟᱦᱴᱟ
+# LOCALIZATION NOTE (of_pages): "{{pagesCount}}" will be replaced by a number
+# representing the total number of pages in the document.
+of_pages=ᱨᱮᱭᱟᱜ {{pagesCount}}
+# LOCALIZATION NOTE (page_of_pages): "{{pageNumber}}" and "{{pagesCount}}"
+# will be replaced by a number representing the currently visible page,
+# respectively a number representing the total number of pages in the document.
+page_of_pages=({{pageNumber}} ᱠᱷᱚᱱ {{pagesCount}})
+
+zoom_out.title=ᱦᱤᱲᱤᱧ ᱛᱮᱭᱟᱨ
+zoom_out_label=ᱦᱤᱲᱤᱧ ᱛᱮᱭᱟᱨ
+zoom_in.title=ᱢᱟᱨᱟᱝ ᱛᱮᱭᱟᱨ
+zoom_in_label=ᱢᱟᱨᱟᱝ ᱛᱮᱭᱟᱨ
+zoom.title=ᱡᱩᱢ
+presentation_mode.title=ᱩᱫᱩᱜ ᱥᱚᱫᱚᱨ ᱚᱵᱚᱥᱛᱟ ᱨᱮ ᱚᱛᱟᱭ ᱢᱮ
+presentation_mode_label=ᱩᱫᱩᱜ ᱥᱚᱫᱚᱨ ᱚᱵᱚᱥᱛᱟ ᱨᱮ
+open_file.title=ᱨᱮᱫ ᱡᱷᱤᱡᱽ ᱢᱮ
+open_file_label=ᱡᱷᱤᱡᱽ ᱢᱮ
+print.title=ᱪᱷᱟᱯᱟ
+print_label=ᱪᱷᱟᱯᱟ
+save.title=ᱥᱟᱺᱪᱟᱣ ᱢᱮ
+save_label=ᱥᱟᱺᱪᱟᱣ ᱢᱮ
+bookmark1.title=ᱱᱤᱛᱚᱜᱟᱜ ᱥᱟᱦᱴᱟ (ᱱᱤᱛᱚᱜᱟᱜ ᱥᱟᱦᱴᱟ ᱠᱷᱚᱱ URL ᱫᱮᱠᱷᱟᱣ ᱢᱮ)
+bookmark1_label=ᱱᱤᱛᱚᱜᱟᱜ ᱥᱟᱦᱴᱟ
+# LOCALIZATION NOTE (open_in_app.title): This string is used in Firefox for Android.
+open_in_app.title=ᱮᱯ ᱨᱮ ᱡᱷᱤᱡᱽ ᱢᱮ
+# LOCALIZATION NOTE (open_in_app_label): This string is used in Firefox for Android. Length of the translation matters since we are in a mobile context, with limited screen estate.
+open_in_app_label=ᱮᱯ ᱨᱮ ᱡᱷᱤᱡᱽ ᱢᱮ
+
+# Secondary toolbar and context menu
+tools.title=ᱦᱟᱹᱛᱤᱭᱟᱹᱨ ᱠᱚ
+tools_label=ᱦᱟᱹᱛᱤᱭᱟᱹᱨ ᱠᱚ
+first_page.title=ᱯᱩᱭᱞᱩ ᱥᱟᱦᱴᱟ ᱥᱮᱫ ᱪᱟᱞᱟᱜ ᱢᱮ
+first_page_label=ᱯᱩᱭᱞᱩ ᱥᱟᱦᱴᱟ ᱥᱮᱫ ᱪᱟᱞᱟᱜ ᱢᱮ
+last_page.title=ᱢᱩᱪᱟᱹᱫ ᱥᱟᱦᱴᱟ ᱥᱮᱫ ᱪᱟᱞᱟᱜ ᱢᱮ
+last_page_label=ᱢᱩᱪᱟᱹᱫ ᱥᱟᱦᱴᱟ ᱥᱮᱫ ᱪᱟᱞᱟᱜ ᱢᱮ
+page_rotate_cw.title=ᱜᱷᱚᱰᱤ ᱦᱤᱥᱟᱹᱵ ᱛᱮ ᱟᱹᱪᱩᱨ
+page_rotate_cw_label=ᱜᱷᱚᱰᱤ ᱦᱤᱥᱟᱹᱵ ᱛᱮ ᱟᱹᱪᱩᱨ
+page_rotate_ccw.title=ᱜᱷᱚᱰᱤ ᱦᱤᱥᱟᱹᱵ ᱛᱮ ᱩᱞᱴᱟᱹ ᱟᱹᱪᱩᱨ
+page_rotate_ccw_label=ᱜᱷᱚᱰᱤ ᱦᱤᱥᱟᱹᱵ ᱛᱮ ᱩᱞᱴᱟᱹ ᱟᱹᱪᱩᱨ
+
+cursor_text_select_tool.title=ᱚᱞ ᱵᱟᱪᱷᱟᱣ ᱦᱟᱹᱛᱤᱭᱟᱨ ᱮᱢ ᱪᱷᱚᱭ ᱢᱮ
+cursor_text_select_tool_label=ᱚᱞ ᱵᱟᱪᱷᱟᱣ ᱦᱟᱹᱛᱤᱭᱟᱨ
+cursor_hand_tool.title=ᱛᱤ ᱦᱟᱹᱛᱤᱭᱟᱨ ᱮᱢ ᱪᱷᱚᱭ ᱢᱮ
+cursor_hand_tool_label=ᱛᱤ ᱦᱟᱹᱛᱤᱭᱟᱨ
+
+scroll_page.title=ᱥᱟᱦᱴᱟ ᱜᱩᱲᱟᱹᱣ ᱵᱮᱵᱷᱟᱨ ᱢᱮ
+scroll_page_label=ᱥᱟᱦᱴᱟ ᱜᱩᱲᱟᱹᱣ
+scroll_vertical.title=ᱥᱤᱫᱽ ᱜᱩᱲᱟᱹᱣ ᱵᱮᱵᱷᱟᱨ ᱢᱮ
+scroll_vertical_label=ᱥᱤᱫᱽ ᱜᱩᱲᱟᱹᱣ
+scroll_horizontal.title=ᱜᱤᱛᱤᱡ ᱛᱮ ᱜᱩᱲᱟᱹᱣ ᱵᱮᱵᱷᱟᱨ ᱢᱮ
+scroll_horizontal_label=ᱜᱤᱛᱤᱡ ᱛᱮ ᱜᱩᱲᱟᱹᱣ
+scroll_wrapped.title=ᱞᱤᱯᱴᱟᱹᱣ ᱜᱩᱰᱨᱟᱹᱣ ᱵᱮᱵᱷᱟᱨ ᱢᱮ
+scroll_wrapped_label=ᱞᱤᱯᱴᱟᱣ ᱜᱩᱰᱨᱟᱹᱣ
+
+spread_none.title=ᱟᱞᱚᱢ ᱡᱚᱲᱟᱣ ᱟ ᱥᱟᱦᱴᱟ ᱫᱚ ᱯᱟᱥᱱᱟᱣᱜᱼᱟ
+spread_none_label=ᱯᱟᱥᱱᱟᱣ ᱵᱟᱹᱱᱩᱜᱼᱟ
+spread_odd.title=ᱥᱟᱦᱴᱟ ᱯᱟᱥᱱᱟᱣ ᱡᱚᱲᱟᱣ ᱢᱮ ᱡᱟᱦᱟᱸ ᱫᱚ ᱚᱰᱼᱮᱞ ᱥᱟᱦᱴᱟᱠᱚ ᱥᱟᱞᱟᱜ ᱮᱛᱦᱚᱵᱚᱜ ᱠᱟᱱᱟ
+spread_odd_label=ᱚᱰ ᱯᱟᱥᱱᱟᱣ
+spread_even.title=ᱥᱟᱦᱴᱟ ᱯᱟᱥᱱᱟᱣ ᱡᱚᱲᱟᱣ ᱢᱮ ᱡᱟᱦᱟᱸ ᱫᱚ ᱤᱣᱮᱱᱼᱮᱞ ᱥᱟᱦᱴᱟᱠᱚ ᱥᱟᱞᱟᱜ ᱮᱛᱦᱚᱵᱚᱜ ᱠᱟᱱᱟ
+spread_even_label=ᱯᱟᱥᱱᱟᱣ ᱤᱣᱮᱱ
+
+# Document properties dialog box
+document_properties.title=ᱫᱚᱞᱤᱞ ᱜᱩᱱᱠᱚ …
+document_properties_label=ᱫᱚᱞᱤᱞ ᱜᱩᱱᱠᱚ …
+document_properties_file_name=ᱨᱮᱫᱽ ᱧᱩᱛᱩᱢ :
+document_properties_file_size=ᱨᱮᱫᱽ ᱢᱟᱯ :
+# LOCALIZATION NOTE (document_properties_kb): "{{size_kb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in kilobytes, respectively in bytes.
+document_properties_kb={{size_kb}} KB ({{size_b}} ᱵᱟᱭᱤᱴ ᱠᱚ)
+# LOCALIZATION NOTE (document_properties_mb): "{{size_mb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in megabytes, respectively in bytes.
+document_properties_mb={{size_mb}} MB ({{size_b}} ᱵᱟᱭᱤᱴ ᱠᱚ)
+document_properties_title=ᱧᱩᱛᱩᱢ :
+document_properties_author=ᱚᱱᱚᱞᱤᱭᱟᱹ :
+document_properties_subject=ᱵᱤᱥᱚᱭ :
+document_properties_keywords=ᱠᱟᱹᱴᱷᱤ ᱥᱟᱵᱟᱫᱽ :
+document_properties_creation_date=ᱛᱮᱭᱟᱨ ᱢᱟᱸᱦᱤᱛ :
+document_properties_modification_date=ᱵᱚᱫᱚᱞ ᱦᱚᱪᱚ ᱢᱟᱹᱦᱤᱛ :
+# LOCALIZATION NOTE (document_properties_date_string): "{{date}}" and "{{time}}"
+# will be replaced by the creation/modification date, and time, of the PDF file.
+document_properties_date_string={{date}}, {{time}}
+document_properties_creator=ᱵᱮᱱᱟᱣᱤᱡ :
+document_properties_producer=PDF ᱛᱮᱭᱟᱨ ᱚᱰᱚᱠᱤᱡ :
+document_properties_version=PDF ᱵᱷᱟᱹᱨᱥᱚᱱ :
+document_properties_page_count=ᱥᱟᱦᱴᱟ ᱞᱮᱠᱷᱟ :
+document_properties_page_size=ᱥᱟᱦᱴᱟ ᱢᱟᱯ :
+document_properties_page_size_unit_inches=ᱤᱧᱪ
+document_properties_page_size_unit_millimeters=ᱢᱤᱢᱤ
+document_properties_page_size_orientation_portrait=ᱯᱚᱴᱨᱮᱴ
+document_properties_page_size_orientation_landscape=ᱞᱮᱱᱰᱥᱠᱮᱯ
+document_properties_page_size_name_a3=A3
+document_properties_page_size_name_a4=A4
+document_properties_page_size_name_letter=ᱪᱤᱴᱷᱤ
+document_properties_page_size_name_legal=ᱠᱟᱹᱱᱩᱱᱤ
+# LOCALIZATION NOTE (document_properties_page_size_dimension_string):
+# "{{width}}", "{{height}}", {{unit}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement and orientation, of the (current) page.
+document_properties_page_size_dimension_string={{width}} × {{height}} {{unit}} ({{orientation}})
+# LOCALIZATION NOTE (document_properties_page_size_dimension_name_string):
+# "{{width}}", "{{height}}", {{unit}}, {{name}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement, name, and orientation, of the (current) page.
+document_properties_page_size_dimension_name_string={{width}} × {{height}} {{unit}} ({{name}}, {{orientation}})
+# LOCALIZATION NOTE (document_properties_linearized): The linearization status of
+# the document; usually called "Fast Web View" in English locales of Adobe software.
+document_properties_linearized=ᱞᱚᱜᱚᱱ ᱣᱮᱵᱽ ᱧᱮᱞ :
+document_properties_linearized_yes=ᱦᱚᱭ
+document_properties_linearized_no=ᱵᱟᱝ
+document_properties_close=ᱵᱚᱸᱫᱚᱭ ᱢᱮ
+
+print_progress_message=ᱪᱷᱟᱯᱟ ᱞᱟᱹᱜᱤᱫ ᱫᱚᱞᱤᱞ ᱛᱮᱭᱟᱨᱚᱜ ᱠᱟᱱᱟ …
+# LOCALIZATION NOTE (print_progress_percent): "{{progress}}" will be replaced by
+# a numerical per cent value.
+print_progress_percent={{progress}}%
+print_progress_close=ᱵᱟᱹᱰᱨᱟᱹ
+
+# Tooltips and alt text for side panel toolbar buttons
+# (the _label strings are alt text for the buttons, the .title strings are
+# tooltips)
+toggle_sidebar.title=ᱫᱷᱟᱨᱮᱵᱟᱨ ᱥᱮᱫ ᱩᱪᱟᱹᱲᱚᱜ ᱢᱮ
+toggle_sidebar_notification2.title=ᱫᱷᱟᱨᱮᱵᱟᱨ ᱥᱮᱫ ᱩᱪᱟᱹᱲᱚᱜ ᱢᱮ  (ᱫᱚᱞᱤᱞ ᱨᱮ ᱟᱣᱴᱞᱟᱭᱤᱢ ᱢᱮᱱᱟᱜᱼᱟ/ᱞᱟᱪᱷᱟᱠᱚ/ᱯᱚᱨᱚᱛᱠᱚ)
+toggle_sidebar_label=ᱫᱷᱟᱨᱮᱵᱟᱨ ᱥᱮᱫ ᱩᱪᱟᱹᱲᱚᱜ ᱢᱮ
+document_outline.title=ᱫᱚᱞᱚᱞ ᱟᱣᱴᱞᱟᱭᱤᱱ ᱫᱮᱠᱷᱟᱣ ᱢᱮ (ᱡᱷᱚᱛᱚ ᱡᱤᱱᱤᱥᱠᱚ ᱵᱟᱨ ᱡᱮᱠᱷᱟ ᱚᱛᱟ ᱠᱮᱛᱮ ᱡᱷᱟᱹᱞ/ᱦᱩᱰᱤᱧ ᱪᱷᱚᱭ ᱢᱮ)
+document_outline_label=ᱫᱚᱞᱤᱞ ᱛᱮᱭᱟᱨ ᱛᱮᱫ
+attachments.title=ᱞᱟᱴᱷᱟ ᱥᱮᱞᱮᱫ ᱠᱚ ᱩᱫᱩᱜᱽ ᱢᱮ
+attachments_label=ᱞᱟᱴᱷᱟ ᱥᱮᱞᱮᱫ ᱠᱚ
+layers.title=ᱯᱚᱨᱚᱛ ᱫᱮᱠᱷᱟᱣ ᱢᱮ (ᱢᱩᱞ ᱡᱟᱭᱜᱟ ᱛᱮ ᱡᱷᱚᱛᱚ ᱯᱚᱨᱚᱛᱠᱚ ᱨᱤᱥᱮᱴ ᱞᱟᱹᱜᱤᱫ ᱵᱟᱨ ᱡᱮᱠᱷᱟ ᱚᱛᱚᱭ ᱢᱮ)
+layers_label=ᱯᱚᱨᱚᱛᱠᱚ
+thumbs.title=ᱪᱤᱛᱟᱹᱨ ᱟᱦᱞᱟ ᱠᱚ ᱩᱫᱩᱜᱽ ᱢᱮ
+thumbs_label=ᱪᱤᱛᱟᱹᱨ ᱟᱦᱞᱟ ᱠᱚ
+current_outline_item.title=ᱱᱤᱛᱚᱜᱟᱜ ᱟᱣᱴᱞᱟᱭᱤᱱ ᱡᱟᱱᱤᱥ ᱯᱟᱱᱛᱮ ᱢᱮ
+current_outline_item_label=ᱱᱤᱛᱚᱜᱟᱜ ᱟᱣᱴᱞᱟᱭᱤᱱ ᱡᱟᱱᱤᱥ
+findbar.title=ᱫᱚᱞᱤᱞ ᱨᱮ ᱯᱟᱱᱛᱮ
+findbar_label=ᱥᱮᱸᱫᱽᱨᱟᱭ ᱢᱮ
+
+additional_layers=ᱵᱟᱹᱲᱛᱤ ᱯᱚᱨᱚᱛᱠᱚ
+# LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
+page_landmark={{page}} ᱥᱟᱦᱴᱟ
+# Thumbnails panel item (tooltip and alt text for images)
+# LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
+# number.
+thumb_page_title={{page}} ᱥᱟᱦᱴᱟ
+# LOCALIZATION NOTE (thumb_page_canvas): "{{page}}" will be replaced by the page
+# number.
+thumb_page_canvas={{page}} ᱥᱟᱦᱴᱟ ᱨᱮᱭᱟᱜ ᱪᱤᱛᱟᱹᱨ ᱟᱦᱞᱟ
+
+# Find panel button title and messages
+find_input.title=ᱥᱮᱸᱫᱽᱨᱟᱭ ᱢᱮ
+find_input.placeholder=ᱫᱚᱞᱤᱞ ᱨᱮ ᱯᱟᱱᱛᱮ ᱢᱮ …
+find_previous.title=ᱟᱭᱟᱛ ᱦᱤᱸᱥ ᱨᱮᱭᱟᱜ ᱯᱟᱹᱦᱤᱞ ᱥᱮᱫᱟᱜ ᱚᱰᱚᱠ ᱧᱟᱢ ᱢᱮ
+find_previous_label=ᱢᱟᱲᱟᱝᱟᱜ
+find_next.title=ᱟᱭᱟᱛ ᱦᱤᱸᱥ ᱨᱮᱭᱟᱜ ᱤᱱᱟᱹ ᱛᱟᱭᱚᱢ ᱚᱰᱚᱠ ᱧᱟᱢ ᱢᱮ
+find_next_label=ᱤᱱᱟᱹ ᱛᱟᱭᱚᱢ
+find_highlight=ᱡᱷᱚᱛᱚ ᱩᱫᱩᱜ ᱨᱟᱠᱟᱵ
+find_match_case_label=ᱡᱚᱲ ᱠᱟᱛᱷᱟ
+find_match_diacritics_label=ᱵᱤᱥᱮᱥᱚᱠ ᱠᱚ ᱢᱮᱲᱟᱣ ᱢᱮ
+find_entire_word_label=ᱡᱷᱚᱛᱚ ᱟᱹᱲᱟᱹᱠᱚ
+find_reached_top=ᱫᱚᱞᱤᱞ ᱨᱮᱭᱟᱜ ᱪᱤᱴ ᱨᱮ ᱥᱮᱴᱮᱨ, ᱞᱟᱛᱟᱨ ᱠᱷᱚᱱ ᱞᱮᱛᱟᱲ
+find_reached_bottom=ᱫᱚᱞᱤᱞ ᱨᱮᱭᱟᱜ ᱢᱩᱪᱟᱹᱫ ᱨᱮ ᱥᱮᱴᱮᱨ, ᱪᱚᱴ ᱠᱷᱚᱱ ᱞᱮᱛᱟᱲ
+# LOCALIZATION NOTE (find_match_count): The supported plural forms are
+# [one|two|few|many|other], with [other] as the default value.
+# "{{current}}" and "{{total}}" will be replaced by a number representing the
+# index of the currently active find result, respectively a number representing
+# the total number of matches in the document.
+find_match_count={[ plural(total) ]}
+find_match_count[one]={{current}} ᱨᱮᱭᱟᱜ {{total}} ᱡᱚᱲ
+find_match_count[two]={{current}} ᱨᱮᱭᱟᱜ {{total}} ᱡᱚᱲᱠᱚ
+find_match_count[few]={{current}} ᱨᱮᱭᱟᱜ {{total}} ᱡᱚᱲᱠᱚ
+find_match_count[many]={{current}} ᱨᱮᱭᱟᱜ {{total}} ᱡᱚᱲᱠᱚ
+find_match_count[other]={{current}} ᱨᱮᱭᱟᱜ {{total}} ᱡᱚᱲᱠᱚ
+# LOCALIZATION NOTE (find_match_count_limit): The supported plural forms are
+# [zero|one|two|few|many|other], with [other] as the default value.
+# "{{limit}}" will be replaced by a numerical value.
+find_match_count_limit={[ plural(limit) ]}
+find_match_count_limit[zero]={{limit}} ᱡᱚᱲ ᱠᱚ ᱠᱷᱚᱱ ᱰᱷᱮᱨ
+find_match_count_limit[one]={{limit}} ᱡᱚᱲ ᱠᱷᱚᱱ ᱰᱷᱮᱨ
+find_match_count_limit[two]={{limit}} ᱡᱚᱲ ᱠᱚ ᱠᱷᱚᱱ ᱰᱷᱮᱨ
+find_match_count_limit[few]={{limit}} ᱡᱚᱲ ᱠᱚ ᱠᱷᱚᱱ ᱰᱷᱮᱨ
+find_match_count_limit[many]={{limit}} ᱡᱚᱲ ᱠᱚ ᱠᱷᱚᱱ ᱰᱷᱮᱨ
+find_match_count_limit[other]={{limit}} ᱡᱚᱲ ᱠᱚ ᱠᱷᱚᱱ ᱰᱷᱮᱨ
+find_not_found=ᱛᱚᱯᱚᱞ ᱫᱚᱱᱚᱲ ᱵᱟᱝ ᱧᱟᱢ ᱞᱮᱱᱟ
+
+# Predefined zoom values
+page_scale_width=ᱥᱟᱦᱴᱟ ᱚᱥᱟᱨ
+page_scale_fit=ᱥᱟᱦᱴᱟ ᱠᱷᱟᱯ
+page_scale_auto=ᱟᱡᱼᱟᱡ ᱛᱮ ᱦᱩᱰᱤᱧ ᱞᱟᱹᱴᱩ ᱛᱮᱭᱟᱨ
+page_scale_actual=ᱴᱷᱤᱠ ᱢᱟᱨᱟᱝ ᱛᱮᱫ
+# LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
+# numerical scale value.
+page_scale_percent={{scale}}%
+
+# Loading indicator messages
+loading_error=PDF ᱞᱟᱫᱮ ᱡᱚᱦᱚᱜ ᱢᱤᱫ ᱵᱷᱩᱞ ᱦᱩᱭ ᱮᱱᱟ ᱾
+invalid_file_error=ᱵᱟᱝ ᱵᱟᱛᱟᱣ ᱟᱨᱵᱟᱝᱠᱷᱟᱱ ᱰᱤᱜᱟᱹᱣ PDF ᱨᱮᱫᱽ ᱾
+missing_file_error=ᱟᱫᱟᱜ PDF ᱨᱮᱫᱽ ᱾
+unexpected_response_error=ᱵᱟᱝᱵᱩᱡᱷ ᱥᱚᱨᱵᱷᱚᱨ ᱛᱮᱞᱟ ᱾
+rendering_error=ᱥᱟᱦᱴᱟ ᱮᱢ ᱡᱚᱦᱚᱠ ᱢᱤᱫ ᱵᱷᱩᱞ ᱦᱩᱭ ᱮᱱᱟ ᱾
+
+# LOCALIZATION NOTE (annotation_date_string): "{{date}}" and "{{time}}" will be
+# replaced by the modification date, and time, of the annotation.
+annotation_date_string={{date}}, {{time}}
+
+# LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
+# "{{type}}" will be replaced with an annotation type from a list defined in
+# the PDF spec (32000-1:2008 Table 169 – Annotation types).
+# Some common types are e.g.: "Check", "Text", "Comment", "Note"
+text_annotation_type.alt=[{{type}} ᱢᱚᱱᱛᱚ ᱮᱢ]
+password_label=ᱱᱚᱶᱟ PDF ᱨᱮᱫᱽ ᱡᱷᱤᱡᱽ ᱞᱟᱹᱜᱤᱫ ᱫᱟᱱᱟᱝ ᱥᱟᱵᱟᱫᱽ ᱟᱫᱮᱨ ᱢᱮ ᱾
+password_invalid=ᱵᱷᱩᱞ ᱫᱟᱱᱟᱝ ᱥᱟᱵᱟᱫᱽ ᱾ ᱫᱟᱭᱟᱠᱟᱛᱮ ᱫᱩᱦᱲᱟᱹ ᱪᱮᱥᱴᱟᱭ ᱢᱮ ᱾
+password_ok=ᱴᱷᱤᱠ
+password_cancel=ᱵᱟᱹᱰᱨᱟᱹ
+
+printing_not_supported=ᱦᱚᱥᱤᱭᱟᱨ : ᱪᱷᱟᱯᱟ ᱱᱚᱣᱟ ᱯᱟᱱᱛᱮᱭᱟᱜ ᱫᱟᱨᱟᱭ ᱛᱮ ᱯᱩᱨᱟᱹᱣ ᱵᱟᱭ ᱜᱚᱲᱚᱣᱟᱠᱟᱱᱟ ᱾
+printing_not_ready=ᱦᱩᱥᱤᱭᱟᱹᱨ : ᱪᱷᱟᱯᱟ ᱞᱟᱹᱜᱤᱫ PDF ᱯᱩᱨᱟᱹ ᱵᱟᱭ ᱞᱟᱫᱮ ᱟᱠᱟᱱᱟ ᱾
+web_fonts_disabled=ᱣᱮᱵᱽ ᱪᱤᱠᱤ ᱵᱟᱝ ᱦᱩᱭ ᱦᱚᱪᱚ ᱠᱟᱱᱟ : ᱵᱷᱤᱛᱤᱨ ᱛᱷᱟᱯᱚᱱ PDF ᱪᱤᱠᱤ ᱵᱮᱵᱷᱟᱨ ᱵᱟᱝ ᱦᱩᱭ ᱠᱮᱭᱟ ᱾
+
+# Editor
+editor_free_text2.title=ᱚᱞ
+editor_free_text2_label=ᱚᱞ
+editor_ink2.title=ᱛᱮᱭᱟᱨ
+editor_ink2_label=ᱛᱮᱭᱟᱨ
+
+editor_stamp.title=ᱢᱤᱫᱴᱟᱹᱝ ᱪᱤᱛᱟᱹᱨ ᱥᱮᱞᱮᱫ ᱢᱮ
+editor_stamp_label=ᱢᱤᱫᱴᱟᱹᱝ ᱪᱤᱛᱟᱹᱨ ᱥᱮᱞᱮᱫ ᱢᱮ
+
+free_text2_default_content=ᱚᱞ ᱮᱛᱦᱚᱵ ᱢᱮ …
+
+# Editor Parameters
+editor_free_text_color=ᱨᱚᱝ
+editor_free_text_size=ᱢᱟᱯ
+editor_ink_color=ᱨᱚᱝ
+editor_ink_thickness=ᱢᱚᱴᱟ
+editor_ink_opacity=ᱟᱨᱯᱟᱨ
+
+# Editor aria
+editor_free_text2_aria_label=ᱚᱞ ᱥᱟᱯᱲᱟᱣᱤᱭᱟᱹ
+editor_ink2_aria_label=ᱛᱮᱭᱟᱨ ᱥᱟᱯᱲᱟᱣᱤᱭᱟᱹ
+editor_ink_canvas_aria_label=ᱵᱮᱵᱷᱟᱨᱤᱭᱟᱹ ᱛᱮᱭᱟᱨ ᱠᱟᱫ ᱪᱤᱛᱟᱹᱨ

--- a/js/pdfjs/web/locale/sc/viewer.properties
+++ b/js/pdfjs/web/locale/sc/viewer.properties
@@ -1,0 +1,242 @@
+# Copyright 2012 Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Main toolbar buttons (tooltips and alt text for images)
+previous.title=Pàgina anteriore
+previous_label=S'ischeda chi b'est primu
+next.title=Pàgina imbeniente
+next_label=Imbeniente
+
+# LOCALIZATION NOTE (page.title): The tooltip for the pageNumber input.
+page.title=Pàgina
+# LOCALIZATION NOTE (of_pages): "{{pagesCount}}" will be replaced by a number
+# representing the total number of pages in the document.
+of_pages=de {{pagesCount}}
+# LOCALIZATION NOTE (page_of_pages): "{{pageNumber}}" and "{{pagesCount}}"
+# will be replaced by a number representing the currently visible page,
+# respectively a number representing the total number of pages in the document.
+page_of_pages=({{pageNumber}} de {{pagesCount}})
+
+zoom_out.title=Impitica
+zoom_out_label=Impitica
+zoom_in.title=Ismànnia
+zoom_in_label=Ismànnia
+zoom.title=Ismànnia
+presentation_mode.title=Cola a sa modalidade de presentatzione
+presentation_mode_label=Modalidade de presentatzione
+open_file.title=Aberi s'archìviu
+open_file_label=Abertu
+print.title=Imprenta
+print_label=Imprenta
+
+save.title=Sarva
+save_label=Sarva
+
+
+# Secondary toolbar and context menu
+tools.title=Istrumentos
+tools_label=Istrumentos
+first_page.title=Bae a sa prima pàgina
+first_page_label=Bae a sa prima pàgina
+last_page.title=Bae a s'ùrtima pàgina
+last_page_label=Bae a s'ùrtima pàgina
+page_rotate_cw.title=Gira in sensu oràriu
+page_rotate_cw_label=Gira in sensu oràriu
+page_rotate_ccw.title=Gira in sensu anti-oràriu
+page_rotate_ccw_label=Gira in sensu anti-oràriu
+
+cursor_text_select_tool.title=Ativa s'aina de seletzione de testu
+cursor_text_select_tool_label=Aina de seletzione de testu
+cursor_hand_tool.title=Ativa s'aina de manu
+cursor_hand_tool_label=Aina de manu
+
+scroll_page.title=Imprea s'iscurrimentu de pàgina
+scroll_page_label=Iscurrimentu de pàgina
+scroll_vertical.title=Imprea s'iscurrimentu verticale
+scroll_vertical_label=Iscurrimentu verticale
+scroll_horizontal.title=Imprea s'iscurrimentu orizontale
+scroll_horizontal_label=Iscurrimentu orizontale
+scroll_wrapped.title=Imprea s'iscurrimentu continu
+scroll_wrapped_label=Iscurrimentu continu
+
+
+# Document properties dialog box
+document_properties.title=Propiedades de su documentu…
+document_properties_label=Propiedades de su documentu…
+document_properties_file_name=Nòmine de s'archìviu:
+document_properties_file_size=Mannària de s'archìviu:
+# LOCALIZATION NOTE (document_properties_kb): "{{size_kb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in kilobytes, respectively in bytes.
+document_properties_kb={{size_kb}} KB ({{size_b}} bytes)
+# LOCALIZATION NOTE (document_properties_mb): "{{size_mb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in megabytes, respectively in bytes.
+document_properties_mb={{size_mb}} MB ({{size_b}} bytes)
+document_properties_title=Tìtulu:
+document_properties_author=Autoria:
+document_properties_subject=Ogetu:
+document_properties_keywords=Faeddos crae:
+document_properties_creation_date=Data de creatzione:
+document_properties_modification_date=Data de modìfica:
+# LOCALIZATION NOTE (document_properties_date_string): "{{date}}" and "{{time}}"
+# will be replaced by the creation/modification date, and time, of the PDF file.
+document_properties_date_string={{date}}, {{time}}
+document_properties_creator=Creatzione:
+document_properties_producer=Produtore de PDF:
+document_properties_version=Versione de PDF:
+document_properties_page_count=Contu de pàginas:
+document_properties_page_size=Mannària de sa pàgina:
+document_properties_page_size_unit_inches=pòddighes
+document_properties_page_size_unit_millimeters=mm
+document_properties_page_size_orientation_portrait=verticale
+document_properties_page_size_orientation_landscape=orizontale
+document_properties_page_size_name_a3=A3
+document_properties_page_size_name_a4=A4
+document_properties_page_size_name_letter=Lìtera
+document_properties_page_size_name_legal=Legale
+# LOCALIZATION NOTE (document_properties_page_size_dimension_string):
+# "{{width}}", "{{height}}", {{unit}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement and orientation, of the (current) page.
+document_properties_page_size_dimension_string={{width}} × {{height}} {{unit}} ({{orientation}})
+# LOCALIZATION NOTE (document_properties_page_size_dimension_name_string):
+# "{{width}}", "{{height}}", {{unit}}, {{name}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement, name, and orientation, of the (current) page.
+document_properties_page_size_dimension_name_string={{width}} × {{height}} {{unit}} ({{name}}, {{orientation}})
+# LOCALIZATION NOTE (document_properties_linearized): The linearization status of
+# the document; usually called "Fast Web View" in English locales of Adobe software.
+document_properties_linearized=Visualizatzione web lestra:
+document_properties_linearized_yes=Eja
+document_properties_linearized_no=Nono
+document_properties_close=Serra
+
+print_progress_message=Aparitzende s'imprenta de su documentu…
+# LOCALIZATION NOTE (print_progress_percent): "{{progress}}" will be replaced by
+# a numerical per cent value.
+print_progress_percent={{progress}}%
+print_progress_close=Cantzella
+
+# Tooltips and alt text for side panel toolbar buttons
+# (the _label strings are alt text for the buttons, the .title strings are
+# tooltips)
+toggle_sidebar.title=Ativa/disativa sa barra laterale
+toggle_sidebar_notification2.title=Ativa/disativa sa barra laterale (su documentu cuntenet un'ischema, alligongiados o livellos)
+toggle_sidebar_label=Ativa/disativa sa barra laterale
+document_outline_label=Ischema de su documentu
+attachments.title=Ammustra alligongiados
+attachments_label=Alliongiados
+layers.title=Ammustra livellos (clic dòpiu pro ripristinare totu is livellos a s'istadu predefinidu)
+layers_label=Livellos
+thumbs.title=Ammustra miniaturas
+thumbs_label=Miniaturas
+current_outline_item.title=Agata s'elementu atuale de s'ischema
+current_outline_item_label=Elementu atuale de s'ischema
+findbar.title=Agata in su documentu
+findbar_label=Agata
+
+additional_layers=Livellos additzionales
+# LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
+page_landmark=Pàgina {{page}}
+# Thumbnails panel item (tooltip and alt text for images)
+# LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
+# number.
+thumb_page_title=Pàgina {{page}}
+# LOCALIZATION NOTE (thumb_page_canvas): "{{page}}" will be replaced by the page
+# number.
+thumb_page_canvas=Miniatura de sa pàgina {{page}}
+
+# Find panel button title and messages
+find_input.title=Agata
+find_input.placeholder=Agata in su documentu…
+find_previous.title=Agata s'ocurrèntzia pretzedente de sa fràsia
+find_previous_label=S'ischeda chi b'est primu
+find_next.title=Agata s'ocurrèntzia imbeniente de sa fràsia
+find_next_label=Imbeniente
+find_highlight=Evidèntzia totu
+find_match_case_label=Distinghe intre majùsculas e minùsculas
+find_match_diacritics_label=Respeta is diacrìticos
+find_entire_word_label=Faeddos intreos
+find_reached_top=S'est lòmpidu a su cumintzu de su documentu, si sighit dae su bàsciu
+find_reached_bottom=Acabbu de su documentu, si sighit dae s'artu
+# LOCALIZATION NOTE (find_match_count): The supported plural forms are
+# [one|two|few|many|other], with [other] as the default value.
+# "{{current}}" and "{{total}}" will be replaced by a number representing the
+# index of the currently active find result, respectively a number representing
+# the total number of matches in the document.
+find_match_count={[ plural(total) ]}
+find_match_count[one]={{current}} dae {{total}} currispondèntzia
+find_match_count[two]={{current}} dae {{total}} currispondèntzias
+find_match_count[few]={{current}} dae {{total}} currispondèntzias
+find_match_count[many]={{current}} dae {{total}} currispondèntzias
+find_match_count[other]={{current}} dae {{total}} currispondèntzias
+# LOCALIZATION NOTE (find_match_count_limit): The supported plural forms are
+# [zero|one|two|few|many|other], with [other] as the default value.
+# "{{limit}}" will be replaced by a numerical value.
+find_match_count_limit={[ plural(limit) ]}
+find_match_count_limit[zero]=Prus de {{limit}} currispondèntzias
+find_match_count_limit[one]=Prus de {{limit}} currispondèntzia
+find_match_count_limit[two]=Prus de {{limit}} currispondèntzias
+find_match_count_limit[few]=Prus de {{limit}} currispondèntzias
+find_match_count_limit[many]=Prus de {{limit}} currispondèntzias
+find_match_count_limit[other]=Prus de {{limit}} currispondèntzias
+find_not_found=Testu no agatadu
+
+# Predefined zoom values
+page_scale_auto=Ingrandimentu automàticu
+page_scale_actual=Mannària reale
+# LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
+# numerical scale value.
+page_scale_percent={{scale}}%
+
+# Loading indicator messages
+loading_error=Faddina in sa càrriga de su PDF.
+invalid_file_error=Archìviu PDF non vàlidu o corrùmpidu.
+missing_file_error=Ammancat s'archìviu PDF.
+unexpected_response_error=Risposta imprevista de su serbidore.
+
+rendering_error=Faddina in sa visualizatzione de sa pàgina.
+
+# LOCALIZATION NOTE (annotation_date_string): "{{date}}" and "{{time}}" will be
+# replaced by the modification date, and time, of the annotation.
+annotation_date_string={{date}}, {{time}}
+
+# LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
+# "{{type}}" will be replaced with an annotation type from a list defined in
+# the PDF spec (32000-1:2008 Table 169 – Annotation types).
+# Some common types are e.g.: "Check", "Text", "Comment", "Note"
+password_label=Inserta sa crae pro abèrrere custu archìviu PDF.
+password_invalid=Sa crae no est curreta. Torra a nche proare.
+password_ok=Andat bene
+password_cancel=Cantzella
+
+printing_not_supported=Atentzione: s'imprenta no est funtzionende de su totu in custu navigadore.
+printing_not_ready=Atentzione: su PDF no est istadu carrigadu de su totu pro s'imprenta.
+web_fonts_disabled=Is tipografias web sunt disativadas: is tipografias incrustadas a su PDF non podent èssere impreadas.
+
+# Editor
+editor_free_text2.title=Testu
+editor_free_text2_label=Testu
+editor_ink2.title=Disinnu
+editor_ink2_label=Disinnu
+
+free_text2_default_content=Cumintza a iscrìere…
+
+# Editor Parameters
+editor_free_text_color=Colore
+editor_free_text_size=Mannària
+editor_ink_color=Colore
+editor_ink_thickness=Grussària
+
+# Editor aria
+editor_free_text2_aria_label=Editore de testu
+editor_ink2_aria_label=Editore de disinnos
+editor_ink_canvas_aria_label=Immàgine creada dae s’utente

--- a/js/pdfjs/web/locale/scn/viewer.properties
+++ b/js/pdfjs/web/locale/scn/viewer.properties
@@ -1,0 +1,101 @@
+# Copyright 2012 Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Main toolbar buttons (tooltips and alt text for images)
+
+# LOCALIZATION NOTE (page.title): The tooltip for the pageNumber input.
+# LOCALIZATION NOTE (of_pages): "{{pagesCount}}" will be replaced by a number
+# representing the total number of pages in the document.
+# LOCALIZATION NOTE (page_of_pages): "{{pageNumber}}" and "{{pagesCount}}"
+# will be replaced by a number representing the currently visible page,
+# respectively a number representing the total number of pages in the document.
+
+zoom_out.title=Cchiù nicu
+zoom_out_label=Cchiù nicu
+zoom_in.title=Cchiù granni
+zoom_in_label=Cchiù granni
+
+# Secondary toolbar and context menu
+
+
+
+
+# Document properties dialog box
+# LOCALIZATION NOTE (document_properties_kb): "{{size_kb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in kilobytes, respectively in bytes.
+# LOCALIZATION NOTE (document_properties_mb): "{{size_mb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in megabytes, respectively in bytes.
+# LOCALIZATION NOTE (document_properties_date_string): "{{date}}" and "{{time}}"
+# will be replaced by the creation/modification date, and time, of the PDF file.
+# LOCALIZATION NOTE (document_properties_page_size_dimension_string):
+# "{{width}}", "{{height}}", {{unit}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement and orientation, of the (current) page.
+# LOCALIZATION NOTE (document_properties_page_size_dimension_name_string):
+# "{{width}}", "{{height}}", {{unit}}, {{name}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement, name, and orientation, of the (current) page.
+# LOCALIZATION NOTE (document_properties_linearized): The linearization status of
+# the document; usually called "Fast Web View" in English locales of Adobe software.
+document_properties_linearized=Vista web lesta:
+document_properties_linearized_yes=Se
+
+# LOCALIZATION NOTE (print_progress_percent): "{{progress}}" will be replaced by
+# a numerical per cent value.
+print_progress_close=Sfai
+
+# Tooltips and alt text for side panel toolbar buttons
+# (the _label strings are alt text for the buttons, the .title strings are
+# tooltips)
+
+# Thumbnails panel item (tooltip and alt text for images)
+# LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
+# number.
+# LOCALIZATION NOTE (thumb_page_canvas): "{{page}}" will be replaced by the page
+# number.
+
+# Find panel button title and messages
+# LOCALIZATION NOTE (find_match_count): The supported plural forms are
+# [one|two|few|many|other], with [other] as the default value.
+# "{{current}}" and "{{total}}" will be replaced by a number representing the
+# index of the currently active find result, respectively a number representing
+# the total number of matches in the document.
+# LOCALIZATION NOTE (find_match_count_limit): The supported plural forms are
+# [zero|one|two|few|many|other], with [other] as the default value.
+# "{{limit}}" will be replaced by a numerical value.
+
+# Error panel labels
+# LOCALIZATION NOTE (error_version_info): "{{version}}" and "{{build}}" will be
+# replaced by the PDF.JS version and build ID.
+# LOCALIZATION NOTE (error_message): "{{message}}" will be replaced by an
+# english string describing the error.
+# LOCALIZATION NOTE (error_stack): "{{stack}}" will be replaced with a stack
+# trace.
+# LOCALIZATION NOTE (error_file): "{{file}}" will be replaced with a filename
+# LOCALIZATION NOTE (error_line): "{{line}}" will be replaced with a line number
+
+# Predefined zoom values
+page_scale_width=Larghizza dâ pàggina
+# LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
+# numerical scale value.
+
+# Loading indicator messages
+
+# LOCALIZATION NOTE (annotation_date_string): "{{date}}" and "{{time}}" will be
+# replaced by the modification date, and time, of the annotation.
+
+# LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
+# "{{type}}" will be replaced with an annotation type from a list defined in
+# the PDF spec (32000-1:2008 Table 169 – Annotation types).
+# Some common types are e.g.: "Check", "Text", "Comment", "Note"
+password_cancel=Sfai
+

--- a/js/pdfjs/web/locale/sco/viewer.properties
+++ b/js/pdfjs/web/locale/sco/viewer.properties
@@ -1,0 +1,226 @@
+# Copyright 2012 Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Main toolbar buttons (tooltips and alt text for images)
+previous.title=Page Afore
+previous_label=Previous
+next.title=Page Efter
+next_label=Neist
+
+# LOCALIZATION NOTE (page.title): The tooltip for the pageNumber input.
+page.title=Page
+# LOCALIZATION NOTE (of_pages): "{{pagesCount}}" will be replaced by a number
+# representing the total number of pages in the document.
+of_pages=o {{pagesCount}}
+# LOCALIZATION NOTE (page_of_pages): "{{pageNumber}}" and "{{pagesCount}}"
+# will be replaced by a number representing the currently visible page,
+# respectively a number representing the total number of pages in the document.
+page_of_pages=({{pageNumber}} o {{pagesCount}})
+
+zoom_out.title=Zoom Oot
+zoom_out_label=Zoom Oot
+zoom_in.title=Zoom In
+zoom_in_label=Zoom In
+zoom.title=Zoom
+presentation_mode.title=Flit tae Presentation Mode
+presentation_mode_label=Presentation Mode
+open_file.title=Open File
+open_file_label=Open
+print.title=Prent
+print_label=Prent
+
+# Secondary toolbar and context menu
+tools.title=Tools
+tools_label=Tools
+first_page.title=Gang tae First Page
+first_page_label=Gang tae First Page
+last_page.title=Gang tae Lest Page
+last_page_label=Gang tae Lest Page
+page_rotate_cw.title=Rotate Clockwise
+page_rotate_cw_label=Rotate Clockwise
+page_rotate_ccw.title=Rotate Coonterclockwise
+page_rotate_ccw_label=Rotate Coonterclockwise
+
+cursor_text_select_tool.title=Enable Text Walin Tool
+cursor_text_select_tool_label=Text Walin Tool
+cursor_hand_tool.title=Enable Haun Tool
+cursor_hand_tool_label=Haun Tool
+
+scroll_vertical.title=Yaise Vertical Scrollin
+scroll_vertical_label=Vertical Scrollin
+scroll_horizontal.title=Yaise Horizontal Scrollin
+scroll_horizontal_label=Horizontal Scrollin
+scroll_wrapped.title=Yaise Wrapped Scrollin
+scroll_wrapped_label=Wrapped Scrollin
+
+spread_none.title=Dinnae jyn page spreids
+spread_none_label=Nae Spreids
+spread_odd.title=Jyn page spreids stertin wi odd-numbered pages
+spread_odd_label=Odd Spreids
+spread_even.title=Jyn page spreids stertin wi even-numbered pages
+spread_even_label=Even Spreids
+
+# Document properties dialog box
+document_properties.title=Document Properties…
+document_properties_label=Document Properties…
+document_properties_file_name=File nemme:
+document_properties_file_size=File size:
+# LOCALIZATION NOTE (document_properties_kb): "{{size_kb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in kilobytes, respectively in bytes.
+document_properties_kb={{size_kb}} KB ({{size_b}} bytes)
+# LOCALIZATION NOTE (document_properties_mb): "{{size_mb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in megabytes, respectively in bytes.
+document_properties_mb={{size_mb}} MB ({{size_b}} bytes)
+document_properties_title=Title:
+document_properties_author=Author:
+document_properties_subject=Subjeck:
+document_properties_keywords=Keywirds:
+document_properties_creation_date=Date o Makkin:
+document_properties_modification_date=Date o Chynges:
+# LOCALIZATION NOTE (document_properties_date_string): "{{date}}" and "{{time}}"
+# will be replaced by the creation/modification date, and time, of the PDF file.
+document_properties_date_string={{date}}, {{time}}
+document_properties_creator=Makker:
+document_properties_producer=PDF Producer:
+document_properties_version=PDF Version:
+document_properties_page_count=Page Coont:
+document_properties_page_size=Page Size:
+document_properties_page_size_unit_inches=in
+document_properties_page_size_unit_millimeters=mm
+document_properties_page_size_orientation_portrait=portrait
+document_properties_page_size_orientation_landscape=landscape
+document_properties_page_size_name_a3=A3
+document_properties_page_size_name_a4=A4
+document_properties_page_size_name_letter=Letter
+document_properties_page_size_name_legal=Legal
+# LOCALIZATION NOTE (document_properties_page_size_dimension_string):
+# "{{width}}", "{{height}}", {{unit}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement and orientation, of the (current) page.
+document_properties_page_size_dimension_string={{width}} × {{height}} {{unit}} ({{orientation}})
+# LOCALIZATION NOTE (document_properties_page_size_dimension_name_string):
+# "{{width}}", "{{height}}", {{unit}}, {{name}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement, name, and orientation, of the (current) page.
+document_properties_page_size_dimension_name_string={{width}} × {{height}} {{unit}} ({{name}}, {{orientation}})
+# LOCALIZATION NOTE (document_properties_linearized): The linearization status of
+# the document; usually called "Fast Web View" in English locales of Adobe software.
+document_properties_linearized=Fast Wab View:
+document_properties_linearized_yes=Aye
+document_properties_linearized_no=Naw
+document_properties_close=Sneck
+
+print_progress_message=Reddin document fur prentin…
+# LOCALIZATION NOTE (print_progress_percent): "{{progress}}" will be replaced by
+# a numerical per cent value.
+print_progress_percent={{progress}}%
+print_progress_close=Stap
+
+# Tooltips and alt text for side panel toolbar buttons
+# (the _label strings are alt text for the buttons, the .title strings are
+# tooltips)
+toggle_sidebar.title=Toggle Sidebaur
+toggle_sidebar_notification2.title=Toggle Sidebaur (document conteens ootline/attachments/layers)
+toggle_sidebar_label=Toggle Sidebaur
+document_outline.title=Kythe Document Ootline (double-click fur tae oot-fauld/in-fauld aw items)
+document_outline_label=Document Ootline
+attachments.title=Kythe Attachments
+attachments_label=Attachments
+layers.title=Kythe Layers (double-click fur tae reset aw layers tae the staunart state)
+layers_label=Layers
+thumbs.title=Kythe Thumbnails
+thumbs_label=Thumbnails
+current_outline_item.title=Find Current Ootline Item
+current_outline_item_label=Current Ootline Item
+findbar.title=Find in Document
+findbar_label=Find
+
+additional_layers=Mair Layers
+# LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
+page_landmark=Page {{page}}
+# Thumbnails panel item (tooltip and alt text for images)
+# LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
+# number.
+thumb_page_title=Page {{page}}
+# LOCALIZATION NOTE (thumb_page_canvas): "{{page}}" will be replaced by the page
+# number.
+thumb_page_canvas=Thumbnail o Page {{page}}
+
+# Find panel button title and messages
+find_input.title=Find
+find_input.placeholder=Find in document…
+find_previous.title=Airt oot the last time this phrase occurred
+find_previous_label=Previous
+find_next.title=Airt oot the neist time this phrase occurs
+find_next_label=Neist
+find_highlight=Highlicht aw
+find_match_case_label=Match case
+find_entire_word_label=Hale Wirds
+find_reached_top=Raxed tap o document, went on fae the dowp end
+find_reached_bottom=Raxed end o document, went on fae the tap
+# LOCALIZATION NOTE (find_match_count): The supported plural forms are
+# [one|two|few|many|other], with [other] as the default value.
+# "{{current}}" and "{{total}}" will be replaced by a number representing the
+# index of the currently active find result, respectively a number representing
+# the total number of matches in the document.
+find_match_count={[ plural(total) ]}
+find_match_count[one]={{current}} o {{total}} match
+find_match_count[two]={{current}} o {{total}} matches
+find_match_count[few]={{current}} o {{total}} matches
+find_match_count[many]={{current}} o {{total}} matches
+find_match_count[other]={{current}} o {{total}} matches
+# LOCALIZATION NOTE (find_match_count_limit): The supported plural forms are
+# [zero|one|two|few|many|other], with [other] as the default value.
+# "{{limit}}" will be replaced by a numerical value.
+find_match_count_limit={[ plural(limit) ]}
+find_match_count_limit[zero]=Mair nor {{limit}} matches
+find_match_count_limit[one]=Mair nor {{limit}} match
+find_match_count_limit[two]=Mair nor {{limit}} matches
+find_match_count_limit[few]=Mair nor {{limit}} matches
+find_match_count_limit[many]=Mair nor {{limit}} matches
+find_match_count_limit[other]=Mair nor {{limit}} matches
+find_not_found=Phrase no fund
+
+# Predefined zoom values
+page_scale_width=Page Width
+page_scale_fit=Page Fit
+page_scale_auto=Automatic Zoom
+page_scale_actual=Actual Size
+# LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
+# numerical scale value.
+page_scale_percent={{scale}}%
+
+loading_error=An mishanter tuik place while loadin the PDF.
+invalid_file_error=No suithfest or camshauchlet PDF file.
+missing_file_error=PDF file tint.
+unexpected_response_error=Unexpectit server repone.
+
+rendering_error=A mishanter tuik place while renderin the page.
+
+# LOCALIZATION NOTE (annotation_date_string): "{{date}}" and "{{time}}" will be
+# replaced by the modification date, and time, of the annotation.
+annotation_date_string={{date}}, {{time}}
+
+# LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
+# "{{type}}" will be replaced with an annotation type from a list defined in
+# the PDF spec (32000-1:2008 Table 169 – Annotation types).
+# Some common types are e.g.: "Check", "Text", "Comment", "Note"
+text_annotation_type.alt=[{{type}} Annotation]
+password_label=Inpit the passwird fur tae open this PDF file.
+password_invalid=Passwird no suithfest. Gonnae gie it anither shot.
+password_ok=OK
+password_cancel=Stap
+
+printing_not_supported=Tak tent: Prentin isnae richt supportit by this stravaiger.
+printing_not_ready=Tak tent: The PDF isnae richt loadit fur prentin.
+web_fonts_disabled=Wab fonts are disabled: cannae yaise embeddit PDF fonts.
+

--- a/js/pdfjs/web/locale/si/viewer.properties
+++ b/js/pdfjs/web/locale/si/viewer.properties
@@ -1,0 +1,215 @@
+# Copyright 2012 Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Main toolbar buttons (tooltips and alt text for images)
+previous.title=කලින් පිටුව
+previous_label=කලින්
+next.title=ඊළඟ පිටුව
+next_label=ඊළඟ
+
+# LOCALIZATION NOTE (page.title): The tooltip for the pageNumber input.
+page.title=පිටුව
+# LOCALIZATION NOTE (of_pages): "{{pagesCount}}" will be replaced by a number
+# representing the total number of pages in the document.
+# LOCALIZATION NOTE (page_of_pages): "{{pageNumber}}" and "{{pagesCount}}"
+# will be replaced by a number representing the currently visible page,
+# respectively a number representing the total number of pages in the document.
+
+zoom_out.title=කුඩාලනය
+zoom_out_label=කුඩාලනය
+zoom_in.title=විශාලනය
+zoom_in_label=විශාලනය
+zoom.title=විශාල කරන්න
+presentation_mode.title=සමර්පණ ප්‍රකාරය වෙත මාරුවන්න
+presentation_mode_label=සමර්පණ ප්‍රකාරය
+open_file.title=ගොනුව අරින්න
+open_file_label=අරින්න
+print.title=මුද්‍රණය
+print_label=මුද්‍රණය
+save.title=සුරකින්න
+save_label=සුරකින්න
+bookmark1_label=පවතින පිටුව
+# LOCALIZATION NOTE (open_in_app.title): This string is used in Firefox for Android.
+open_in_app.title=යෙදුමෙහි අරින්න
+# LOCALIZATION NOTE (open_in_app_label): This string is used in Firefox for Android. Length of the translation matters since we are in a mobile context, with limited screen estate.
+open_in_app_label=යෙදුමෙහි අරින්න
+
+# Secondary toolbar and context menu
+tools.title=මෙවලම්
+tools_label=මෙවලම්
+first_page.title=මුල් පිටුවට යන්න
+first_page_label=මුල් පිටුවට යන්න
+last_page.title=අවසන් පිටුවට යන්න
+last_page_label=අවසන් පිටුවට යන්න
+
+cursor_text_select_tool.title=පෙළ තේරීමේ මෙවලම සබල කරන්න
+cursor_text_select_tool_label=පෙළ තේරීමේ මෙවලම
+cursor_hand_tool.title=අත් මෙවලම සබල කරන්න
+cursor_hand_tool_label=අත් මෙවලම
+
+scroll_page.title=පිටුව අනුචලනය භාවිතය
+scroll_page_label=පිටුව අනුචලනය
+scroll_vertical.title=සිරස් අනුචලනය භාවිතය
+scroll_vertical_label=සිරස් අනුචලනය
+scroll_horizontal.title=තිරස් අනුචලනය භාවිතය
+scroll_horizontal_label=තිරස් අනුචලනය
+
+
+# Document properties dialog box
+document_properties.title=ලේඛනයේ ගුණාංග…
+document_properties_label=ලේඛනයේ ගුණාංග…
+document_properties_file_name=ගොනුවේ නම:
+document_properties_file_size=ගොනුවේ ප්‍රමාණය:
+# LOCALIZATION NOTE (document_properties_kb): "{{size_kb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in kilobytes, respectively in bytes.
+document_properties_kb=කි.බ. {{size_kb}} (බයිට {{size_b}})
+# LOCALIZATION NOTE (document_properties_mb): "{{size_mb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in megabytes, respectively in bytes.
+document_properties_mb=මෙ.බ. {{size_mb}} (බයිට {{size_b}})
+document_properties_title=සිරැසිය:
+document_properties_author=කතෘ:
+document_properties_subject=මාතෘකාව:
+document_properties_keywords=මූල පද:
+document_properties_creation_date=සෑදූ දිනය:
+document_properties_modification_date=සංශෝධිත දිනය:
+# LOCALIZATION NOTE (document_properties_date_string): "{{date}}" and "{{time}}"
+# will be replaced by the creation/modification date, and time, of the PDF file.
+document_properties_date_string={{date}}, {{time}}
+document_properties_creator=නිර්මාතෘ:
+document_properties_producer=පීඩීඑෆ් සම්පාදක:
+document_properties_version=පීඩීඑෆ් අනුවාදය:
+document_properties_page_count=පිටු ගණන:
+document_properties_page_size=පිටුවේ තරම:
+document_properties_page_size_unit_inches=අඟල්
+document_properties_page_size_unit_millimeters=මි.මී.
+document_properties_page_size_orientation_portrait=සිරස්
+document_properties_page_size_orientation_landscape=තිරස්
+document_properties_page_size_name_a3=A3
+document_properties_page_size_name_a4=A4
+# LOCALIZATION NOTE (document_properties_page_size_dimension_string):
+# "{{width}}", "{{height}}", {{unit}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement and orientation, of the (current) page.
+document_properties_page_size_dimension_string={{width}} × {{height}} {{unit}} ({{orientation}})
+# LOCALIZATION NOTE (document_properties_page_size_dimension_name_string):
+# "{{width}}", "{{height}}", {{unit}}, {{name}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement, name, and orientation, of the (current) page.
+document_properties_page_size_dimension_name_string={{width}}×{{height}}{{unit}}{{name}}{{orientation}}
+# LOCALIZATION NOTE (document_properties_linearized): The linearization status of
+# the document; usually called "Fast Web View" in English locales of Adobe software.
+document_properties_linearized=වේගවත් වියමන දැක්ම:
+document_properties_linearized_yes=ඔව්
+document_properties_linearized_no=නැහැ
+document_properties_close=වසන්න
+
+print_progress_message=මුද්‍රණය සඳහා ලේඛනය සූදානම් වෙමින්…
+# LOCALIZATION NOTE (print_progress_percent): "{{progress}}" will be replaced by
+# a numerical per cent value.
+print_progress_percent={{progress}}%
+print_progress_close=අවලංගු කරන්න
+
+# Tooltips and alt text for side panel toolbar buttons
+# (the _label strings are alt text for the buttons, the .title strings are
+# tooltips)
+document_outline_label=ලේඛනයේ වටසන
+attachments.title=ඇමුණුම් පෙන්වන්න
+attachments_label=ඇමුණුම්
+layers.title=ස්තර පෙන්වන්න (සියළු ස්තර පෙරනිමි තත්‍වයට යළි සැකසීමට දෙවරක් ඔබන්න)
+layers_label=ස්තර
+thumbs.title=සිඟිති රූ පෙන්වන්න
+thumbs_label=සිඟිති රූ
+findbar.title=ලේඛනයෙහි සොයන්න
+findbar_label=සොයන්න
+
+additional_layers=අතිරේක ස්තර
+# LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
+page_landmark=පිටුව {{page}}
+# Thumbnails panel item (tooltip and alt text for images)
+# LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
+# number.
+thumb_page_title=පිටුව {{page}}
+# LOCALIZATION NOTE (thumb_page_canvas): "{{page}}" will be replaced by the page
+# number.
+thumb_page_canvas=පිටුවේ සිඟිත රූව {{page}}
+
+# Find panel button title and messages
+find_input.title=සොයන්න
+find_input.placeholder=ලේඛනයේ සොයන්න…
+find_previous.title=මෙම වැකිකඩ කලින් යෙදුණු ස්ථානය සොයන්න
+find_previous_label=කලින්
+find_next.title=මෙම වැකිකඩ ඊළඟට යෙදෙන ස්ථානය සොයන්න
+find_next_label=ඊළඟ
+find_highlight=සියල්ල උද්දීපනය
+find_entire_word_label=සමස්ත වචන
+find_reached_top=ලේඛනයේ මුදුනට ළඟා විය, පහළ සිට ඉහළට
+find_reached_bottom=ලේඛනයේ අවසානයට ළඟා විය, ඉහළ සිට පහළට
+# LOCALIZATION NOTE (find_match_count): The supported plural forms are
+# [one|two|few|many|other], with [other] as the default value.
+# "{{current}}" and "{{total}}" will be replaced by a number representing the
+# index of the currently active find result, respectively a number representing
+# the total number of matches in the document.
+# LOCALIZATION NOTE (find_match_count_limit): The supported plural forms are
+# [zero|one|two|few|many|other], with [other] as the default value.
+# "{{limit}}" will be replaced by a numerical value.
+find_match_count_limit[zero]=ගැළපීම් {{limit}} කට වඩා
+find_match_count_limit[two]=ගැළපුම් {{limit}} කට වඩා
+find_match_count_limit[few]=ගැළපුම් {{limit}} කට වඩා
+find_match_count_limit[many]=ගැළපුම් {{limit}} කට වඩා
+find_match_count_limit[other]=ගැළපුම් {{limit}} කට වඩා
+find_not_found=වැකිකඩ හමු නොවිණි
+
+# Predefined zoom values
+page_scale_width=පිටුවේ පළල
+page_scale_auto=ස්වයංක්‍රීය විශාලනය
+page_scale_actual=සැබෑ ප්‍රමාණය
+# LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
+# numerical scale value.
+page_scale_percent={{scale}}%
+
+# Loading indicator messages
+loading_error=පීඩීඑෆ් පූරණය කිරීමේදී දෝෂයක් සිදු විය.
+invalid_file_error=වලංගු නොවන හෝ හානිවූ පීඩීඑෆ් ගොනුවකි.
+missing_file_error=මඟහැරුණු පීඩීඑෆ් ගොනුවකි.
+unexpected_response_error=අනපේක්‍ෂිත සේවාදායක ප්‍රතිචාරයකි.
+
+# LOCALIZATION NOTE (annotation_date_string): "{{date}}" and "{{time}}" will be
+# replaced by the modification date, and time, of the annotation.
+annotation_date_string={{date}}, {{time}}
+
+# LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
+# "{{type}}" will be replaced with an annotation type from a list defined in
+# the PDF spec (32000-1:2008 Table 169 – Annotation types).
+# Some common types are e.g.: "Check", "Text", "Comment", "Note"
+password_label=මෙම පීඩීඑෆ් ගොනුව විවෘත කිරීමට මුරපදය යොදන්න.
+password_invalid=වැරදි මුරපදයකි. නැවත උත්සාහ කරන්න.
+password_ok=හරි
+password_cancel=අවලංගු
+
+printing_not_supported=අවවාදයයි: මෙම අතිරික්සුව මුද්‍රණය සඳහා හොඳින් සහාය නොදක්වයි.
+printing_not_ready=අවවාදයයි: මුද්‍රණයට පීඩීඑෆ් ගොනුව සම්පූර්ණයෙන් පූරණය වී නැත.
+web_fonts_disabled=වියමන අකුරු අබලයි: පීඩීඑෆ් වෙත කාවැද්දූ රුවකුරු භාවිතා කළ නොහැකිය.
+
+# Editor
+editor_free_text2.title=පෙළ
+editor_free_text2_label=පෙළ
+
+
+
+# Editor Parameters
+editor_free_text_color=වර්ණය
+editor_free_text_size=තරම
+editor_ink_color=වර්ණය
+editor_ink_thickness=ඝණකම
+
+# Editor aria
+editor_free_text2_aria_label=වදන් සකසනය

--- a/js/pdfjs/web/locale/sk/viewer.properties
+++ b/js/pdfjs/web/locale/sk/viewer.properties
@@ -1,0 +1,257 @@
+# Copyright 2012 Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Main toolbar buttons (tooltips and alt text for images)
+previous.title=Predchádzajúca strana
+previous_label=Predchádzajúca
+next.title=Nasledujúca strana
+next_label=Nasledujúca
+
+# LOCALIZATION NOTE (page.title): The tooltip for the pageNumber input.
+page.title=Strana
+# LOCALIZATION NOTE (of_pages): "{{pagesCount}}" will be replaced by a number
+# representing the total number of pages in the document.
+of_pages=z {{pagesCount}}
+# LOCALIZATION NOTE (page_of_pages): "{{pageNumber}}" and "{{pagesCount}}"
+# will be replaced by a number representing the currently visible page,
+# respectively a number representing the total number of pages in the document.
+page_of_pages=({{pageNumber}} z {{pagesCount}})
+
+zoom_out.title=Zmenšiť veľkosť
+zoom_out_label=Zmenšiť veľkosť
+zoom_in.title=Zväčšiť veľkosť
+zoom_in_label=Zväčšiť veľkosť
+zoom.title=Nastavenie veľkosti
+presentation_mode.title=Prepnúť na režim prezentácie
+presentation_mode_label=Režim prezentácie
+open_file.title=Otvoriť súbor
+open_file_label=Otvoriť
+print.title=Tlačiť
+print_label=Tlačiť
+
+save.title=Uložiť
+save_label=Uložiť
+bookmark1.title=Aktuálna stránka (zobraziť adresu URL z aktuálnej stránky)
+bookmark1_label=Aktuálna stránka
+
+open_in_app.title=Otvoriť v aplikácii
+open_in_app_label=Otvoriť v aplikácii
+
+# Secondary toolbar and context menu
+tools.title=Nástroje
+tools_label=Nástroje
+first_page.title=Prejsť na prvú stranu
+first_page_label=Prejsť na prvú stranu
+last_page.title=Prejsť na poslednú stranu
+last_page_label=Prejsť na poslednú stranu
+page_rotate_cw.title=Otočiť v smere hodinových ručičiek
+page_rotate_cw_label=Otočiť v smere hodinových ručičiek
+page_rotate_ccw.title=Otočiť proti smeru hodinových ručičiek
+page_rotate_ccw_label=Otočiť proti smeru hodinových ručičiek
+
+cursor_text_select_tool.title=Povoliť výber textu
+cursor_text_select_tool_label=Výber textu
+cursor_hand_tool.title=Povoliť nástroj ruka
+cursor_hand_tool_label=Nástroj ruka
+
+scroll_page.title=Použiť rolovanie po stránkach
+scroll_page_label=Rolovanie po stránkach
+scroll_vertical.title=Používať zvislé posúvanie
+scroll_vertical_label=Zvislé posúvanie
+scroll_horizontal.title=Používať vodorovné posúvanie
+scroll_horizontal_label=Vodorovné posúvanie
+scroll_wrapped.title=Použiť postupné posúvanie
+scroll_wrapped_label=Postupné posúvanie
+
+spread_none.title=Nezdružovať stránky
+spread_none_label=Žiadne združovanie
+spread_odd.title=Združí stránky a umiestni nepárne stránky vľavo
+spread_odd_label=Združiť stránky (nepárne vľavo)
+spread_even.title=Združí stránky a umiestni párne stránky vľavo
+spread_even_label=Združiť stránky (párne vľavo)
+
+# Document properties dialog box
+document_properties.title=Vlastnosti dokumentu…
+document_properties_label=Vlastnosti dokumentu…
+document_properties_file_name=Názov súboru:
+document_properties_file_size=Veľkosť súboru:
+# LOCALIZATION NOTE (document_properties_kb): "{{size_kb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in kilobytes, respectively in bytes.
+document_properties_kb={{size_kb}} kB ({{size_b}} bajtov)
+# LOCALIZATION NOTE (document_properties_mb): "{{size_mb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in megabytes, respectively in bytes.
+document_properties_mb={{size_mb}} MB ({{size_b}} bajtov)
+document_properties_title=Názov:
+document_properties_author=Autor:
+document_properties_subject=Predmet:
+document_properties_keywords=Kľúčové slová:
+document_properties_creation_date=Dátum vytvorenia:
+document_properties_modification_date=Dátum úpravy:
+# LOCALIZATION NOTE (document_properties_date_string): "{{date}}" and "{{time}}"
+# will be replaced by the creation/modification date, and time, of the PDF file.
+document_properties_date_string={{date}}, {{time}}
+document_properties_creator=Vytvoril:
+document_properties_producer=Tvorca PDF:
+document_properties_version=Verzia PDF:
+document_properties_page_count=Počet strán:
+document_properties_page_size=Veľkosť stránky:
+document_properties_page_size_unit_inches=in
+document_properties_page_size_unit_millimeters=mm
+document_properties_page_size_orientation_portrait=na výšku
+document_properties_page_size_orientation_landscape=na šírku
+document_properties_page_size_name_a3=A3
+document_properties_page_size_name_a4=A4
+document_properties_page_size_name_letter=List
+document_properties_page_size_name_legal=Legal
+# LOCALIZATION NOTE (document_properties_page_size_dimension_string):
+# "{{width}}", "{{height}}", {{unit}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement and orientation, of the (current) page.
+document_properties_page_size_dimension_string={{width}} × {{height}} {{unit}} ({{orientation}})
+# LOCALIZATION NOTE (document_properties_page_size_dimension_name_string):
+# "{{width}}", "{{height}}", {{unit}}, {{name}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement, name, and orientation, of the (current) page.
+document_properties_page_size_dimension_name_string={{width}} × {{height}} {{unit}} ({{name}}, {{orientation}})
+# LOCALIZATION NOTE (document_properties_linearized): The linearization status of
+# the document; usually called "Fast Web View" in English locales of Adobe software.
+document_properties_linearized=Rýchle Web View:
+document_properties_linearized_yes=Áno
+document_properties_linearized_no=Nie
+document_properties_close=Zavrieť
+
+print_progress_message=Príprava dokumentu na tlač…
+# LOCALIZATION NOTE (print_progress_percent): "{{progress}}" will be replaced by
+# a numerical per cent value.
+print_progress_percent={{progress}} %
+print_progress_close=Zrušiť
+
+# Tooltips and alt text for side panel toolbar buttons
+# (the _label strings are alt text for the buttons, the .title strings are
+# tooltips)
+toggle_sidebar.title=Prepnúť bočný panel
+toggle_sidebar_notification2.title=Prepnúť bočný panel (dokument obsahuje osnovu/prílohy/vrstvy)
+toggle_sidebar_label=Prepnúť bočný panel
+document_outline.title=Zobraziť osnovu dokumentu (dvojitým kliknutím rozbalíte/zbalíte všetky položky)
+document_outline_label=Osnova dokumentu
+attachments.title=Zobraziť prílohy
+attachments_label=Prílohy
+layers.title=Zobraziť vrstvy (dvojitým kliknutím uvediete všetky vrstvy do pôvodného stavu)
+layers_label=Vrstvy
+thumbs.title=Zobraziť miniatúry
+thumbs_label=Miniatúry
+current_outline_item.title=Nájsť aktuálnu položku v osnove
+current_outline_item_label=Aktuálna položka v osnove
+findbar.title=Hľadať v dokumente
+findbar_label=Hľadať
+
+additional_layers=Ďalšie vrstvy
+# LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
+page_landmark=Strana {{page}}
+# Thumbnails panel item (tooltip and alt text for images)
+# LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
+# number.
+thumb_page_title=Strana {{page}}
+# LOCALIZATION NOTE (thumb_page_canvas): "{{page}}" will be replaced by the page
+# number.
+thumb_page_canvas=Miniatúra strany {{page}}
+
+# Find panel button title and messages
+find_input.title=Hľadať
+find_input.placeholder=Hľadať v dokumente…
+find_previous.title=Vyhľadať predchádzajúci výskyt reťazca
+find_previous_label=Predchádzajúce
+find_next.title=Vyhľadať ďalší výskyt reťazca
+find_next_label=Ďalšie
+find_highlight=Zvýrazniť všetky
+find_match_case_label=Rozlišovať veľkosť písmen
+find_match_diacritics_label=Rozlišovať diakritiku
+find_entire_word_label=Celé slová
+find_reached_top=Bol dosiahnutý začiatok stránky, pokračuje sa od konca
+find_reached_bottom=Bol dosiahnutý koniec stránky, pokračuje sa od začiatku
+# LOCALIZATION NOTE (find_match_count): The supported plural forms are
+# [one|two|few|many|other], with [other] as the default value.
+# "{{current}}" and "{{total}}" will be replaced by a number representing the
+# index of the currently active find result, respectively a number representing
+# the total number of matches in the document.
+find_match_count={[ plural(total) ]}
+find_match_count[one]={{current}}. z {{total}} výsledku
+find_match_count[two]={{current}}. z {{total}} výsledkov
+find_match_count[few]={{current}}. z {{total}} výsledkov
+find_match_count[many]={{current}}. z {{total}} výsledkov
+find_match_count[other]={{current}}. z {{total}} výsledkov
+# LOCALIZATION NOTE (find_match_count_limit): The supported plural forms are
+# [zero|one|two|few|many|other], with [other] as the default value.
+# "{{limit}}" will be replaced by a numerical value.
+find_match_count_limit={[ plural(limit) ]}
+find_match_count_limit[zero]=Viac než {{limit}} výsledkov
+find_match_count_limit[one]=Viac než {{limit}} výsledok
+find_match_count_limit[two]=Viac než {{limit}} výsledky
+find_match_count_limit[few]=Viac než {{limit}} výsledky
+find_match_count_limit[many]=Viac než {{limit}} výsledkov
+find_match_count_limit[other]=Viac než {{limit}} výsledkov
+find_not_found=Výraz nebol nájdený
+
+# Predefined zoom values
+page_scale_width=Na šírku strany
+page_scale_fit=Na veľkosť strany
+page_scale_auto=Automatická veľkosť
+page_scale_actual=Skutočná veľkosť
+# LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
+# numerical scale value.
+page_scale_percent={{scale}} %
+
+# Loading indicator messages
+loading_error=Počas načítavania dokumentu PDF sa vyskytla chyba.
+invalid_file_error=Neplatný alebo poškodený súbor PDF.
+missing_file_error=Chýbajúci súbor PDF.
+unexpected_response_error=Neočakávaná odpoveď zo servera.
+
+rendering_error=Pri vykresľovaní stránky sa vyskytla chyba.
+
+# LOCALIZATION NOTE (annotation_date_string): "{{date}}" and "{{time}}" will be
+# replaced by the modification date, and time, of the annotation.
+annotation_date_string={{date}}, {{time}}
+
+# LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
+# "{{type}}" will be replaced with an annotation type from a list defined in
+# the PDF spec (32000-1:2008 Table 169 – Annotation types).
+# Some common types are e.g.: "Check", "Text", "Comment", "Note"
+text_annotation_type.alt=[Anotácia typu {{type}}]
+password_label=Ak chcete otvoriť tento súbor PDF, zadajte jeho heslo.
+password_invalid=Heslo nie je platné. Skúste to znova.
+password_ok=OK
+password_cancel=Zrušiť
+
+printing_not_supported=Upozornenie: tlač nie je v tomto prehliadači plne podporovaná.
+printing_not_ready=Upozornenie: súbor PDF nie je plne načítaný pre tlač.
+web_fonts_disabled=Webové písma sú vypnuté: nie je možné použiť písma vložené do súboru PDF.
+
+# Editor
+editor_free_text2.title=Text
+editor_free_text2_label=Text
+editor_ink2.title=Kreslenie
+editor_ink2_label=Kresliť
+
+free_text2_default_content=Začnite písať…
+
+# Editor Parameters
+editor_free_text_color=Farba
+editor_free_text_size=Veľkosť
+editor_ink_color=Farba
+editor_ink_thickness=Hrúbka
+editor_ink_opacity=Priehľadnosť
+
+# Editor aria
+editor_free_text2_aria_label=Textový editor
+editor_ink2_aria_label=Editor kreslenia
+editor_ink_canvas_aria_label=Obrázok vytvorený používateľom

--- a/js/pdfjs/web/locale/skr/viewer.properties
+++ b/js/pdfjs/web/locale/skr/viewer.properties
@@ -1,0 +1,256 @@
+# Copyright 2012 Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Main toolbar buttons (tooltips and alt text for images)
+previous.title=پچھلا ورقہ
+previous_label=پچھلا
+next.title=اڳلا ورقہ
+next_label=اڳلا
+
+# LOCALIZATION NOTE (page.title): The tooltip for the pageNumber input.
+page.title=ورقہ
+# LOCALIZATION NOTE (of_pages): "{{pagesCount}}" will be replaced by a number
+# representing the total number of pages in the document.
+of_pages={{pagesCount}} دا
+# LOCALIZATION NOTE (page_of_pages): "{{pageNumber}}" and "{{pagesCount}}"
+# will be replaced by a number representing the currently visible page,
+# respectively a number representing the total number of pages in the document.
+page_of_pages=({{pageNumber}} دا {{pagesCount}})
+
+zoom_out.title=زوم آؤٹ
+zoom_out_label=زوم آؤٹ
+zoom_in.title=زوم اِن
+zoom_in_label=زوم اِن
+zoom.title=زوم
+presentation_mode.title=پریزنٹیشن موڈ تے سوئچ کرو
+presentation_mode_label=پریزنٹیشن موڈ
+open_file.title=فائل کھولو
+open_file_label=کھولو
+print.title=چھاپو
+print_label=چھاپو 
+save.title=ہتھیکڑا کرو
+save_label=ہتھیکڑا کرو
+bookmark1.title=موجودہ ورقہ (موجودہ ورقے کنوں یوآرایل ݙیکھو)
+bookmark1_label=موجودہ ورقہ
+
+open_in_app.title=ایپ وچ کھولو
+open_in_app_label=ایپ وچ کھولو
+
+# Secondary toolbar and context menu
+tools.title=اوزار
+tools_label=اوزار
+first_page.title=پہلے ورقے تے ونڄو
+first_page_label=پہلے ورقے تے ونڄو
+last_page.title=چھیکڑی ورقے تے ونڄو
+last_page_label=چھیکڑی ورقے تے ونڄو
+page_rotate_cw.title=گھڑی وانگوں گھماؤ
+page_rotate_cw_label=گھڑی وانگوں گھماؤ
+page_rotate_ccw.title=گھڑی تے اُپٹھ گھماؤ
+page_rotate_ccw_label=گھڑی تے اُپٹھ گھماؤ
+
+cursor_text_select_tool.title=متن منتخب کݨ والا آلہ فعال بݨاؤ
+cursor_text_select_tool_label=متن منتخب کرݨ والا آلہ
+cursor_hand_tool.title=ہینڈ ٹول فعال بݨاؤ
+cursor_hand_tool_label=ہینڈ ٹول
+
+scroll_page.title=پیج سکرولنگ استعمال کرو
+scroll_page_label=پیج سکرولنگ
+scroll_vertical.title=عمودی سکرولنگ استعمال کرو
+scroll_vertical_label=عمودی سکرولنگ
+scroll_horizontal.title=افقی سکرولنگ استعمال کرو
+scroll_horizontal_label=افقی سکرولنگ
+scroll_wrapped.title=ویڑھی ہوئی سکرولنگ استعمال کرو
+scroll_wrapped_label=وہڑھی ہوئی سکرولنگ
+
+spread_none.title=پیج سپریڈز وِچ شامل نہ تھیوو۔
+spread_none_label=کوئی پولھ کائنی
+spread_odd.title=طاق نمبر والے ورقیاں دے نال شروع تھیوݨ والے پیج سپریڈز وِچ شامل تھیوو۔
+spread_odd_label=تاک پھیلاؤ
+spread_even.title=جفت نمر والے ورقیاں نال شروع تھیوݨ والے پیج سپریڈز وِ شامل تھیوو۔
+spread_even_label=جفت پھیلاؤ
+
+# Document properties dialog box
+document_properties.title=دستاویز خواص…
+document_properties_label=دستاویز خواص …
+document_properties_file_name=فائل دا ناں:
+document_properties_file_size=فائل دا سائز:
+# LOCALIZATION NOTE (document_properties_kb): "{{size_kb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in kilobytes, respectively in bytes.
+document_properties_kb={{size_kb}} کے بی ({{size_b}} بائٹس)
+# LOCALIZATION NOTE (document_properties_mb): "{{size_mb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in megabytes, respectively in bytes.
+document_properties_mb={{size_mb}} ایم بی ({{size_b}} بائٹس)
+document_properties_title=عنوان:
+document_properties_author=تخلیق کار:
+document_properties_subject=موضوع:
+document_properties_keywords=کلیدی الفاظ:
+document_properties_creation_date=تخلیق دی تاریخ:
+document_properties_modification_date=ترمیم دی تاریخ:
+# LOCALIZATION NOTE (document_properties_date_string): "{{date}}" and "{{time}}"
+# will be replaced by the creation/modification date, and time, of the PDF file.
+document_properties_date_string={{date}}, {{time}}
+document_properties_creator=تخلیق کار:
+document_properties_producer=PDF پیدا کار:
+document_properties_version=PDF ورژن:
+document_properties_page_count=ورقہ شماری:
+document_properties_page_size=ورقہ دی سائز:
+document_properties_page_size_unit_inches=وِچ
+document_properties_page_size_unit_millimeters=mm
+document_properties_page_size_orientation_portrait=عمودی انداز
+document_properties_page_size_orientation_landscape=افقى انداز
+document_properties_page_size_name_a3=A3
+document_properties_page_size_name_a4=A4
+document_properties_page_size_name_letter=لیٹر
+document_properties_page_size_name_legal=قنونی
+# LOCALIZATION NOTE (document_properties_page_size_dimension_string):
+# "{{width}}", "{{height}}", {{unit}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement and orientation, of the (current) page.
+document_properties_page_size_dimension_string={{width}} × {{height}} {{unit}} ({{orientation}})
+# LOCALIZATION NOTE (document_properties_page_size_dimension_name_string):
+# "{{width}}", "{{height}}", {{unit}}, {{name}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement, name, and orientation, of the (current) page.
+document_properties_page_size_dimension_name_string={{width}} × {{height}} {{unit}} ({{name}}, {{orientation}})
+# LOCALIZATION NOTE (document_properties_linearized): The linearization status of
+# the document; usually called "Fast Web View" in English locales of Adobe software.
+document_properties_linearized=تکھا ویب نظارہ:
+document_properties_linearized_yes=جیا
+document_properties_linearized_no=کو
+document_properties_close=بند کرو
+
+print_progress_message=چھاپݨ کیتے دستاویز تیار تھیندے پئے ہن …
+# LOCALIZATION NOTE (print_progress_percent): "{{progress}}" will be replaced by
+# a numerical per cent value.
+print_progress_percent={{progress}}%
+print_progress_close=منسوخ کرو
+
+# Tooltips and alt text for side panel toolbar buttons
+# (the _label strings are alt text for the buttons, the .title strings are
+# tooltips)
+toggle_sidebar.title=سائیڈ بار ٹوگل کرو
+toggle_sidebar_notification2.title=سائیڈ بار ٹوگل کرو (دستاویز وِچ آؤٹ لائن/ منسلکات/ پرتاں شامل ہن)
+toggle_sidebar_label=سائیڈ بار ٹوگل کرو
+document_outline.title=دستاویز دا خاکہ ݙکھاؤ (تمام آئٹمز کوں پھیلاوݨ/سنگوڑݨ کیتے ڈبل کلک کرو)
+document_outline_label=دستاویز آؤٹ لائن
+attachments.title=نتھیاں ݙکھاؤ
+attachments_label=منسلکات
+layers.title=پرتاں ݙکھاؤ (تمام پرتاں کوں ڈیفالٹ حالت وِچ دوبارہ ترتیب ݙیوݨ کیتے ڈبل کلک کرو)
+layers_label=پرتاں
+thumbs.title=تھمبنیل ݙکھاؤ
+thumbs_label=تھمبنیلز
+current_outline_item.title=موجودہ آؤٹ لائن آئٹم لبھو
+current_outline_item_label=موجودہ آؤٹ لائن آئٹم
+findbar.title=دستاویز وِچ لبھو
+findbar_label=لبھو
+
+additional_layers=اضافی پرتاں
+# LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
+page_landmark=ورقہ {{page}}
+# Thumbnails panel item (tooltip and alt text for images)
+# LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
+# number.
+thumb_page_title=ورقہ {{page}}
+# LOCALIZATION NOTE (thumb_page_canvas): "{{page}}" will be replaced by the page
+# number.
+thumb_page_canvas=ورقے دا تھمبنیل {{page}}
+
+# Find panel button title and messages
+find_input.title=لبھو
+find_input.placeholder=دستاویز وِچ لبھو …
+find_previous.title=فقرے دا پچھلا واقعہ لبھو
+find_previous_label=پچھلا
+find_next.title=فقرے دا اڳلا واقعہ لبھو
+find_next_label=اڳلا
+find_highlight=تمام نشابر کرو
+find_match_case_label=حروف مشابہ کرو
+find_match_diacritics_label=ڈائیکرٹکس مشابہ کرو
+find_entire_word_label=تمام الفاظ
+find_reached_top=ورقے دے شروع تے پُج ڳیا، تلوں جاری کیتا ڳیا
+find_reached_bottom=ورقے دے پاند تے پُڄ ڳیا، اُتوں شروع کیتا ڳیا
+# LOCALIZATION NOTE (find_match_count): The supported plural forms are
+# [one|two|few|many|other], with [other] as the default value.
+# "{{current}}" and "{{total}}" will be replaced by a number representing the
+# index of the currently active find result, respectively a number representing
+# the total number of matches in the document.
+find_match_count={[ جمع (کل) ]}
+find_match_count[one]={{current}} دا {{total}} موازنہ کرو
+find_match_count[two]={{current}} دا {{total}} موازنہ
+find_match_count[few]={{current}} دا {{total}} موازنہ
+find_match_count[many]={{current}} دا {{total}} موازنہ
+find_match_count[other]={{current}} دا {{total}} موازنہ
+# LOCALIZATION NOTE (find_match_count_limit): The supported plural forms are
+# [zero|one|two|few|many|other], with [other] as the default value.
+# "{{limit}}" will be replaced by a numerical value.
+find_match_count_limit={[ جمع (حد) ]}
+find_match_count_limit[zero]={{limit}} کنوں زیادہ مماثلتاں۔
+find_match_count_limit[one]={{limit}}  مماثل کنوں ودھ
+find_match_count_limit[two]={{limit}} کنوں زیادہ مماثلتاں۔
+find_match_count_limit[few]={{limit}}  مماثلاں کنوں ودھ
+find_match_count_limit[many]={{limit}}  مماثلاں کنوں ودھ
+find_match_count_limit[other]={{limit}}  مماثلاں کنوں ودھ
+find_not_found=فقرہ نئیں ملیا
+
+# Predefined zoom values
+page_scale_width=ورقے دی چوڑائی
+page_scale_fit=ورقہ فٹنگ
+page_scale_auto=آپوں آپ زوم
+page_scale_actual=اصل میچا
+# LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
+# numerical scale value.
+page_scale_percent={{scale}}%
+
+# Loading indicator messages
+loading_error=PDF لوڈ کریندے ویلھے نقص آ ڳیا۔
+invalid_file_error=غلط یا خراب شدہ PDF فائل۔
+missing_file_error=PDF فائل غائب ہے۔
+unexpected_response_error=سرور دا غیر متوقع جواب۔
+
+rendering_error=ورقہ رینڈر کریندے ویلھے ہک خرابی پیش آڳئی۔
+
+# LOCALIZATION NOTE (annotation_date_string): "{{date}}" and "{{time}}" will be
+# replaced by the modification date, and time, of the annotation.
+annotation_date_string={{date}}, {{time}}
+
+# LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
+# "{{type}}" will be replaced with an annotation type from a list defined in
+# the PDF spec (32000-1:2008 Table 169 – Annotation types).
+# Some common types are e.g.: "Check", "Text", "Comment", "Note"
+text_annotation_type.alt=[{{type}} تشریح]
+password_label=ایہ PDF فائل کھولݨ کیتے پاس ورڈ درج کرو۔
+password_invalid=غلط پاس ورڈ: براہ مہربانی ولدا کوشش کرو۔
+password_ok=ٹھیک ہے
+password_cancel=منسوخ کرو
+
+printing_not_supported=چتاوݨی: چھپائی ایں براؤزر تے پوری طراں معاونت شدہ کائنی۔
+printing_not_ready=چتاوݨی: PDF چھپائی کیتے پوری طراں لوڈ نئیں تھئی۔
+web_fonts_disabled=ویب فونٹس غیر فعال ہن: ایمبیڈڈ PDF  فونٹس استعمال کرݨ کنوں قاصر ہن
+
+# Editor
+editor_free_text2.title=متن
+editor_free_text2_label=متن
+editor_ink2.title=چھکو
+editor_ink2_label=چھکو
+
+free_text2_default_content=ٹائپنگ شروع کرو …
+
+# Editor Parameters
+editor_free_text_color=رنگ
+editor_free_text_size=سائز
+editor_ink_color=رنگ
+editor_ink_thickness=ٹھولھ
+editor_ink_opacity=دھندلاپن
+
+# Editor aria
+editor_free_text2_aria_label=ٹیکسٹ ایڈیٹر
+editor_ink2_aria_label=ڈرا ایڈیٹر
+editor_ink_canvas_aria_label=صارف دی بݨائی ہوئی تصویر

--- a/js/pdfjs/web/locale/sl/viewer.properties
+++ b/js/pdfjs/web/locale/sl/viewer.properties
@@ -1,0 +1,259 @@
+# Copyright 2012 Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Main toolbar buttons (tooltips and alt text for images)
+previous.title=Prejšnja stran
+previous_label=Nazaj
+next.title=Naslednja stran
+next_label=Naprej
+
+# LOCALIZATION NOTE (page.title): The tooltip for the pageNumber input.
+page.title=Stran
+# LOCALIZATION NOTE (of_pages): "{{pagesCount}}" will be replaced by a number
+# representing the total number of pages in the document.
+of_pages=od {{pagesCount}}
+# LOCALIZATION NOTE (page_of_pages): "{{pageNumber}}" and "{{pagesCount}}"
+# will be replaced by a number representing the currently visible page,
+# respectively a number representing the total number of pages in the document.
+page_of_pages=({{pageNumber}} od {{pagesCount}})
+
+zoom_out.title=Pomanjšaj
+zoom_out_label=Pomanjšaj
+zoom_in.title=Povečaj
+zoom_in_label=Povečaj
+zoom.title=Povečava
+presentation_mode.title=Preklopi v način predstavitve
+presentation_mode_label=Način predstavitve
+open_file.title=Odpri datoteko
+open_file_label=Odpri
+print.title=Natisni
+print_label=Natisni
+save.title=Shrani
+save_label=Shrani
+bookmark1.title=Trenutna stran (prikaži URL, ki vodi do trenutne strani)
+bookmark1_label=Na trenutno stran
+# LOCALIZATION NOTE (open_in_app.title): This string is used in Firefox for Android.
+open_in_app.title=Odpri v programu
+# LOCALIZATION NOTE (open_in_app_label): This string is used in Firefox for Android. Length of the translation matters since we are in a mobile context, with limited screen estate.
+open_in_app_label=Odpri v programu
+
+# Secondary toolbar and context menu
+tools.title=Orodja
+tools_label=Orodja
+first_page.title=Pojdi na prvo stran
+first_page_label=Pojdi na prvo stran
+last_page.title=Pojdi na zadnjo stran
+last_page_label=Pojdi na zadnjo stran
+page_rotate_cw.title=Zavrti v smeri urnega kazalca
+page_rotate_cw_label=Zavrti v smeri urnega kazalca
+page_rotate_ccw.title=Zavrti v nasprotni smeri urnega kazalca
+page_rotate_ccw_label=Zavrti v nasprotni smeri urnega kazalca
+
+cursor_text_select_tool.title=Omogoči orodje za izbor besedila
+cursor_text_select_tool_label=Orodje za izbor besedila
+cursor_hand_tool.title=Omogoči roko
+cursor_hand_tool_label=Roka
+
+scroll_page.title=Uporabi drsenje po strani
+scroll_page_label=Drsenje po strani
+scroll_vertical.title=Uporabi navpično drsenje
+scroll_vertical_label=Navpično drsenje
+scroll_horizontal.title=Uporabi vodoravno drsenje
+scroll_horizontal_label=Vodoravno drsenje
+scroll_wrapped.title=Uporabi ovito drsenje
+scroll_wrapped_label=Ovito drsenje
+
+spread_none.title=Ne združuj razponov strani
+spread_none_label=Brez razponov
+spread_odd.title=Združuj razpone strani z začetkom pri lihih straneh
+spread_odd_label=Lihi razponi
+spread_even.title=Združuj razpone strani z začetkom pri sodih straneh
+spread_even_label=Sodi razponi
+
+# Document properties dialog box
+document_properties.title=Lastnosti dokumenta …
+document_properties_label=Lastnosti dokumenta …
+document_properties_file_name=Ime datoteke:
+document_properties_file_size=Velikost datoteke:
+# LOCALIZATION NOTE (document_properties_kb): "{{size_kb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in kilobytes, respectively in bytes.
+document_properties_kb={{size_kb}} KB ({{size_b}} bajtov)
+# LOCALIZATION NOTE (document_properties_mb): "{{size_mb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in megabytes, respectively in bytes.
+document_properties_mb={{size_mb}} MB ({{size_b}} bajtov)
+document_properties_title=Ime:
+document_properties_author=Avtor:
+document_properties_subject=Tema:
+document_properties_keywords=Ključne besede:
+document_properties_creation_date=Datum nastanka:
+document_properties_modification_date=Datum spremembe:
+# LOCALIZATION NOTE (document_properties_date_string): "{{date}}" and "{{time}}"
+# will be replaced by the creation/modification date, and time, of the PDF file.
+document_properties_date_string={{date}}, {{time}}
+document_properties_creator=Ustvaril:
+document_properties_producer=Izdelovalec PDF:
+document_properties_version=Različica PDF:
+document_properties_page_count=Število strani:
+document_properties_page_size=Velikost strani:
+document_properties_page_size_unit_inches=palcev
+document_properties_page_size_unit_millimeters=mm
+document_properties_page_size_orientation_portrait=pokončno
+document_properties_page_size_orientation_landscape=ležeče
+document_properties_page_size_name_a3=A3
+document_properties_page_size_name_a4=A4
+document_properties_page_size_name_letter=Pismo
+document_properties_page_size_name_legal=Pravno
+# LOCALIZATION NOTE (document_properties_page_size_dimension_string):
+# "{{width}}", "{{height}}", {{unit}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement and orientation, of the (current) page.
+document_properties_page_size_dimension_string={{width}} × {{height}} {{unit}} ({{orientation}})
+# LOCALIZATION NOTE (document_properties_page_size_dimension_name_string):
+# "{{width}}", "{{height}}", {{unit}}, {{name}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement, name, and orientation, of the (current) page.
+document_properties_page_size_dimension_name_string={{width}} × {{height}} {{unit}} ({{name}}, {{orientation}})
+# LOCALIZATION NOTE (document_properties_linearized): The linearization status of
+# the document; usually called "Fast Web View" in English locales of Adobe software.
+document_properties_linearized=Hitri spletni ogled:
+document_properties_linearized_yes=Da
+document_properties_linearized_no=Ne
+document_properties_close=Zapri
+
+print_progress_message=Priprava dokumenta na tiskanje …
+# LOCALIZATION NOTE (print_progress_percent): "{{progress}}" will be replaced by
+# a numerical per cent value.
+print_progress_percent={{progress}} %
+print_progress_close=Prekliči
+
+# Tooltips and alt text for side panel toolbar buttons
+# (the _label strings are alt text for the buttons, the .title strings are
+# tooltips)
+toggle_sidebar.title=Preklopi stransko vrstico
+toggle_sidebar_notification2.title=Preklopi stransko vrstico (dokument vsebuje oris/priponke/plasti)
+toggle_sidebar_label=Preklopi stransko vrstico
+document_outline.title=Prikaži oris dokumenta (dvokliknite za razširitev/strnitev vseh predmetov)
+document_outline_label=Oris dokumenta
+attachments.title=Prikaži priponke
+attachments_label=Priponke
+layers.title=Prikaži plasti (dvokliknite za ponastavitev vseh plasti na privzeto stanje)
+layers_label=Plasti
+thumbs.title=Prikaži sličice
+thumbs_label=Sličice
+current_outline_item.title=Najdi trenutni predmet orisa
+current_outline_item_label=Trenutni predmet orisa
+findbar.title=Iskanje po dokumentu
+findbar_label=Najdi
+
+additional_layers=Dodatne plasti
+# LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
+page_landmark=Stran {{page}}
+# Thumbnails panel item (tooltip and alt text for images)
+# LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
+# number.
+thumb_page_title=Stran {{page}}
+# LOCALIZATION NOTE (thumb_page_canvas): "{{page}}" will be replaced by the page
+# number.
+thumb_page_canvas=Sličica strani {{page}}
+
+# Find panel button title and messages
+find_input.title=Najdi
+find_input.placeholder=Najdi v dokumentu …
+find_previous.title=Najdi prejšnjo ponovitev iskanega
+find_previous_label=Najdi nazaj
+find_next.title=Najdi naslednjo ponovitev iskanega
+find_next_label=Najdi naprej
+find_highlight=Označi vse
+find_match_case_label=Razlikuj velike/male črke
+find_match_diacritics_label=Razlikuj diakritične znake
+find_entire_word_label=Cele besede
+find_reached_top=Dosežen začetek dokumenta iz smeri konca
+find_reached_bottom=Doseženo konec dokumenta iz smeri začetka
+# LOCALIZATION NOTE (find_match_count): The supported plural forms are
+# [one|two|few|many|other], with [other] as the default value.
+# "{{current}}" and "{{total}}" will be replaced by a number representing the
+# index of the currently active find result, respectively a number representing
+# the total number of matches in the document.
+find_match_count={[ plural(total) ]}
+find_match_count[one]=Zadetek {{current}} od {{total}}
+find_match_count[two]=Zadetek {{current}} od {{total}}
+find_match_count[few]=Zadetek {{current}} od {{total}}
+find_match_count[many]=Zadetek {{current}} od {{total}}
+find_match_count[other]=Zadetek {{current}} od {{total}}
+# LOCALIZATION NOTE (find_match_count_limit): The supported plural forms are
+# [zero|one|two|few|many|other], with [other] as the default value.
+# "{{limit}}" will be replaced by a numerical value.
+find_match_count_limit={[ plural(limit) ]}
+find_match_count_limit[zero]=Več kot {{limit}} zadetkov
+find_match_count_limit[one]=Več kot {{limit}} zadetek
+find_match_count_limit[two]=Več kot {{limit}} zadetka
+find_match_count_limit[few]=Več kot {{limit}} zadetki
+find_match_count_limit[many]=Več kot {{limit}} zadetkov
+find_match_count_limit[other]=Več kot {{limit}} zadetkov
+find_not_found=Iskanega ni mogoče najti
+
+# Predefined zoom values
+page_scale_width=Širina strani
+page_scale_fit=Prilagodi stran
+page_scale_auto=Samodejno
+page_scale_actual=Dejanska velikost
+# LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
+# numerical scale value.
+page_scale_percent={{scale}} %
+
+# Loading indicator messages
+loading_error=Med nalaganjem datoteke PDF je prišlo do napake.
+invalid_file_error=Neveljavna ali pokvarjena datoteka PDF.
+missing_file_error=Ni datoteke PDF.
+unexpected_response_error=Nepričakovan odgovor strežnika.
+rendering_error=Med pripravljanjem strani je prišlo do napake!
+
+# LOCALIZATION NOTE (annotation_date_string): "{{date}}" and "{{time}}" will be
+# replaced by the modification date, and time, of the annotation.
+annotation_date_string={{date}}, {{time}}
+
+# LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
+# "{{type}}" will be replaced with an annotation type from a list defined in
+# the PDF spec (32000-1:2008 Table 169 – Annotation types).
+# Some common types are e.g.: "Check", "Text", "Comment", "Note"
+text_annotation_type.alt=[Opomba vrste {{type}}]
+password_label=Vnesite geslo za odpiranje te datoteke PDF.
+password_invalid=Neveljavno geslo. Poskusite znova.
+password_ok=V redu
+password_cancel=Prekliči
+
+printing_not_supported=Opozorilo: ta brskalnik ne podpira vseh možnosti tiskanja.
+printing_not_ready=Opozorilo: PDF ni v celoti naložen za tiskanje.
+web_fonts_disabled=Spletne pisave so onemogočene: vgradnih pisav za PDF ni mogoče uporabiti.
+
+# Editor
+editor_free_text2.title=Besedilo
+editor_free_text2_label=Besedilo
+editor_ink2.title=Riši
+editor_ink2_label=Riši
+
+editor_stamp.title=Dodaj sliko
+editor_stamp_label=Dodaj sliko
+
+free_text2_default_content=Začnite tipkati …
+
+# Editor Parameters
+editor_free_text_color=Barva
+editor_free_text_size=Velikost
+editor_ink_color=Barva
+editor_ink_thickness=Debelina
+editor_ink_opacity=Neprosojnost
+
+# Editor aria
+editor_free_text2_aria_label=Urejevalnik besedila
+editor_ink2_aria_label=Urejevalnik risanja
+editor_ink_canvas_aria_label=Uporabnikova slika

--- a/js/pdfjs/web/locale/son/viewer.properties
+++ b/js/pdfjs/web/locale/son/viewer.properties
@@ -1,0 +1,152 @@
+# Copyright 2012 Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Main toolbar buttons (tooltips and alt text for images)
+previous.title=Moo bisante
+previous_label=Bisante
+next.title=Jinehere moo
+next_label=Jine
+
+# LOCALIZATION NOTE (page.title): The tooltip for the pageNumber input.
+page.title=Moo
+# LOCALIZATION NOTE (of_pages): "{{pagesCount}}" will be replaced by a number
+# representing the total number of pages in the document.
+of_pages={{pagesCount}} ra
+# LOCALIZATION NOTE (page_of_pages): "{{pageNumber}}" and "{{pagesCount}}"
+# will be replaced by a number representing the currently visible page,
+# respectively a number representing the total number of pages in the document.
+page_of_pages=({{pageNumber}} ka hun {{pagesCount}}) ra
+
+zoom_out.title=Nakasandi
+zoom_out_label=Nakasandi
+zoom_in.title=Bebbeerandi
+zoom_in_label=Bebbeerandi
+zoom.title=Bebbeerandi
+presentation_mode.title=Bere cebeyan alhaali
+presentation_mode_label=Cebeyan alhaali
+open_file.title=Tuku feeri
+open_file_label=Feeri
+print.title=Kar
+print_label=Kar
+
+# Secondary toolbar and context menu
+tools.title=Goyjinawey
+tools_label=Goyjinawey
+first_page.title=Koy moo jinaa ga
+first_page_label=Koy moo jinaa ga
+last_page.title=Koy moo koraa ga
+last_page_label=Koy moo koraa ga
+page_rotate_cw.title=Kuubi kanbe guma here
+page_rotate_cw_label=Kuubi kanbe guma here
+page_rotate_ccw.title=Kuubi kanbe wowa here
+page_rotate_ccw_label=Kuubi kanbe wowa here
+
+
+# Document properties dialog box
+document_properties.title=Takadda mayrawey…
+document_properties_label=Takadda mayrawey…
+document_properties_file_name=Tuku maa:
+document_properties_file_size=Tuku adadu:
+# LOCALIZATION NOTE (document_properties_kb): "{{size_kb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in kilobytes, respectively in bytes.
+document_properties_kb=KB {{size_kb}} (cebsu-ize {{size_b}})
+# LOCALIZATION NOTE (document_properties_mb): "{{size_mb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in megabytes, respectively in bytes.
+document_properties_mb=MB {{size_mb}} (cebsu-ize {{size_b}})
+document_properties_title=Tiiramaa:
+document_properties_author=Hantumkaw:
+document_properties_subject=Dalil:
+document_properties_keywords=Kufalkalimawey:
+document_properties_creation_date=Teeyan han:
+document_properties_modification_date=Barmayan han:
+# LOCALIZATION NOTE (document_properties_date_string): "{{date}}" and "{{time}}"
+# will be replaced by the creation/modification date, and time, of the PDF file.
+document_properties_date_string={{date}}, {{time}}
+document_properties_creator=Teekaw:
+document_properties_producer=PDF berandikaw:
+document_properties_version=PDF dumi:
+document_properties_page_count=Moo hinna:
+document_properties_close=Daabu
+
+print_progress_message=Goo ma takaddaa soolu k'a kar se…
+# LOCALIZATION NOTE (print_progress_percent): "{{progress}}" will be replaced by
+# a numerical per cent value.
+print_progress_percent={{progress}}%
+print_progress_close=Naŋ
+
+# Tooltips and alt text for side panel toolbar buttons
+# (the _label strings are alt text for the buttons, the .title strings are
+# tooltips)
+toggle_sidebar.title=Kanjari ceraw zuu
+toggle_sidebar_label=Kanjari ceraw zuu
+document_outline.title=Takaddaa korfur alhaaloo cebe (naagu cee hinka ka haya-izey kul hayandi/kankamandi)
+document_outline_label=Takadda filla-boŋ
+attachments.title=Hangarey cebe
+attachments_label=Hangarey
+thumbs.title=Kabeboy biyey cebe
+thumbs_label=Kabeboy biyey
+findbar.title=Ceeci takaddaa ra
+findbar_label=Ceeci
+
+# Thumbnails panel item (tooltip and alt text for images)
+# LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
+# number.
+thumb_page_title={{page}} moo
+# LOCALIZATION NOTE (thumb_page_canvas): "{{page}}" will be replaced by the page
+# number.
+thumb_page_canvas=Kabeboy bii {{page}} moo še
+
+# Find panel button title and messages
+find_input.title=Ceeci
+find_input.placeholder=Ceeci takaddaa ra…
+find_previous.title=Kalimaɲaŋoo bangayri bisantaa ceeci
+find_previous_label=Bisante
+find_next.title=Kalimaɲaŋoo hiino bangayroo ceeci
+find_next_label=Jine
+find_highlight=Ikul šilbay
+find_match_case_label=Harfu-beeriyan hawgay
+find_reached_top=A too moŋoo boŋoo, koy jine ka šinitin nda cewoo
+find_reached_bottom=A too moɲoo cewoo, koy jine šintioo ga
+find_not_found=Kalimaɲaa mana duwandi
+
+# Predefined zoom values
+page_scale_width=Mooo hayyan
+page_scale_fit=Moo sawayan
+page_scale_auto=Boŋše azzaati barmayyan
+page_scale_actual=Adadu cimi
+# LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
+# numerical scale value.
+page_scale_percent={{scale}}%
+
+loading_error=Firka bangay kaŋ PDF goo ma zumandi.
+invalid_file_error=PDF tuku laala wala laybante.
+missing_file_error=PDF tuku kumante.
+unexpected_response_error=Manti feršikaw tuuruyan maatante.
+
+rendering_error=Firka bangay kaŋ moɲoo goo ma willandi.
+
+# LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
+# "{{type}}" will be replaced with an annotation type from a list defined in
+# the PDF spec (32000-1:2008 Table 169 – Annotation types).
+# Some common types are e.g.: "Check", "Text", "Comment", "Note"
+text_annotation_type.alt={{type}} maasa-caw]
+password_label=Šennikufal dam ka PDF tukoo woo feeri.
+password_invalid=Šennikufal laalo. Ceeci koyne taare.
+password_ok=Ayyo
+password_cancel=Naŋ
+
+printing_not_supported=Yaamar: Karyan ši tee ka timme nda ceecikaa woo.
+printing_not_ready=Yaamar: PDF ši zunbu ka timme karyan še.
+web_fonts_disabled=Interneti šigirawey kay: ši hin ka goy nda PDF šigira hurantey.
+

--- a/js/pdfjs/web/locale/sq/viewer.properties
+++ b/js/pdfjs/web/locale/sq/viewer.properties
@@ -1,0 +1,247 @@
+# Copyright 2012 Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Main toolbar buttons (tooltips and alt text for images)
+previous.title=Faqja e Mëparshme
+previous_label=E mëparshmja
+next.title=Faqja Pasuese
+next_label=Pasuesja
+
+# LOCALIZATION NOTE (page.title): The tooltip for the pageNumber input.
+page.title=Faqe
+# LOCALIZATION NOTE (of_pages): "{{pagesCount}}" will be replaced by a number
+# representing the total number of pages in the document.
+of_pages=nga {{pagesCount}} gjithsej
+# LOCALIZATION NOTE (page_of_pages): "{{pageNumber}}" and "{{pagesCount}}"
+# will be replaced by a number representing the currently visible page,
+# respectively a number representing the total number of pages in the document.
+page_of_pages=({{pageNumber}} nga {{pagesCount}})
+
+zoom_out.title=Zvogëlojeni
+zoom_out_label=Zvogëlojeni
+zoom_in.title=Zmadhojeni
+zoom_in_label=Zmadhojini
+zoom.title=Zmadhim/Zvogëlim
+presentation_mode.title=Kalo te Mënyra Paraqitje
+presentation_mode_label=Mënyra Paraqitje
+open_file.title=Hapni Kartelë
+open_file_label=Hape
+print.title=Shtypje
+print_label=Shtype
+save.title=Ruaje
+save_label=Ruaje
+
+bookmark1.title=Faqja e Tanishme (Shihni URL nga Faqja e Tanishme)
+bookmark1_label=Faqja e Tanishme
+
+# Secondary toolbar and context menu
+tools.title=Mjete
+tools_label=Mjete
+first_page.title=Kaloni te Faqja e Parë
+first_page_label=Kaloni te Faqja e Parë
+last_page.title=Kaloni te Faqja e Fundit
+last_page_label=Kaloni te Faqja e Fundit
+page_rotate_cw.title=Rrotullojeni Në Kahun Orar
+page_rotate_cw_label=Rrotulloje Në Kahun Orar
+page_rotate_ccw.title=Rrotullojeni Në Kahun Kundërorar
+page_rotate_ccw_label=Rrotulloje Në Kahun Kundërorar
+
+cursor_text_select_tool.title=Aktivizo Mjet Përzgjedhjeje Teksti
+cursor_text_select_tool_label=Mjet Përzgjedhjeje Teksti
+cursor_hand_tool.title=Aktivizo Mjetin Dorë
+cursor_hand_tool_label=Mjeti Dorë
+
+scroll_page.title=Përdor Rrëshqitje Në Faqe
+scroll_page_label=Rrëshqitje Në Faqe
+scroll_vertical.title=Përdor Rrëshqitje Vertikale
+scroll_vertical_label=Rrëshqitje Vertikale
+scroll_horizontal.title=Përdor Rrëshqitje Horizontale
+scroll_horizontal_label=Rrëshqitje Horizontale
+scroll_wrapped.title=Përdor Rrëshqitje Me Mbështjellje
+scroll_wrapped_label=Rrëshqitje Me Mbështjellje
+
+
+# Document properties dialog box
+document_properties.title=Veti Dokumenti…
+document_properties_label=Veti Dokumenti…
+document_properties_file_name=Emër kartele:
+document_properties_file_size=Madhësi kartele:
+# LOCALIZATION NOTE (document_properties_kb): "{{size_kb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in kilobytes, respectively in bytes.
+document_properties_kb={{size_kb}} KB ({{size_b}} bajte)
+# LOCALIZATION NOTE (document_properties_mb): "{{size_mb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in megabytes, respectively in bytes.
+document_properties_mb={{size_mb}} MB ({{size_b}} bajte)
+document_properties_title=Titull:
+document_properties_author=Autor:
+document_properties_subject=Subjekt:
+document_properties_keywords=Fjalëkyçe:
+document_properties_creation_date=Datë Krijimi:
+document_properties_modification_date=Datë Ndryshimi:
+# LOCALIZATION NOTE (document_properties_date_string): "{{date}}" and "{{time}}"
+# will be replaced by the creation/modification date, and time, of the PDF file.
+document_properties_date_string={{date}}, {{time}}
+document_properties_creator=Krijues:
+document_properties_producer=Prodhues PDF-je:
+document_properties_version=Version PDF-je:
+document_properties_page_count=Numër Faqesh:
+document_properties_page_size=Madhësi Faqeje:
+document_properties_page_size_unit_inches=inç
+document_properties_page_size_unit_millimeters=mm
+document_properties_page_size_orientation_portrait=portret
+document_properties_page_size_orientation_landscape=së gjeri
+document_properties_page_size_name_a3=A3
+document_properties_page_size_name_a4=A4
+document_properties_page_size_name_letter=Letter
+document_properties_page_size_name_legal=Legal
+# LOCALIZATION NOTE (document_properties_page_size_dimension_string):
+# "{{width}}", "{{height}}", {{unit}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement and orientation, of the (current) page.
+document_properties_page_size_dimension_string={{width}} × {{height}} {{unit}} ({{orientation}})
+# LOCALIZATION NOTE (document_properties_page_size_dimension_name_string):
+# "{{width}}", "{{height}}", {{unit}}, {{name}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement, name, and orientation, of the (current) page.
+document_properties_page_size_dimension_name_string={{width}} × {{height}} {{unit}} ({{name}}, {{orientation}})
+# LOCALIZATION NOTE (document_properties_linearized): The linearization status of
+# the document; usually called "Fast Web View" in English locales of Adobe software.
+document_properties_linearized=Parje e Shpjetë në Web:
+document_properties_linearized_yes=Po
+document_properties_linearized_no=Jo
+document_properties_close=Mbylleni
+
+print_progress_message=Po përgatitet dokumenti për shtypje…
+# LOCALIZATION NOTE (print_progress_percent): "{{progress}}" will be replaced by
+# a numerical per cent value.
+print_progress_percent={{progress}}%
+print_progress_close=Anuloje
+
+# Tooltips and alt text for side panel toolbar buttons
+# (the _label strings are alt text for the buttons, the .title strings are
+# tooltips)
+toggle_sidebar.title=Shfaqni/Fshihni Anështyllën
+toggle_sidebar_notification2.title=Hap/Mbyll Anështylë (dokumenti përmban përvijim/nashkëngjitje/shtresa)
+toggle_sidebar_label=Shfaq/Fshih Anështyllën
+document_outline.title=Shfaqni Përvijim Dokumenti (dyklikoni që të shfaqen/fshihen krejt elementët)
+document_outline_label=Përvijim Dokumenti
+attachments.title=Shfaqni Bashkëngjitje
+attachments_label=Bashkëngjitje
+layers.title=Shfaq Shtresa (dyklikoni që të rikthehen krejt shtresat në gjendjen e tyre parazgjedhje)
+layers_label=Shtresa
+thumbs.title=Shfaqni Miniatura
+thumbs_label=Miniatura
+current_outline_item.title=Gjej Objektin e Tanishëm të Përvijuar
+current_outline_item_label=Objekt i Tanishëm i Përvijuar
+findbar.title=Gjeni në Dokument
+findbar_label=Gjej
+
+additional_layers=Shtresa Shtesë
+# LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
+page_landmark=Faqja {{page}}
+# Thumbnails panel item (tooltip and alt text for images)
+# LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
+# number.
+thumb_page_title=Faqja {{page}}
+# LOCALIZATION NOTE (thumb_page_canvas): "{{page}}" will be replaced by the page
+# number.
+thumb_page_canvas=Miniaturë e Faqes {{page}}
+
+# Find panel button title and messages
+find_input.title=Gjej
+find_input.placeholder=Gjeni në dokument…
+find_previous.title=Gjeni hasjen e mëparshme të togfjalëshit
+find_previous_label=E mëparshmja
+find_next.title=Gjeni hasjen pasuese të togfjalëshit
+find_next_label=Pasuesja
+find_highlight=Theksoji të tëra
+find_match_case_label=Siç Është Shkruar
+find_match_diacritics_label=Me Përputhje Me Shenjat Diakritike
+find_entire_word_label=Fjalë të Plota
+find_reached_top=U mbërrit në krye të dokumentit, vazhduar prej fundit
+find_reached_bottom=U mbërrit në fund të dokumentit, vazhduar prej kreut
+# LOCALIZATION NOTE (find_match_count): The supported plural forms are
+# [one|two|few|many|other], with [other] as the default value.
+# "{{current}}" and "{{total}}" will be replaced by a number representing the
+# index of the currently active find result, respectively a number representing
+# the total number of matches in the document.
+find_match_count={[ plural(total) ]}
+find_match_count[one]={{current}} nga {{total}} përputhje gjithsej
+find_match_count[two]={{current}} nga {{total}} përputhje gjithsej
+find_match_count[few]={{current}} nga {{total}} përputhje gjithsej
+find_match_count[many]={{current}} nga {{total}} përputhje gjithsej
+find_match_count[other]={{current}} nga {{total}} përputhje gjithsej
+# LOCALIZATION NOTE (find_match_count_limit): The supported plural forms are
+# [zero|one|two|few|many|other], with [other] as the default value.
+# "{{limit}}" will be replaced by a numerical value.
+find_match_count_limit={[ plural(limit) ]}
+find_match_count_limit[zero]=Më shumë se {{limit}} përputhje
+find_match_count_limit[one]=Më shumë se {{limit}} përputhje
+find_match_count_limit[two]=Më shumë se {{limit}} përputhje
+find_match_count_limit[few]=Më shumë se {{limit}} përputhje
+find_match_count_limit[many]=Më shumë se {{limit}} përputhje
+find_match_count_limit[other]=Më shumë se {{limit}} përputhje
+find_not_found=Togfjalësh që s’gjendet
+
+# Predefined zoom values
+page_scale_width=Gjerësi Faqeje
+page_scale_fit=Sa Nxë Faqja
+page_scale_auto=Zoom i Vetvetishëm
+page_scale_actual=Madhësia Faktike
+# LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
+# numerical scale value.
+page_scale_percent={{scale}}%
+
+loading_error=Ndodhi një gabim gjatë ngarkimit të PDF-së.
+invalid_file_error=Kartelë PDF e pavlefshme ose e dëmtuar.
+missing_file_error=Kartelë PDF që mungon.
+unexpected_response_error=Përgjigje shërbyesi e papritur.
+
+rendering_error=Ndodhi një gabim gjatë riprodhimit të faqes.
+
+# LOCALIZATION NOTE (annotation_date_string): "{{date}}" and "{{time}}" will be
+# replaced by the modification date, and time, of the annotation.
+annotation_date_string={{date}}, {{time}}
+
+# LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
+# "{{type}}" will be replaced with an annotation type from a list defined in
+# the PDF spec (32000-1:2008 Table 169 – Annotation types).
+# Some common types are e.g.: "Check", "Text", "Comment", "Note"
+text_annotation_type.alt=[Nënvizim {{type}}]
+password_label=Jepni fjalëkalimin që të hapet kjo kartelë PDF.
+password_invalid=Fjalëkalim i pavlefshëm. Ju lutemi, riprovoni.
+password_ok=OK
+password_cancel=Anuloje
+
+printing_not_supported=Kujdes: Shtypja s’mbulohet plotësisht nga ky shfletues.
+printing_not_ready=Kujdes: PDF-ja s’është ngarkuar plotësisht që ta shtypni.
+web_fonts_disabled=Shkronjat Web janë të çaktivizuara: s’arrihet të përdoren shkronja të trupëzuara në PDF.
+
+# Editor
+editor_free_text2.title=Tekst
+editor_free_text2_label=Tekst
+editor_ink2.title=Vizatoni
+editor_ink2_label=Vizatoni
+
+free_text2_default_content=Filloni të shtypni…
+
+# Editor Parameters
+editor_free_text_color=Ngjyrë
+editor_free_text_size=Madhësi
+editor_ink_color=Ngjyrë
+editor_ink_thickness=Trashësi
+editor_ink_opacity=Patejdukshmëri
+
+# Editor aria
+editor_free_text2_aria_label=Përpunues Tekstesh
+editor_ink2_aria_label=Përpunues Vizatimesh
+editor_ink_canvas_aria_label=Figurë e krijuar nga përdoruesi

--- a/js/pdfjs/web/locale/sr/viewer.properties
+++ b/js/pdfjs/web/locale/sr/viewer.properties
@@ -1,0 +1,259 @@
+# Copyright 2012 Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Main toolbar buttons (tooltips and alt text for images)
+previous.title=Претходна страница
+previous_label=Претходна
+next.title=Следећа страница
+next_label=Следећа
+
+# LOCALIZATION NOTE (page.title): The tooltip for the pageNumber input.
+page.title=Страница
+# LOCALIZATION NOTE (of_pages): "{{pagesCount}}" will be replaced by a number
+# representing the total number of pages in the document.
+of_pages=од {{pagesCount}}
+# LOCALIZATION NOTE (page_of_pages): "{{pageNumber}}" and "{{pagesCount}}"
+# will be replaced by a number representing the currently visible page,
+# respectively a number representing the total number of pages in the document.
+page_of_pages=({{pageNumber}} од {{pagesCount}})
+
+zoom_out.title=Умањи
+zoom_out_label=Умањи
+zoom_in.title=Увеличај
+zoom_in_label=Увеличај
+zoom.title=Увеличавање
+presentation_mode.title=Промени на приказ у режиму презентације
+presentation_mode_label=Режим презентације
+open_file.title=Отвори датотеку
+open_file_label=Отвори
+print.title=Штампај
+print_label=Штампај
+
+save.title=Сачувај
+save_label=Сачувај
+bookmark1.title=Тренутна страница (погледајте URL са тренутне странице)
+bookmark1_label=Тренутна страница
+
+# LOCALIZATION NOTE (open_in_app.title): This string is used in Firefox for Android.
+open_in_app.title=Отвори у апликацији
+# LOCALIZATION NOTE (open_in_app_label): This string is used in Firefox for Android. Length of the translation matters since we are in a mobile context, with limited screen estate.
+open_in_app_label=Отвори у апликацији
+
+# Secondary toolbar and context menu
+tools.title=Алатке
+tools_label=Алатке
+first_page.title=Иди на прву страницу
+first_page_label=Иди на прву страницу
+last_page.title=Иди на последњу страницу
+last_page_label=Иди на последњу страницу
+page_rotate_cw.title=Ротирај у смеру казаљке на сату
+page_rotate_cw_label=Ротирај у смеру казаљке на сату
+page_rotate_ccw.title=Ротирај у смеру супротном од казаљке на сату
+page_rotate_ccw_label=Ротирај у смеру супротном од казаљке на сату
+
+cursor_text_select_tool.title=Омогући алат за селектовање текста
+cursor_text_select_tool_label=Алат за селектовање текста
+cursor_hand_tool.title=Омогући алат за померање
+cursor_hand_tool_label=Алат за померање
+
+scroll_page.title=Користи скроловање по омоту
+scroll_page_label=Скроловање странице
+scroll_vertical.title=Користи вертикално скроловање
+scroll_vertical_label=Вертикално скроловање
+scroll_horizontal.title=Користи хоризонтално скроловање
+scroll_horizontal_label=Хоризонтално скроловање
+scroll_wrapped.title=Користи скроловање по омоту
+scroll_wrapped_label=Скроловање по омоту
+
+spread_none.title=Немој спајати ширења страница
+spread_none_label=Без распростирања
+spread_odd.title=Споји ширења страница које почињу непарним бројем
+spread_odd_label=Непарна распростирања
+spread_even.title=Споји ширења страница које почињу парним бројем
+spread_even_label=Парна распростирања
+
+# Document properties dialog box
+document_properties.title=Параметри документа…
+document_properties_label=Параметри документа…
+document_properties_file_name=Име датотеке:
+document_properties_file_size=Величина датотеке:
+# LOCALIZATION NOTE (document_properties_kb): "{{size_kb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in kilobytes, respectively in bytes.
+document_properties_kb={{size_kb}} KB ({{size_b}} B)
+# LOCALIZATION NOTE (document_properties_mb): "{{size_mb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in megabytes, respectively in bytes.
+document_properties_mb={{size_mb}} MB ({{size_b}} B)
+document_properties_title=Наслов:
+document_properties_author=Аутор:
+document_properties_subject=Тема:
+document_properties_keywords=Кључне речи:
+document_properties_creation_date=Датум креирања:
+document_properties_modification_date=Датум модификације:
+# LOCALIZATION NOTE (document_properties_date_string): "{{date}}" and "{{time}}"
+# will be replaced by the creation/modification date, and time, of the PDF file.
+document_properties_date_string={{date}}, {{time}}
+document_properties_creator=Стваралац:
+document_properties_producer=PDF произвођач:
+document_properties_version=PDF верзија:
+document_properties_page_count=Број страница:
+document_properties_page_size=Величина странице:
+document_properties_page_size_unit_inches=ин
+document_properties_page_size_unit_millimeters=мм
+document_properties_page_size_orientation_portrait=усправно
+document_properties_page_size_orientation_landscape=водоравно
+document_properties_page_size_name_a3=А3
+document_properties_page_size_name_a4=А4
+document_properties_page_size_name_letter=Слово
+document_properties_page_size_name_legal=Права
+# LOCALIZATION NOTE (document_properties_page_size_dimension_string):
+# "{{width}}", "{{height}}", {{unit}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement and orientation, of the (current) page.
+document_properties_page_size_dimension_string={{width}} × {{height}} {{unit}} ({{orientation}})
+# LOCALIZATION NOTE (document_properties_page_size_dimension_name_string):
+# "{{width}}", "{{height}}", {{unit}}, {{name}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement, name, and orientation, of the (current) page.
+document_properties_page_size_dimension_name_string={{width}} × {{height}} {{unit}} ({{name}}, {{orientation}})
+# LOCALIZATION NOTE (document_properties_linearized): The linearization status of
+# the document; usually called "Fast Web View" in English locales of Adobe software.
+document_properties_linearized=Брз веб приказ:
+document_properties_linearized_yes=Да
+document_properties_linearized_no=Не
+document_properties_close=Затвори
+
+print_progress_message=Припремам документ за штампање…
+# LOCALIZATION NOTE (print_progress_percent): "{{progress}}" will be replaced by
+# a numerical per cent value.
+print_progress_percent={{progress}}%
+print_progress_close=Откажи
+
+# Tooltips and alt text for side panel toolbar buttons
+# (the _label strings are alt text for the buttons, the .title strings are
+# tooltips)
+toggle_sidebar.title=Прикажи додатну палету
+toggle_sidebar_notification2.title=Прикажи/сакриј бочну траку (документ садржи контуру/прилоге/слојеве)
+toggle_sidebar_label=Прикажи додатну палету
+document_outline.title=Прикажи структуру документа (двоструким кликом проширујете/скупљате све ставке)
+document_outline_label=Контура документа
+attachments.title=Прикажи прилоге
+attachments_label=Прилози
+layers.title=Прикажи слојеве (дупли клик за враћање свих слојева у подразумевано стање)
+layers_label=Слојеви
+thumbs.title=Прикажи сличице
+thumbs_label=Сличице
+current_outline_item.title=Пронађите тренутни елемент структуре
+current_outline_item_label=Тренутна контура
+findbar.title=Пронађи у документу
+findbar_label=Пронађи
+
+additional_layers=Додатни слојеви
+# LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
+page_landmark=Страница {{page}}
+# Thumbnails panel item (tooltip and alt text for images)
+# LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
+# number.
+thumb_page_title=Страница {{page}}
+# LOCALIZATION NOTE (thumb_page_canvas): "{{page}}" will be replaced by the page
+# number.
+thumb_page_canvas=Сличица од странице {{page}}
+
+# Find panel button title and messages
+find_input.title=Пронађи
+find_input.placeholder=Пронађи у документу…
+find_previous.title=Пронађи претходно појављивање фразе
+find_previous_label=Претходна
+find_next.title=Пронађи следеће појављивање фразе
+find_next_label=Следећа
+find_highlight=Истакнути све
+find_match_case_label=Подударања
+find_match_diacritics_label=Дијакритика
+find_entire_word_label=Целе речи
+find_reached_top=Достигнут врх документа, наставио са дна
+find_reached_bottom=Достигнуто дно документа, наставио са врха
+# LOCALIZATION NOTE (find_match_count): The supported plural forms are
+# [one|two|few|many|other], with [other] as the default value.
+# "{{current}}" and "{{total}}" will be replaced by a number representing the
+# index of the currently active find result, respectively a number representing
+# the total number of matches in the document.
+find_match_count={[ plural(total) ]}
+find_match_count[one]={{current}} од {{total}} одговара
+find_match_count[two]={{current}} од {{total}} одговара
+find_match_count[few]={{current}} од {{total}} одговара
+find_match_count[many]={{current}} од {{total}} одговара
+find_match_count[other]={{current}} од {{total}} одговара
+# LOCALIZATION NOTE (find_match_count_limit): The supported plural forms are
+# [zero|one|two|few|many|other], with [other] as the default value.
+# "{{limit}}" will be replaced by a numerical value.
+find_match_count_limit={[ plural(limit) ]}
+find_match_count_limit[zero]=Више од {{limit}} одговара
+find_match_count_limit[one]=Више од {{limit}} одговара
+find_match_count_limit[two]=Више од {{limit}} одговара
+find_match_count_limit[few]=Више од {{limit}} одговара
+find_match_count_limit[many]=Више од {{limit}} одговара
+find_match_count_limit[other]=Више од {{limit}} одговара
+find_not_found=Фраза није пронађена
+
+# Predefined zoom values
+page_scale_width=Ширина странице
+page_scale_fit=Прилагоди страницу
+page_scale_auto=Аутоматско увеличавање
+page_scale_actual=Стварна величина
+# LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
+# numerical scale value.
+page_scale_percent={{scale}}%
+
+# Loading indicator messages
+loading_error=Дошло је до грешке приликом учитавања PDF-а.
+invalid_file_error=PDF датотека је неважећа или је оштећена.
+missing_file_error=Недостаје PDF датотека.
+unexpected_response_error=Неочекиван одговор од сервера.
+
+rendering_error=Дошло је до грешке приликом рендеровања ове странице.
+
+# LOCALIZATION NOTE (annotation_date_string): "{{date}}" and "{{time}}" will be
+# replaced by the modification date, and time, of the annotation.
+annotation_date_string={{date}}, {{time}}
+
+# LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
+# "{{type}}" will be replaced with an annotation type from a list defined in
+# the PDF spec (32000-1:2008 Table 169 – Annotation types).
+# Some common types are e.g.: "Check", "Text", "Comment", "Note"
+text_annotation_type.alt=[{{type}} коментар]
+password_label=Унесите лозинку да бисте отворили овај PDF докуменат.
+password_invalid=Неисправна лозинка. Покушајте поново.
+password_ok=У реду
+password_cancel=Откажи
+
+printing_not_supported=Упозорење: Штампање није у потпуности подржано у овом прегледачу.
+printing_not_ready=Упозорење: PDF није у потпуности учитан за штампу.
+web_fonts_disabled=Веб фонтови су онемогућени: не могу користити уграђене PDF фонтове.
+
+# Editor
+editor_free_text2.title=Текст
+editor_free_text2_label=Текст
+editor_ink2.title=Цртај
+editor_ink2_label=Цртај
+
+free_text2_default_content=Почни куцање…
+
+# Editor Parameters
+editor_free_text_color=Боја
+editor_free_text_size=Величина
+editor_ink_color=Боја
+editor_ink_thickness=Дебљина
+editor_ink_opacity=Опацитет
+
+# Editor aria
+editor_free_text2_aria_label=Уређивач текста
+editor_ink2_aria_label=Уређивач цртежа
+editor_ink_canvas_aria_label=Кориснички направљена слика

--- a/js/pdfjs/web/locale/sv-SE/viewer.properties
+++ b/js/pdfjs/web/locale/sv-SE/viewer.properties
@@ -1,0 +1,259 @@
+# Copyright 2012 Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Main toolbar buttons (tooltips and alt text for images)
+previous.title=Föregående sida
+previous_label=Föregående
+next.title=Nästa sida
+next_label=Nästa
+
+# LOCALIZATION NOTE (page.title): The tooltip for the pageNumber input.
+page.title=Sida
+# LOCALIZATION NOTE (of_pages): "{{pagesCount}}" will be replaced by a number
+# representing the total number of pages in the document.
+of_pages=av {{pagesCount}}
+# LOCALIZATION NOTE (page_of_pages): "{{pageNumber}}" and "{{pagesCount}}"
+# will be replaced by a number representing the currently visible page,
+# respectively a number representing the total number of pages in the document.
+page_of_pages=({{pageNumber}} av {{pagesCount}})
+
+zoom_out.title=Zooma ut
+zoom_out_label=Zooma ut
+zoom_in.title=Zooma in
+zoom_in_label=Zooma in
+zoom.title=Zoom
+presentation_mode.title=Byt till presentationsläge
+presentation_mode_label=Presentationsläge
+open_file.title=Öppna fil
+open_file_label=Öppna
+print.title=Skriv ut
+print_label=Skriv ut
+save.title=Spara
+save_label=Spara
+bookmark1.title=Aktuell sida (Visa URL från aktuell sida)
+bookmark1_label=Aktuell sida
+# LOCALIZATION NOTE (open_in_app.title): This string is used in Firefox for Android.
+open_in_app.title=Öppna i app
+# LOCALIZATION NOTE (open_in_app_label): This string is used in Firefox for Android. Length of the translation matters since we are in a mobile context, with limited screen estate.
+open_in_app_label=Öppna i app
+
+# Secondary toolbar and context menu
+tools.title=Verktyg
+tools_label=Verktyg
+first_page.title=Gå till första sidan
+first_page_label=Gå till första sidan
+last_page.title=Gå till sista sidan
+last_page_label=Gå till sista sidan
+page_rotate_cw.title=Rotera medurs
+page_rotate_cw_label=Rotera medurs
+page_rotate_ccw.title=Rotera moturs
+page_rotate_ccw_label=Rotera moturs
+
+cursor_text_select_tool.title=Aktivera textmarkeringsverktyg
+cursor_text_select_tool_label=Textmarkeringsverktyg
+cursor_hand_tool.title=Aktivera handverktyg
+cursor_hand_tool_label=Handverktyg
+
+scroll_page.title=Använd sidrullning
+scroll_page_label=Sidrullning
+scroll_vertical.title=Använd vertikal rullning
+scroll_vertical_label=Vertikal rullning
+scroll_horizontal.title=Använd horisontell rullning
+scroll_horizontal_label=Horisontell rullning
+scroll_wrapped.title=Använd överlappande rullning
+scroll_wrapped_label=Överlappande rullning
+
+spread_none.title=Visa enkelsidor
+spread_none_label=Enkelsidor
+spread_odd.title=Visa uppslag med olika sidnummer till vänster
+spread_odd_label=Uppslag med framsida
+spread_even.title=Visa uppslag med lika sidnummer till vänster
+spread_even_label=Uppslag utan framsida
+
+# Document properties dialog box
+document_properties.title=Dokumentegenskaper…
+document_properties_label=Dokumentegenskaper…
+document_properties_file_name=Filnamn:
+document_properties_file_size=Filstorlek:
+# LOCALIZATION NOTE (document_properties_kb): "{{size_kb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in kilobytes, respectively in bytes.
+document_properties_kb={{size_kb}} kB ({{size_b}} byte)
+# LOCALIZATION NOTE (document_properties_mb): "{{size_mb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in megabytes, respectively in bytes.
+document_properties_mb={{size_mb}} MB ({{size_b}} byte)
+document_properties_title=Titel:
+document_properties_author=Författare:
+document_properties_subject=Ämne:
+document_properties_keywords=Nyckelord:
+document_properties_creation_date=Skapades:
+document_properties_modification_date=Ändrades:
+# LOCALIZATION NOTE (document_properties_date_string): "{{date}}" and "{{time}}"
+# will be replaced by the creation/modification date, and time, of the PDF file.
+document_properties_date_string={{date}}, {{time}}
+document_properties_creator=Skapare:
+document_properties_producer=PDF-producent:
+document_properties_version=PDF-version:
+document_properties_page_count=Sidantal:
+document_properties_page_size=Pappersstorlek:
+document_properties_page_size_unit_inches=in
+document_properties_page_size_unit_millimeters=mm
+document_properties_page_size_orientation_portrait=porträtt
+document_properties_page_size_orientation_landscape=landskap
+document_properties_page_size_name_a3=A3
+document_properties_page_size_name_a4=A4
+document_properties_page_size_name_letter=Letter
+document_properties_page_size_name_legal=Legal
+# LOCALIZATION NOTE (document_properties_page_size_dimension_string):
+# "{{width}}", "{{height}}", {{unit}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement and orientation, of the (current) page.
+document_properties_page_size_dimension_string={{width}} × {{height}} {{unit}} ({{orientation}})
+# LOCALIZATION NOTE (document_properties_page_size_dimension_name_string):
+# "{{width}}", "{{height}}", {{unit}}, {{name}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement, name, and orientation, of the (current) page.
+document_properties_page_size_dimension_name_string={{width}} × {{height}} {{unit}} ({{name}}, {{orientation}})
+# LOCALIZATION NOTE (document_properties_linearized): The linearization status of
+# the document; usually called "Fast Web View" in English locales of Adobe software.
+document_properties_linearized=Snabb webbvisning:
+document_properties_linearized_yes=Ja
+document_properties_linearized_no=Nej
+document_properties_close=Stäng
+
+print_progress_message=Förbereder sidor för utskrift…
+# LOCALIZATION NOTE (print_progress_percent): "{{progress}}" will be replaced by
+# a numerical per cent value.
+print_progress_percent={{progress}}%
+print_progress_close=Avbryt
+
+# Tooltips and alt text for side panel toolbar buttons
+# (the _label strings are alt text for the buttons, the .title strings are
+# tooltips)
+toggle_sidebar.title=Visa/dölj sidofält
+toggle_sidebar_notification2.title=Växla sidofält (dokumentet innehåller dokumentstruktur/bilagor/lager)
+toggle_sidebar_label=Visa/dölj sidofält
+document_outline.title=Visa dokumentdisposition (dubbelklicka för att expandera/komprimera alla objekt)
+document_outline_label=Dokumentöversikt
+attachments.title=Visa Bilagor
+attachments_label=Bilagor
+layers.title=Visa lager (dubbelklicka för att återställa alla lager till standardläge)
+layers_label=Lager
+thumbs.title=Visa miniatyrer
+thumbs_label=Miniatyrer
+current_outline_item.title=Hitta aktuellt dispositionsobjekt
+current_outline_item_label=Aktuellt dispositionsobjekt
+findbar.title=Sök i dokument
+findbar_label=Sök
+
+additional_layers=Ytterligare lager
+# LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
+page_landmark=Sida {{page}}
+# Thumbnails panel item (tooltip and alt text for images)
+# LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
+# number.
+thumb_page_title=Sida {{page}}
+# LOCALIZATION NOTE (thumb_page_canvas): "{{page}}" will be replaced by the page
+# number.
+thumb_page_canvas=Miniatyr av sida {{page}}
+
+# Find panel button title and messages
+find_input.title=Sök
+find_input.placeholder=Sök i dokument…
+find_previous.title=Hitta föregående förekomst av frasen
+find_previous_label=Föregående
+find_next.title=Hitta nästa förekomst av frasen
+find_next_label=Nästa
+find_highlight=Markera alla
+find_match_case_label=Matcha versal/gemen
+find_match_diacritics_label=Matcha diakritiska tecken
+find_entire_word_label=Hela ord
+find_reached_top=Nådde början av dokumentet, började från slutet
+find_reached_bottom=Nådde slutet på dokumentet, började från början
+# LOCALIZATION NOTE (find_match_count): The supported plural forms are
+# [one|two|few|many|other], with [other] as the default value.
+# "{{current}}" and "{{total}}" will be replaced by a number representing the
+# index of the currently active find result, respectively a number representing
+# the total number of matches in the document.
+find_match_count={[ plural(total) ]}
+find_match_count[one]={{current}} av {{total}} träff
+find_match_count[two]={{current}} av {{total}} träffar
+find_match_count[few]={{current}} av {{total}} träffar
+find_match_count[many]={{current}} av {{total}} träffar
+find_match_count[other]={{current}} av {{total}} träffar
+# LOCALIZATION NOTE (find_match_count_limit): The supported plural forms are
+# [zero|one|two|few|many|other], with [other] as the default value.
+# "{{limit}}" will be replaced by a numerical value.
+find_match_count_limit={[ plural(limit) ]}
+find_match_count_limit[zero]=Mer än {{limit}} träffar
+find_match_count_limit[one]=Mer än {{limit}} träff
+find_match_count_limit[two]=Mer än {{limit}} träffar
+find_match_count_limit[few]=Mer än {{limit}} träffar
+find_match_count_limit[many]=Mer än {{limit}} träffar
+find_match_count_limit[other]=Mer än {{limit}} träffar
+find_not_found=Frasen hittades inte
+
+# Predefined zoom values
+page_scale_width=Sidbredd
+page_scale_fit=Anpassa sida
+page_scale_auto=Automatisk zoom
+page_scale_actual=Verklig storlek
+# LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
+# numerical scale value.
+page_scale_percent={{scale}}%
+
+# Loading indicator messages
+loading_error=Ett fel uppstod vid laddning av PDF-filen.
+invalid_file_error=Ogiltig eller korrupt PDF-fil.
+missing_file_error=Saknad PDF-fil.
+unexpected_response_error=Oväntat svar från servern.
+rendering_error=Ett fel uppstod vid visning av sidan.
+
+# LOCALIZATION NOTE (annotation_date_string): "{{date}}" and "{{time}}" will be
+# replaced by the modification date, and time, of the annotation.
+annotation_date_string={{date}} {{time}}
+
+# LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
+# "{{type}}" will be replaced with an annotation type from a list defined in
+# the PDF spec (32000-1:2008 Table 169 – Annotation types).
+# Some common types are e.g.: "Check", "Text", "Comment", "Note"
+text_annotation_type.alt=[{{type}}-annotering]
+password_label=Skriv in lösenordet för att öppna PDF-filen.
+password_invalid=Ogiltigt lösenord. Försök igen.
+password_ok=OK
+password_cancel=Avbryt
+
+printing_not_supported=Varning: Utskrifter stöds inte helt av den här webbläsaren.
+printing_not_ready=Varning: PDF:en är inte klar för utskrift.
+web_fonts_disabled=Webbtypsnitt är inaktiverade: kan inte använda inbäddade PDF-typsnitt.
+
+# Editor
+editor_free_text2.title=Text
+editor_free_text2_label=Text
+editor_ink2.title=Rita
+editor_ink2_label=Rita
+
+editor_stamp.title=Lägg till en bild
+editor_stamp_label=Lägg till en bild
+
+free_text2_default_content=Börja skriva…
+
+# Editor Parameters
+editor_free_text_color=Färg
+editor_free_text_size=Storlek
+editor_ink_color=Färg
+editor_ink_thickness=Tjocklek
+editor_ink_opacity=Opacitet
+
+# Editor aria
+editor_free_text2_aria_label=Textredigerare
+editor_ink2_aria_label=Ritredigerare
+editor_ink_canvas_aria_label=Användarskapad bild

--- a/js/pdfjs/web/locale/szl/viewer.properties
+++ b/js/pdfjs/web/locale/szl/viewer.properties
@@ -1,0 +1,224 @@
+# Copyright 2012 Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Main toolbar buttons (tooltips and alt text for images)
+previous.title=Piyrwyjszo strōna
+previous_label=Piyrwyjszo
+next.title=Nastympno strōna
+next_label=Dalij
+
+# LOCALIZATION NOTE (page.title): The tooltip for the pageNumber input.
+page.title=Strōna
+# LOCALIZATION NOTE (of_pages): "{{pagesCount}}" will be replaced by a number
+# representing the total number of pages in the document.
+of_pages=ze {{pagesCount}}
+# LOCALIZATION NOTE (page_of_pages): "{{pageNumber}}" and "{{pagesCount}}"
+# will be replaced by a number representing the currently visible page,
+# respectively a number representing the total number of pages in the document.
+page_of_pages=({{pageNumber}} ze {{pagesCount}})
+
+zoom_out.title=Zmyńsz
+zoom_out_label=Zmyńsz
+zoom_in.title=Zwiynksz
+zoom_in_label=Zwiynksz
+zoom.title=Srogość
+presentation_mode.title=Przełōncz na tryb prezyntacyje
+presentation_mode_label=Tryb prezyntacyje
+open_file.title=Ôdewrzij zbiōr
+open_file_label=Ôdewrzij
+print.title=Durkuj
+print_label=Durkuj
+
+# Secondary toolbar and context menu
+tools.title=Noczynia
+tools_label=Noczynia
+first_page.title=Idź ku piyrszyj strōnie
+first_page_label=Idź ku piyrszyj strōnie
+last_page.title=Idź ku ôstatnij strōnie
+last_page_label=Idź ku ôstatnij strōnie
+page_rotate_cw.title=Zwyrtnij w prawo
+page_rotate_cw_label=Zwyrtnij w prawo
+page_rotate_ccw.title=Zwyrtnij w lewo
+page_rotate_ccw_label=Zwyrtnij w lewo
+
+cursor_text_select_tool.title=Załōncz noczynie ôbiyranio tekstu
+cursor_text_select_tool_label=Noczynie ôbiyranio tekstu
+cursor_hand_tool.title=Załōncz noczynie rōnczka
+cursor_hand_tool_label=Noczynie rōnczka
+
+scroll_vertical.title=Używej piōnowego przewijanio
+scroll_vertical_label=Piōnowe przewijanie
+scroll_horizontal.title=Używej poziōmego przewijanio
+scroll_horizontal_label=Poziōme przewijanie
+scroll_wrapped.title=Używej szichtowego przewijanio
+scroll_wrapped_label=Szichtowe przewijanie
+
+spread_none.title=Niy dowej strōn w widoku po dwie
+spread_none_label=Po jednyj strōnie
+spread_odd.title=Pokoż strōny po dwie; niyporziste po lewyj
+spread_odd_label=Niyporziste po lewyj
+spread_even.title=Pokoż strōny po dwie; porziste po lewyj
+spread_even_label=Porziste po lewyj
+
+# Document properties dialog box
+document_properties.title=Włosności dokumyntu…
+document_properties_label=Włosności dokumyntu…
+document_properties_file_name=Miano zbioru:
+document_properties_file_size=Srogość zbioru:
+# LOCALIZATION NOTE (document_properties_kb): "{{size_kb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in kilobytes, respectively in bytes.
+document_properties_kb={{size_kb}} KB ({{size_b}} B)
+# LOCALIZATION NOTE (document_properties_mb): "{{size_mb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in megabytes, respectively in bytes.
+document_properties_mb={{size_mb}} MB ({{size_b}} B)
+document_properties_title=Tytuł:
+document_properties_author=Autōr:
+document_properties_subject=Tymat:
+document_properties_keywords=Kluczowe słowa:
+document_properties_creation_date=Data zrychtowanio:
+document_properties_modification_date=Data zmiany:
+# LOCALIZATION NOTE (document_properties_date_string): "{{date}}" and "{{time}}"
+# will be replaced by the creation/modification date, and time, of the PDF file.
+document_properties_date_string={{date}}, {{time}}
+document_properties_creator=Zrychtowane ôd:
+document_properties_producer=PDF ôd:
+document_properties_version=Wersyjo PDF:
+document_properties_page_count=Wielość strōn:
+document_properties_page_size=Srogość strōny:
+document_properties_page_size_unit_inches=in
+document_properties_page_size_unit_millimeters=mm
+document_properties_page_size_orientation_portrait=piōnowo
+document_properties_page_size_orientation_landscape=poziōmo
+document_properties_page_size_name_a3=A3
+document_properties_page_size_name_a4=A4
+document_properties_page_size_name_letter=Letter
+document_properties_page_size_name_legal=Legal
+# LOCALIZATION NOTE (document_properties_page_size_dimension_string):
+# "{{width}}", "{{height}}", {{unit}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement and orientation, of the (current) page.
+document_properties_page_size_dimension_string={{width}} × {{height}} {{unit}} ({{orientation}})
+# LOCALIZATION NOTE (document_properties_page_size_dimension_name_string):
+# "{{width}}", "{{height}}", {{unit}}, {{name}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement, name, and orientation, of the (current) page.
+document_properties_page_size_dimension_name_string={{width}} × {{height}} {{unit}} ({{name}}, {{orientation}})
+# LOCALIZATION NOTE (document_properties_linearized): The linearization status of
+# the document; usually called "Fast Web View" in English locales of Adobe software.
+document_properties_linearized=Gibki necowy podglōnd:
+document_properties_linearized_yes=Ja
+document_properties_linearized_no=Niy
+document_properties_close=Zawrzij
+
+print_progress_message=Rychtowanie dokumyntu do durku…
+# LOCALIZATION NOTE (print_progress_percent): "{{progress}}" will be replaced by
+# a numerical per cent value.
+print_progress_percent={{progress}}%
+print_progress_close=Pociep
+
+# Tooltips and alt text for side panel toolbar buttons
+# (the _label strings are alt text for the buttons, the .title strings are
+# tooltips)
+toggle_sidebar.title=Przełōncz posek na rancie
+toggle_sidebar_notification2.title=Przełōncz posek na rancie (dokumynt mo struktura/przidowki/warstwy)
+toggle_sidebar_label=Przełōncz posek na rancie
+document_outline.title=Pokoż struktura dokumyntu (tuplowane klikniyncie rozszyrzo/swijo wszyskie elymynta)
+document_outline_label=Struktura dokumyntu
+attachments.title=Pokoż przidowki
+attachments_label=Przidowki
+layers.title=Pokoż warstwy (tuplowane klikniyncie resetuje wszyskie warstwy do bazowego stanu)
+layers_label=Warstwy
+thumbs.title=Pokoż miniatury
+thumbs_label=Miniatury
+findbar.title=Znojdź w dokumyncie
+findbar_label=Znojdź
+
+additional_layers=Nadbytnie warstwy
+# LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
+# Thumbnails panel item (tooltip and alt text for images)
+# LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
+# number.
+thumb_page_title=Strōna {{page}}
+# LOCALIZATION NOTE (thumb_page_canvas): "{{page}}" will be replaced by the page
+# number.
+thumb_page_canvas=Miniatura strōny {{page}}
+
+# Find panel button title and messages
+find_input.title=Znojdź
+find_input.placeholder=Znojdź w dokumyncie…
+find_previous.title=Znojdź piyrwyjsze pokozanie sie tyj frazy
+find_previous_label=Piyrwyjszo
+find_next.title=Znojdź nastympne pokozanie sie tyj frazy
+find_next_label=Dalij
+find_highlight=Zaznacz wszysko
+find_match_case_label=Poznowej srogość liter
+find_entire_word_label=Cołke słowa
+find_reached_top=Doszło do samego wiyrchu strōny, dalij ôd spodku
+find_reached_bottom=Doszło do samego spodku strōny, dalij ôd wiyrchu
+# LOCALIZATION NOTE (find_match_count): The supported plural forms are
+# [one|two|few|many|other], with [other] as the default value.
+# "{{current}}" and "{{total}}" will be replaced by a number representing the
+# index of the currently active find result, respectively a number representing
+# the total number of matches in the document.
+find_match_count={[ plural(total) ]}
+find_match_count[one]={{current}} ze {{total}}, co pasujōm
+find_match_count[two]={{current}} ze {{total}}, co pasujōm
+find_match_count[few]={{current}} ze {{total}}, co pasujōm
+find_match_count[many]={{current}} ze {{total}}, co pasujōm
+find_match_count[other]={{current}} ze {{total}}, co pasujōm
+# LOCALIZATION NOTE (find_match_count_limit): The supported plural forms are
+# [zero|one|two|few|many|other], with [other] as the default value.
+# "{{limit}}" will be replaced by a numerical value.
+find_match_count_limit={[ plural(total) ]}
+find_match_count_limit[zero]=Wiyncyj jak {{limit}}, co pasujōm
+find_match_count_limit[one]=Wiyncyj jak {{limit}}, co pasuje
+find_match_count_limit[two]=Wiyncyj jak {{limit}}, co pasujōm
+find_match_count_limit[few]=Wiyncyj jak {{limit}}, co pasujōm
+find_match_count_limit[many]=Wiyncyj jak {{limit}}, co pasujōm
+find_match_count_limit[other]=Wiyncyj jak {{limit}}, co pasujōm
+find_not_found=Fraza niy znaleziōno
+
+# Predefined zoom values
+page_scale_width=Szyrzka strōny
+page_scale_fit=Napasowanie strōny
+page_scale_auto=Autōmatyczno srogość
+page_scale_actual=Aktualno srogość
+# LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
+# numerical scale value.
+page_scale_percent={{scale}}%
+
+# Loading indicator messages
+loading_error=Przi ladowaniu PDFa pokozoł sie feler.
+invalid_file_error=Zły abo felerny zbiōr PDF.
+missing_file_error=Chybio zbioru PDF.
+unexpected_response_error=Niyôczekowano ôdpowiydź serwera.
+
+rendering_error=Przi renderowaniu strōny pokozoł sie feler.
+
+# LOCALIZATION NOTE (annotation_date_string): "{{date}}" and "{{time}}" will be
+# replaced by the modification date, and time, of the annotation.
+annotation_date_string={{date}}, {{time}}
+
+# LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
+# "{{type}}" will be replaced with an annotation type from a list defined in
+# the PDF spec (32000-1:2008 Table 169 – Annotation types).
+# Some common types are e.g.: "Check", "Text", "Comment", "Note"
+text_annotation_type.alt=[Anotacyjo typu {{type}}]
+password_label=Wkludź hasło, coby ôdewrzić tyn zbiōr PDF.
+password_invalid=Hasło je złe. Sprōbuj jeszcze roz.
+password_ok=OK
+password_cancel=Pociep
+
+printing_not_supported=Pozōr: Ta przeglōndarka niy cołkiym ôbsuguje durk.
+printing_not_ready=Pozōr: Tyn PDF niy ma za tela zaladowany do durku.
+web_fonts_disabled=Necowe fōnty sōm zastawiōne: niy idzie użyć wkludzōnych fōntōw PDF.
+

--- a/js/pdfjs/web/locale/ta/viewer.properties
+++ b/js/pdfjs/web/locale/ta/viewer.properties
@@ -1,0 +1,173 @@
+# Copyright 2012 Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Main toolbar buttons (tooltips and alt text for images)
+previous.title=முந்தைய பக்கம்
+previous_label=முந்தையது
+next.title=அடுத்த பக்கம்
+next_label=அடுத்து
+
+# LOCALIZATION NOTE (page.title): The tooltip for the pageNumber input.
+page.title=பக்கம்
+# LOCALIZATION NOTE (of_pages): "{{pagesCount}}" will be replaced by a number
+# representing the total number of pages in the document.
+of_pages={{pagesCount}} இல்
+# LOCALIZATION NOTE (page_of_pages): "{{pageNumber}}" and "{{pagesCount}}"
+# will be replaced by a number representing the currently visible page,
+# respectively a number representing the total number of pages in the document.
+page_of_pages={{pagesCount}}) இல் ({{pageNumber}}
+
+zoom_out.title=சிறிதாக்கு
+zoom_out_label=சிறிதாக்கு
+zoom_in.title=பெரிதாக்கு
+zoom_in_label=பெரிதாக்கு
+zoom.title=பெரிதாக்கு
+presentation_mode.title=விளக்ககாட்சி பயன்முறைக்கு மாறு
+presentation_mode_label=விளக்ககாட்சி பயன்முறை
+open_file.title=கோப்பினை திற
+open_file_label=திற
+print.title=அச்சிடு
+print_label=அச்சிடு
+
+# Secondary toolbar and context menu
+tools.title=கருவிகள்
+tools_label=கருவிகள்
+first_page.title=முதல் பக்கத்திற்கு செல்லவும்
+first_page_label=முதல் பக்கத்திற்கு செல்லவும்
+last_page.title=கடைசி பக்கத்திற்கு செல்லவும்
+last_page_label=கடைசி பக்கத்திற்கு செல்லவும்
+page_rotate_cw.title=வலஞ்சுழியாக சுழற்று
+page_rotate_cw_label=வலஞ்சுழியாக சுழற்று
+page_rotate_ccw.title=இடஞ்சுழியாக சுழற்று
+page_rotate_ccw_label=இடஞ்சுழியாக சுழற்று
+
+cursor_text_select_tool.title=உரைத் தெரிவு கருவியைச் செயல்படுத்து
+cursor_text_select_tool_label=உரைத் தெரிவு கருவி
+cursor_hand_tool.title=கைக் கருவிக்ச் செயற்படுத்து
+cursor_hand_tool_label=கைக்குருவி
+
+# Document properties dialog box
+document_properties.title=ஆவண பண்புகள்...
+document_properties_label=ஆவண பண்புகள்...
+document_properties_file_name=கோப்பு பெயர்:
+document_properties_file_size=கோப்பின் அளவு:
+# LOCALIZATION NOTE (document_properties_kb): "{{size_kb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in kilobytes, respectively in bytes.
+document_properties_kb={{size_kb}} கிபை ({{size_b}} பைட்டுகள்)
+# LOCALIZATION NOTE (document_properties_mb): "{{size_mb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in megabytes, respectively in bytes.
+document_properties_mb={{size_mb}} மெபை ({{size_b}} பைட்டுகள்)
+document_properties_title=தலைப்பு:
+document_properties_author=எழுதியவர்
+document_properties_subject=பொருள்:
+document_properties_keywords=முக்கிய வார்த்தைகள்:
+document_properties_creation_date=படைத்த தேதி :
+document_properties_modification_date=திருத்திய தேதி:
+# LOCALIZATION NOTE (document_properties_date_string): "{{date}}" and "{{time}}"
+# will be replaced by the creation/modification date, and time, of the PDF file.
+document_properties_date_string={{date}}, {{time}}
+document_properties_creator=உருவாக்குபவர்:
+document_properties_producer=பிடிஎஃப் தயாரிப்பாளர்:
+document_properties_version=PDF பதிப்பு:
+document_properties_page_count=பக்க எண்ணிக்கை:
+document_properties_page_size=பக்க அளவு:
+document_properties_page_size_unit_inches=இதில்
+document_properties_page_size_unit_millimeters=mm
+document_properties_page_size_orientation_portrait=நிலைபதிப்பு
+document_properties_page_size_orientation_landscape=நிலைபரப்பு
+document_properties_page_size_name_a3=A3
+document_properties_page_size_name_a4=A4
+document_properties_page_size_name_letter=கடிதம்
+document_properties_page_size_name_legal=சட்டபூர்வ
+# LOCALIZATION NOTE (document_properties_page_size_dimension_string):
+# "{{width}}", "{{height}}", {{unit}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement and orientation, of the (current) page.
+document_properties_page_size_dimension_string={{width}} × {{height}} {{unit}} ({{orientation}})
+# LOCALIZATION NOTE (document_properties_page_size_dimension_name_string):
+# "{{width}}", "{{height}}", {{unit}}, {{name}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement, name, and orientation, of the (current) page.
+document_properties_page_size_dimension_name_string={{width}} × {{height}} {{unit}} ({{name}}, {{orientation}})
+document_properties_close=மூடுக
+
+print_progress_message=அச்சிடுவதற்கான ஆவணம் தயாராகிறது...
+# LOCALIZATION NOTE (print_progress_percent): "{{progress}}" will be replaced by
+# a numerical per cent value.
+print_progress_percent={{progress}}%
+print_progress_close=ரத்து
+
+# Tooltips and alt text for side panel toolbar buttons
+# (the _label strings are alt text for the buttons, the .title strings are
+# tooltips)
+toggle_sidebar.title=பக்கப் பட்டியை நிலைமாற்று
+toggle_sidebar_label=பக்கப் பட்டியை நிலைமாற்று
+document_outline.title=ஆவண அடக்கத்தைக் காட்டு (இருமுறைச் சொடுக்கி அனைத்து உறுப்பிடிகளையும் விரி/சேர்)
+document_outline_label=ஆவண வெளிவரை
+attachments.title=இணைப்புகளை காண்பி
+attachments_label=இணைப்புகள்
+thumbs.title=சிறுபடங்களைக் காண்பி
+thumbs_label=சிறுபடங்கள்
+findbar.title=ஆவணத்தில் கண்டறி
+findbar_label=தேடு
+
+# Thumbnails panel item (tooltip and alt text for images)
+# LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
+# number.
+thumb_page_title=பக்கம் {{page}}
+# LOCALIZATION NOTE (thumb_page_canvas): "{{page}}" will be replaced by the page
+# number.
+thumb_page_canvas=பக்கத்தின் சிறுபடம் {{page}}
+
+# Find panel button title and messages
+find_input.title=கண்டுபிடி
+find_input.placeholder=ஆவணத்தில் கண்டறி…
+find_previous.title=இந்த சொற்றொடரின் முந்தைய நிகழ்வை தேடு
+find_previous_label=முந்தையது
+find_next.title=இந்த சொற்றொடரின் அடுத்த நிகழ்வை தேடு
+find_next_label=அடுத்து
+find_highlight=அனைத்தையும் தனிப்படுத்து
+find_match_case_label=பேரெழுத்தாக்கத்தை உணர்
+find_reached_top=ஆவணத்தின் மேல் பகுதியை அடைந்தது, அடிப்பக்கத்திலிருந்து தொடர்ந்தது
+find_reached_bottom=ஆவணத்தின் முடிவை அடைந்தது, மேலிருந்து தொடர்ந்தது
+find_not_found=சொற்றொடர் காணவில்லை
+
+# Predefined zoom values
+page_scale_width=பக்க அகலம்
+page_scale_fit=பக்கப் பொருத்தம்
+page_scale_auto=தானியக்க பெரிதாக்கல்
+page_scale_actual=உண்மையான அளவு
+# LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
+# numerical scale value.
+page_scale_percent={{scale}}%
+
+loading_error=PDF ஐ ஏற்றும் போது ஒரு பிழை ஏற்பட்டது.
+invalid_file_error=செல்லுபடியாகாத அல்லது சிதைந்த PDF கோப்பு.
+missing_file_error=PDF கோப்பு காணவில்லை.
+unexpected_response_error=சேவகன் பதில் எதிர்பாரதது.
+
+rendering_error=இந்தப் பக்கத்தை காட்சிப்படுத்தும் போது ஒரு பிழை ஏற்பட்டது.
+
+# LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
+# "{{type}}" will be replaced with an annotation type from a list defined in
+# the PDF spec (32000-1:2008 Table 169 – Annotation types).
+# Some common types are e.g.: "Check", "Text", "Comment", "Note"
+text_annotation_type.alt=[{{type}} விளக்கம்]
+password_label=இந்த PDF கோப்பை திறக்க கடவுச்சொல்லை உள்ளிடவும்.
+password_invalid=செல்லுபடியாகாத கடவுச்சொல், தயை செய்து மீண்டும் முயற்சி செய்க.
+password_ok=சரி
+password_cancel=ரத்து
+
+printing_not_supported=எச்சரிக்கை: இந்த உலாவி அச்சிடுதலை முழுமையாக ஆதரிக்கவில்லை.
+printing_not_ready=எச்சரிக்கை: PDF அச்சிட முழுவதுமாக ஏற்றப்படவில்லை.
+web_fonts_disabled=வலை எழுத்துருக்கள் முடக்கப்பட்டுள்ளன: உட்பொதிக்கப்பட்ட PDF எழுத்துருக்களைப் பயன்படுத்த முடியவில்லை.
+

--- a/js/pdfjs/web/locale/te/viewer.properties
+++ b/js/pdfjs/web/locale/te/viewer.properties
@@ -1,0 +1,216 @@
+# Copyright 2012 Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Main toolbar buttons (tooltips and alt text for images)
+previous.title=మునుపటి పేజీ
+previous_label=క్రితం
+next.title=తరువాత పేజీ
+next_label=తరువాత
+
+# LOCALIZATION NOTE (page.title): The tooltip for the pageNumber input.
+page.title=పేజీ
+# LOCALIZATION NOTE (of_pages): "{{pagesCount}}" will be replaced by a number
+# representing the total number of pages in the document.
+of_pages=మొత్తం {{pagesCount}} లో
+# LOCALIZATION NOTE (page_of_pages): "{{pageNumber}}" and "{{pagesCount}}"
+# will be replaced by a number representing the currently visible page,
+# respectively a number representing the total number of pages in the document.
+page_of_pages=(మొత్తం {{pagesCount}} లో {{pageNumber}}వది)
+
+zoom_out.title=జూమ్ తగ్గించు
+zoom_out_label=జూమ్ తగ్గించు
+zoom_in.title=జూమ్ చేయి
+zoom_in_label=జూమ్ చేయి
+zoom.title=జూమ్
+presentation_mode.title=ప్రదర్శనా రీతికి మారు
+presentation_mode_label=ప్రదర్శనా రీతి
+open_file.title=ఫైల్ తెరువు
+open_file_label=తెరువు
+print.title=ముద్రించు
+print_label=ముద్రించు
+
+# Secondary toolbar and context menu
+tools.title=పనిముట్లు
+tools_label=పనిముట్లు
+first_page.title=మొదటి పేజీకి వెళ్ళు
+first_page_label=మొదటి పేజీకి వెళ్ళు
+last_page.title=చివరి పేజీకి వెళ్ళు
+last_page_label=చివరి పేజీకి వెళ్ళు
+page_rotate_cw.title=సవ్యదిశలో తిప్పు
+page_rotate_cw_label=సవ్యదిశలో తిప్పు
+page_rotate_ccw.title=అపసవ్యదిశలో తిప్పు
+page_rotate_ccw_label=అపసవ్యదిశలో తిప్పు
+
+cursor_text_select_tool.title=టెక్స్ట్ ఎంపిక సాధనాన్ని ప్రారంభించండి
+cursor_text_select_tool_label=టెక్స్ట్ ఎంపిక సాధనం
+cursor_hand_tool.title=చేతి సాధనం చేతనించు
+cursor_hand_tool_label=చేతి సాధనం
+
+scroll_vertical_label=నిలువు స్క్రోలింగు
+
+
+# Document properties dialog box
+document_properties.title=పత్రము లక్షణాలు...
+document_properties_label=పత్రము లక్షణాలు...
+document_properties_file_name=దస్త్రం పేరు:
+document_properties_file_size=దస్త్రం పరిమాణం:
+# LOCALIZATION NOTE (document_properties_kb): "{{size_kb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in kilobytes, respectively in bytes.
+document_properties_kb={{size_kb}} KB ({{size_b}} bytes)
+# LOCALIZATION NOTE (document_properties_mb): "{{size_mb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in megabytes, respectively in bytes.
+document_properties_mb={{size_mb}} MB ({{size_b}} bytes)
+document_properties_title=శీర్షిక:
+document_properties_author=మూలకర్త:
+document_properties_subject=విషయం:
+document_properties_keywords=కీ పదాలు:
+document_properties_creation_date=సృష్టించిన తేదీ:
+document_properties_modification_date=సవరించిన తేదీ:
+# LOCALIZATION NOTE (document_properties_date_string): "{{date}}" and "{{time}}"
+# will be replaced by the creation/modification date, and time, of the PDF file.
+document_properties_date_string={{date}}, {{time}}
+document_properties_creator=సృష్టికర్త:
+document_properties_producer=PDF ఉత్పాదకి:
+document_properties_version=PDF వర్షన్:
+document_properties_page_count=పేజీల సంఖ్య:
+document_properties_page_size=కాగితం పరిమాణం:
+document_properties_page_size_unit_inches=లో
+document_properties_page_size_unit_millimeters=mm
+document_properties_page_size_orientation_portrait=నిలువుచిత్రం
+document_properties_page_size_orientation_landscape=అడ్డచిత్రం
+document_properties_page_size_name_a3=A3
+document_properties_page_size_name_a4=A4
+document_properties_page_size_name_letter=లేఖ
+document_properties_page_size_name_legal=చట్టపరమైన
+# LOCALIZATION NOTE (document_properties_page_size_dimension_string):
+# "{{width}}", "{{height}}", {{unit}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement and orientation, of the (current) page.
+document_properties_page_size_dimension_string={{width}} × {{height}} {{unit}} ({{orientation}})
+# LOCALIZATION NOTE (document_properties_page_size_dimension_name_string):
+# "{{width}}", "{{height}}", {{unit}}, {{name}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement, name, and orientation, of the (current) page.
+document_properties_page_size_dimension_name_string={{width}} × {{height}} {{unit}} ({{name}}, {{orientation}})
+# LOCALIZATION NOTE (document_properties_linearized): The linearization status of
+# the document; usually called "Fast Web View" in English locales of Adobe software.
+document_properties_linearized_yes=అవును
+document_properties_linearized_no=కాదు
+document_properties_close=మూసివేయి
+
+print_progress_message=ముద్రించడానికి పత్రము సిద్ధమవుతున్నది…
+# LOCALIZATION NOTE (print_progress_percent): "{{progress}}" will be replaced by
+# a numerical per cent value.
+print_progress_percent={{progress}}%
+print_progress_close=రద్దుచేయి
+
+# Tooltips and alt text for side panel toolbar buttons
+# (the _label strings are alt text for the buttons, the .title strings are
+# tooltips)
+toggle_sidebar.title=పక్కపట్టీ మార్చు
+toggle_sidebar_label=పక్కపట్టీ మార్చు
+document_outline.title=పత్రము రూపము చూపించు (డబుల్ క్లిక్ చేసి అన్ని అంశాలను విస్తరించు/కూల్చు)
+document_outline_label=పత్రము అవుట్‌లైన్
+attachments.title=అనుబంధాలు చూపు
+attachments_label=అనుబంధాలు
+layers_label=పొరలు
+thumbs.title=థంబ్‌నైల్స్ చూపు
+thumbs_label=థంబ్‌నైల్స్
+findbar.title=పత్రములో కనుగొనుము
+findbar_label=కనుగొను
+
+additional_layers=అదనపు పొరలు
+# LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
+# Thumbnails panel item (tooltip and alt text for images)
+# LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
+# number.
+thumb_page_title=పేజీ {{page}}
+# LOCALIZATION NOTE (thumb_page_canvas): "{{page}}" will be replaced by the page
+# number.
+thumb_page_canvas={{page}} పేజీ నఖచిత్రం
+
+# Find panel button title and messages
+find_input.title=కనుగొను
+find_input.placeholder=పత్రములో కనుగొను…
+find_previous.title=పదం యొక్క ముందు సంభవాన్ని కనుగొను
+find_previous_label=మునుపటి
+find_next.title=పదం యొక్క తర్వాతి సంభవాన్ని కనుగొను
+find_next_label=తరువాత
+find_highlight=అన్నిటిని ఉద్దీపనం చేయుము
+find_match_case_label=అక్షరముల తేడాతో పోల్చు
+find_entire_word_label=పూర్తి పదాలు
+find_reached_top=పేజీ పైకి చేరుకున్నది, క్రింది నుండి కొనసాగించండి
+find_reached_bottom=పేజీ చివరకు చేరుకున్నది, పైనుండి కొనసాగించండి
+# LOCALIZATION NOTE (find_match_count): The supported plural forms are
+# [one|two|few|many|other], with [other] as the default value.
+# "{{current}}" and "{{total}}" will be replaced by a number representing the
+# index of the currently active find result, respectively a number representing
+# the total number of matches in the document.
+find_match_count={[ plural(total) ]}
+# LOCALIZATION NOTE (find_match_count_limit): The supported plural forms are
+# [zero|one|two|few|many|other], with [other] as the default value.
+# "{{limit}}" will be replaced by a numerical value.
+find_match_count_limit={[ plural(limit) ]}
+find_not_found=పదబంధం కనబడలేదు
+
+# Predefined zoom values
+page_scale_width=పేజీ వెడల్పు
+page_scale_fit=పేజీ అమర్పు
+page_scale_auto=స్వయంచాలక జూమ్
+page_scale_actual=యథార్ధ పరిమాణం
+# LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
+# numerical scale value.
+page_scale_percent={{scale}}%
+
+# Loading indicator messages
+loading_error=PDF లోడవుచున్నప్పుడు ఒక దోషం ఎదురైంది.
+invalid_file_error=చెల్లని లేదా పాడైన PDF ఫైలు.
+missing_file_error=దొరకని PDF ఫైలు.
+unexpected_response_error=అనుకోని సర్వర్ స్పందన.
+
+rendering_error=పేజీను రెండర్ చేయుటలో ఒక దోషం ఎదురైంది.
+
+# LOCALIZATION NOTE (annotation_date_string): "{{date}}" and "{{time}}" will be
+# replaced by the modification date, and time, of the annotation.
+annotation_date_string={{date}}, {{time}}
+
+# LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
+# "{{type}}" will be replaced with an annotation type from a list defined in
+# the PDF spec (32000-1:2008 Table 169 – Annotation types).
+# Some common types are e.g.: "Check", "Text", "Comment", "Note"
+text_annotation_type.alt=[{{type}} టీకా]
+password_label=ఈ PDF ఫైల్ తెరుచుటకు సంకేతపదం ప్రవేశపెట్టుము.
+password_invalid=సంకేతపదం చెల్లదు. దయచేసి మళ్ళీ ప్రయత్నించండి.
+password_ok=సరే
+password_cancel=రద్దుచేయి
+
+printing_not_supported=హెచ్చరిక: ఈ విహారిణి చేత ముద్రణ పూర్తిగా తోడ్పాటు లేదు.
+printing_not_ready=హెచ్చరిక: ముద్రణ కొరకు ఈ PDF పూర్తిగా లోడవలేదు.
+web_fonts_disabled=వెబ్ ఫాంట్లు అచేతనించబడెను: ఎంబెడెడ్ PDF ఫాంట్లు ఉపయోగించలేక పోయింది.
+
+# Editor
+
+
+# Editor
+
+
+# Editor Parameters
+editor_free_text_color=రంగు
+editor_free_text_size=పరిమాణం
+editor_ink_color=రంగు
+editor_ink_thickness=మందం
+editor_ink_opacity=అకిరణ్యత
+
+# Editor aria
+
+# Editor aria
+

--- a/js/pdfjs/web/locale/tg/viewer.properties
+++ b/js/pdfjs/web/locale/tg/viewer.properties
@@ -1,0 +1,259 @@
+# Copyright 2012 Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Main toolbar buttons (tooltips and alt text for images)
+previous.title=Саҳифаи қаблӣ
+previous_label=Қаблӣ
+next.title=Саҳифаи навбатӣ
+next_label=Навбатӣ
+
+# LOCALIZATION NOTE (page.title): The tooltip for the pageNumber input.
+page.title=Саҳифа
+# LOCALIZATION NOTE (of_pages): "{{pagesCount}}" will be replaced by a number
+# representing the total number of pages in the document.
+of_pages=аз {{pagesCount}}
+# LOCALIZATION NOTE (page_of_pages): "{{pageNumber}}" and "{{pagesCount}}"
+# will be replaced by a number representing the currently visible page,
+# respectively a number representing the total number of pages in the document.
+page_of_pages=({{pageNumber}} аз {{pagesCount}})
+
+zoom_out.title=Хурд кардан
+zoom_out_label=Хурд кардан
+zoom_in.title=Калон кардан
+zoom_in_label=Калон кардан
+zoom.title=Танзими андоза
+presentation_mode.title=Гузариш ба реҷаи тақдим
+presentation_mode_label=Реҷаи тақдим
+open_file.title=Кушодани файл
+open_file_label=Кушодан
+print.title=Чоп кардан
+print_label=Чоп кардан
+save.title=Нигоҳ доштан
+save_label=Нигоҳ доштан
+bookmark1.title=Саҳифаи ҷорӣ (Дидани нишонии URL аз саҳифаи ҷорӣ)
+bookmark1_label=Саҳифаи ҷорӣ
+# LOCALIZATION NOTE (open_in_app.title): This string is used in Firefox for Android.
+open_in_app.title=Кушодан дар барнома
+# LOCALIZATION NOTE (open_in_app_label): This string is used in Firefox for Android. Length of the translation matters since we are in a mobile context, with limited screen estate.
+open_in_app_label=Кушодан дар барнома
+
+# Secondary toolbar and context menu
+tools.title=Абзорҳо
+tools_label=Абзорҳо
+first_page.title=Ба саҳифаи аввал гузаред
+first_page_label=Ба саҳифаи аввал гузаред
+last_page.title=Ба саҳифаи охирин гузаред
+last_page_label=Ба саҳифаи охирин гузаред
+page_rotate_cw.title=Ба самти ҳаракати ақрабаки соат давр задан
+page_rotate_cw_label=Ба самти ҳаракати ақрабаки соат давр задан
+page_rotate_ccw.title=Ба муқобили самти ҳаракати ақрабаки соат давр задан
+page_rotate_ccw_label=Ба муқобили самти ҳаракати ақрабаки соат давр задан
+
+cursor_text_select_tool.title=Фаъол кардани «Абзори интихоби матн»
+cursor_text_select_tool_label=Абзори интихоби матн
+cursor_hand_tool.title=Фаъол кардани «Абзори даст»
+cursor_hand_tool_label=Абзори даст
+
+scroll_page.title=Истифодаи варақзанӣ
+scroll_page_label=Варақзанӣ
+scroll_vertical.title=Истифодаи варақзании амудӣ
+scroll_vertical_label=Варақзании амудӣ
+scroll_horizontal.title=Истифодаи варақзании уфуқӣ
+scroll_horizontal_label=Варақзании уфуқӣ
+scroll_wrapped.title=Истифодаи варақзании миқёсбандӣ
+scroll_wrapped_label=Варақзании миқёсбандӣ
+
+spread_none.title=Густариши саҳифаҳо истифода бурда нашавад
+spread_none_label=Бе густурдани саҳифаҳо
+spread_odd.title=Густариши саҳифаҳо аз саҳифаҳо бо рақамҳои тоқ оғоз карда мешавад
+spread_odd_label=Саҳифаҳои тоқ аз тарафи чап
+spread_even.title=Густариши саҳифаҳо аз саҳифаҳо бо рақамҳои ҷуфт оғоз карда мешавад
+spread_even_label=Саҳифаҳои ҷуфт аз тарафи чап
+
+# Document properties dialog box
+document_properties.title=Хусусиятҳои ҳуҷҷат…
+document_properties_label=Хусусиятҳои ҳуҷҷат…
+document_properties_file_name=Номи файл:
+document_properties_file_size=Андозаи файл:
+# LOCALIZATION NOTE (document_properties_kb): "{{size_kb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in kilobytes, respectively in bytes.
+document_properties_kb={{size_kb}} КБ ({{size_b}} байт)
+# LOCALIZATION NOTE (document_properties_mb): "{{size_mb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in megabytes, respectively in bytes.
+document_properties_mb={{size_mb}} МБ ({{size_b}} байт)
+document_properties_title=Сарлавҳа:
+document_properties_author=Муаллиф:
+document_properties_subject=Мавзуъ:
+document_properties_keywords=Калимаҳои калидӣ:
+document_properties_creation_date=Санаи эҷод:
+document_properties_modification_date=Санаи тағйирот:
+# LOCALIZATION NOTE (document_properties_date_string): "{{date}}" and "{{time}}"
+# will be replaced by the creation/modification date, and time, of the PDF file.
+document_properties_date_string={{date}}, {{time}}
+document_properties_creator=Эҷодкунанда:
+document_properties_producer=Таҳиякунандаи «PDF»:
+document_properties_version=Версияи «PDF»:
+document_properties_page_count=Шумораи саҳифаҳо:
+document_properties_page_size=Андозаи саҳифа:
+document_properties_page_size_unit_inches=дюйм
+document_properties_page_size_unit_millimeters=мм
+document_properties_page_size_orientation_portrait=амудӣ
+document_properties_page_size_orientation_landscape=уфуқӣ
+document_properties_page_size_name_a3=A3
+document_properties_page_size_name_a4=A4
+document_properties_page_size_name_letter=Мактуб
+document_properties_page_size_name_legal=Ҳуқуқӣ
+# LOCALIZATION NOTE (document_properties_page_size_dimension_string):
+# "{{width}}", "{{height}}", {{unit}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement and orientation, of the (current) page.
+document_properties_page_size_dimension_string={{width}} × {{height}} {{unit}} ({{orientation}})
+# LOCALIZATION NOTE (document_properties_page_size_dimension_name_string):
+# "{{width}}", "{{height}}", {{unit}}, {{name}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement, name, and orientation, of the (current) page.
+document_properties_page_size_dimension_name_string={{width}} × {{height}} {{unit}} ({{name}}, {{orientation}})
+# LOCALIZATION NOTE (document_properties_linearized): The linearization status of
+# the document; usually called "Fast Web View" in English locales of Adobe software.
+document_properties_linearized=Намоиши тез дар Интернет:
+document_properties_linearized_yes=Ҳа
+document_properties_linearized_no=Не
+document_properties_close=Пӯшидан
+
+print_progress_message=Омодасозии ҳуҷҷат барои чоп…
+# LOCALIZATION NOTE (print_progress_percent): "{{progress}}" will be replaced by
+# a numerical per cent value.
+print_progress_percent={{progress}}%
+print_progress_close=Бекор кардан
+
+# Tooltips and alt text for side panel toolbar buttons
+# (the _label strings are alt text for the buttons, the .title strings are
+# tooltips)
+toggle_sidebar.title=Фаъол кардани навори ҷонибӣ
+toggle_sidebar_notification2.title=Фаъол кардани навори ҷонибӣ (ҳуҷҷат дорои сохтор/замимаҳо/қабатҳо мебошад)
+toggle_sidebar_label=Фаъол кардани навори ҷонибӣ
+document_outline.title=Намоиш додани сохтори ҳуҷҷат (барои баркушодан/пеҷондани ҳамаи унсурҳо дубора зер кунед)
+document_outline_label=Сохтори ҳуҷҷат
+attachments.title=Намоиш додани замимаҳо
+attachments_label=Замимаҳо
+layers.title=Намоиш додани қабатҳо (барои барқарор кардани ҳамаи қабатҳо ба вазъияти пешфарз дубора зер кунед)
+layers_label=Қабатҳо
+thumbs.title=Намоиш додани тасвирчаҳо
+thumbs_label=Тасвирчаҳо
+current_outline_item.title=Ёфтани унсури сохтори ҷорӣ
+current_outline_item_label=Унсури сохтори ҷорӣ
+findbar.title=Ёфтан дар ҳуҷҷат
+findbar_label=Ёфтан
+
+additional_layers=Қабатҳои иловагӣ
+# LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
+page_landmark=Саҳифаи {{page}}
+# Thumbnails panel item (tooltip and alt text for images)
+# LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
+# number.
+thumb_page_title=Саҳифаи {{page}}
+# LOCALIZATION NOTE (thumb_page_canvas): "{{page}}" will be replaced by the page
+# number.
+thumb_page_canvas=Тасвирчаи саҳифаи {{page}}
+
+# Find panel button title and messages
+find_input.title=Ёфтан
+find_input.placeholder=Ёфтан дар ҳуҷҷат…
+find_previous.title=Ҷустуҷӯи мавриди қаблии ибораи пешниҳодшуда
+find_previous_label=Қаблӣ
+find_next.title=Ҷустуҷӯи мавриди навбатии ибораи пешниҳодшуда
+find_next_label=Навбатӣ
+find_highlight=Ҳамаашро бо ранг ҷудо кардан
+find_match_case_label=Бо дарназардошти ҳарфҳои хурду калон
+find_match_diacritics_label=Бо дарназардошти аломатҳои диакритикӣ
+find_entire_word_label=Калимаҳои пурра
+find_reached_top=Ба болои ҳуҷҷат расид, аз поён идома ёфт
+find_reached_bottom=Ба поёни ҳуҷҷат расид, аз боло идома ёфт
+# LOCALIZATION NOTE (find_match_count): The supported plural forms are
+# [one|two|few|many|other], with [other] as the default value.
+# "{{current}}" and "{{total}}" will be replaced by a number representing the
+# index of the currently active find result, respectively a number representing
+# the total number of matches in the document.
+find_match_count={[ plural(total) ]}
+find_match_count[one]={{current}} аз {{total}} мувофиқат
+find_match_count[two]={{current}} аз {{total}} мувофиқат
+find_match_count[few]={{current}} аз {{total}} мувофиқат
+find_match_count[many]={{current}} аз {{total}} мувофиқат
+find_match_count[other]={{current}} аз {{total}} мувофиқат
+# LOCALIZATION NOTE (find_match_count_limit): The supported plural forms are
+# [zero|one|two|few|many|other], with [other] as the default value.
+# "{{limit}}" will be replaced by a numerical value.
+find_match_count_limit={[ plural(limit) ]}
+find_match_count_limit[zero]=Зиёда аз {{limit}} мувофиқат
+find_match_count_limit[one]=Зиёда аз {{limit}} мувофиқат
+find_match_count_limit[two]=Зиёда аз {{limit}} мувофиқат
+find_match_count_limit[few]=Зиёда аз {{limit}} мувофиқат
+find_match_count_limit[many]=Зиёда аз {{limit}} мувофиқат
+find_match_count_limit[other]=Зиёда аз {{limit}} мувофиқат
+find_not_found=Ибора ёфт нашуд
+
+# Predefined zoom values
+page_scale_width=Аз рӯи паҳнои саҳифа
+page_scale_fit=Аз рӯи андозаи саҳифа
+page_scale_auto=Андозаи худкор
+page_scale_actual=Андозаи воқеӣ
+# LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
+# numerical scale value.
+page_scale_percent={{scale}}%
+
+# Loading indicator messages
+loading_error=Ҳангоми боркунии «PDF» хато ба миён омад.
+invalid_file_error=Файли «PDF» нодуруст ё вайроншуда мебошад.
+missing_file_error=Файли «PDF» ғоиб аст.
+unexpected_response_error=Ҷавоби ногаҳон аз сервер.
+rendering_error=Ҳангоми шаклсозии саҳифа хато ба миён омад.
+
+# LOCALIZATION NOTE (annotation_date_string): "{{date}}" and "{{time}}" will be
+# replaced by the modification date, and time, of the annotation.
+annotation_date_string={{date}}, {{time}}
+
+# LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
+# "{{type}}" will be replaced with an annotation type from a list defined in
+# the PDF spec (32000-1:2008 Table 169 – Annotation types).
+# Some common types are e.g.: "Check", "Text", "Comment", "Note"
+text_annotation_type.alt=[Ҳошиянависӣ - {{type}}]
+password_label=Барои кушодани ин файли «PDF» ниҳонвожаро ворид кунед.
+password_invalid=Ниҳонвожаи нодуруст. Лутфан, аз нав кӯшиш кунед.
+password_ok=ХУБ
+password_cancel=Бекор кардан
+
+printing_not_supported=Диққат: Чопкунӣ аз тарафи ин браузер ба таври пурра дастгирӣ намешавад.
+printing_not_ready=Диққат: Файли «PDF» барои чопкунӣ пурра бор карда нашуд.
+web_fonts_disabled=Шрифтҳои интернетӣ ғайрифаъоланд: истифодаи шрифтҳои дарунсохти «PDF» ғайриимкон аст.
+
+# Editor
+editor_free_text2.title=Матн
+editor_free_text2_label=Матн
+editor_ink2.title=Расмкашӣ
+editor_ink2_label=Расмкашӣ
+
+editor_stamp.title=Илова кардани тасвир
+editor_stamp_label=Илова кардани тасвир
+
+free_text2_default_content=Нависед…
+
+# Editor Parameters
+editor_free_text_color=Ранг
+editor_free_text_size=Андоза
+editor_ink_color=Ранг
+editor_ink_thickness=Ғафсӣ
+editor_ink_opacity=Шаффофӣ
+
+# Editor aria
+editor_free_text2_aria_label=Муҳаррири матн
+editor_ink2_aria_label=Муҳаррири расмкашӣ
+editor_ink_canvas_aria_label=Тасвири эҷодкардаи корбар

--- a/js/pdfjs/web/locale/th/viewer.properties
+++ b/js/pdfjs/web/locale/th/viewer.properties
@@ -1,0 +1,259 @@
+# Copyright 2012 Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Main toolbar buttons (tooltips and alt text for images)
+previous.title=หน้าก่อนหน้า
+previous_label=ก่อนหน้า
+next.title=หน้าถัดไป
+next_label=ถัดไป
+
+# LOCALIZATION NOTE (page.title): The tooltip for the pageNumber input.
+page.title=หน้า
+# LOCALIZATION NOTE (of_pages): "{{pagesCount}}" will be replaced by a number
+# representing the total number of pages in the document.
+of_pages=จาก {{pagesCount}}
+# LOCALIZATION NOTE (page_of_pages): "{{pageNumber}}" and "{{pagesCount}}"
+# will be replaced by a number representing the currently visible page,
+# respectively a number representing the total number of pages in the document.
+page_of_pages=({{pageNumber}} จาก {{pagesCount}})
+
+zoom_out.title=ซูมออก
+zoom_out_label=ซูมออก
+zoom_in.title=ซูมเข้า
+zoom_in_label=ซูมเข้า
+zoom.title=ซูม
+presentation_mode.title=สลับเป็นโหมดการนำเสนอ
+presentation_mode_label=โหมดการนำเสนอ
+open_file.title=เปิดไฟล์
+open_file_label=เปิด
+print.title=พิมพ์
+print_label=พิมพ์
+
+save.title=บันทึก
+save_label=บันทึก
+bookmark1.title=หน้าปัจจุบัน (ดู URL จากหน้าปัจจุบัน)
+bookmark1_label=หน้าปัจจุบัน
+
+# LOCALIZATION NOTE (open_in_app.title): This string is used in Firefox for Android.
+open_in_app.title=เปิดในแอป
+# LOCALIZATION NOTE (open_in_app_label): This string is used in Firefox for Android. Length of the translation matters since we are in a mobile context, with limited screen estate.
+open_in_app_label=เปิดในแอป
+
+# Secondary toolbar and context menu
+tools.title=เครื่องมือ
+tools_label=เครื่องมือ
+first_page.title=ไปยังหน้าแรก
+first_page_label=ไปยังหน้าแรก
+last_page.title=ไปยังหน้าสุดท้าย
+last_page_label=ไปยังหน้าสุดท้าย
+page_rotate_cw.title=หมุนตามเข็มนาฬิกา
+page_rotate_cw_label=หมุนตามเข็มนาฬิกา
+page_rotate_ccw.title=หมุนทวนเข็มนาฬิกา
+page_rotate_ccw_label=หมุนทวนเข็มนาฬิกา
+
+cursor_text_select_tool.title=เปิดใช้งานเครื่องมือการเลือกข้อความ
+cursor_text_select_tool_label=เครื่องมือการเลือกข้อความ
+cursor_hand_tool.title=เปิดใช้งานเครื่องมือมือ
+cursor_hand_tool_label=เครื่องมือมือ
+
+scroll_page.title=ใช้การเลื่อนหน้า
+scroll_page_label=การเลื่อนหน้า
+scroll_vertical.title=ใช้การเลื่อนแนวตั้ง
+scroll_vertical_label=การเลื่อนแนวตั้ง
+scroll_horizontal.title=ใช้การเลื่อนแนวนอน
+scroll_horizontal_label=การเลื่อนแนวนอน
+scroll_wrapped.title=ใช้การเลื่อนแบบคลุม
+scroll_wrapped_label=เลื่อนแบบคลุม
+
+spread_none.title=ไม่ต้องรวมการกระจายหน้า
+spread_none_label=ไม่กระจาย
+spread_odd.title=รวมการกระจายหน้าเริ่มจากหน้าคี่
+spread_odd_label=กระจายอย่างเหลือเศษ
+spread_even.title=รวมการกระจายหน้าเริ่มจากหน้าคู่
+spread_even_label=กระจายอย่างเท่าเทียม
+
+# Document properties dialog box
+document_properties.title=คุณสมบัติเอกสาร…
+document_properties_label=คุณสมบัติเอกสาร…
+document_properties_file_name=ชื่อไฟล์:
+document_properties_file_size=ขนาดไฟล์:
+# LOCALIZATION NOTE (document_properties_kb): "{{size_kb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in kilobytes, respectively in bytes.
+document_properties_kb={{size_kb}} KB ({{size_b}} ไบต์)
+# LOCALIZATION NOTE (document_properties_mb): "{{size_mb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in megabytes, respectively in bytes.
+document_properties_mb={{size_mb}} MB ({{size_b}} ไบต์)
+document_properties_title=ชื่อเรื่อง:
+document_properties_author=ผู้สร้าง:
+document_properties_subject=ชื่อเรื่อง:
+document_properties_keywords=คำสำคัญ:
+document_properties_creation_date=วันที่สร้าง:
+document_properties_modification_date=วันที่แก้ไข:
+# LOCALIZATION NOTE (document_properties_date_string): "{{date}}" and "{{time}}"
+# will be replaced by the creation/modification date, and time, of the PDF file.
+document_properties_date_string={{date}}, {{time}}
+document_properties_creator=ผู้สร้าง:
+document_properties_producer=ผู้ผลิต PDF:
+document_properties_version=รุ่น PDF:
+document_properties_page_count=จำนวนหน้า:
+document_properties_page_size=ขนาดหน้า:
+document_properties_page_size_unit_inches=in
+document_properties_page_size_unit_millimeters=mm
+document_properties_page_size_orientation_portrait=แนวตั้ง
+document_properties_page_size_orientation_landscape=แนวนอน
+document_properties_page_size_name_a3=A3
+document_properties_page_size_name_a4=A4
+document_properties_page_size_name_letter=จดหมาย
+document_properties_page_size_name_legal=ข้อกฎหมาย
+# LOCALIZATION NOTE (document_properties_page_size_dimension_string):
+# "{{width}}", "{{height}}", {{unit}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement and orientation, of the (current) page.
+document_properties_page_size_dimension_string={{width}} × {{height}} {{unit}} ({{orientation}})
+# LOCALIZATION NOTE (document_properties_page_size_dimension_name_string):
+# "{{width}}", "{{height}}", {{unit}}, {{name}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement, name, and orientation, of the (current) page.
+document_properties_page_size_dimension_name_string={{width}} × {{height}} {{unit}} ({{name}}, {{orientation}})
+# LOCALIZATION NOTE (document_properties_linearized): The linearization status of
+# the document; usually called "Fast Web View" in English locales of Adobe software.
+document_properties_linearized=มุมมองเว็บแบบรวดเร็ว:
+document_properties_linearized_yes=ใช่
+document_properties_linearized_no=ไม่
+document_properties_close=ปิด
+
+print_progress_message=กำลังเตรียมเอกสารสำหรับการพิมพ์…
+# LOCALIZATION NOTE (print_progress_percent): "{{progress}}" will be replaced by
+# a numerical per cent value.
+print_progress_percent={{progress}}%
+print_progress_close=ยกเลิก
+
+# Tooltips and alt text for side panel toolbar buttons
+# (the _label strings are alt text for the buttons, the .title strings are
+# tooltips)
+toggle_sidebar.title=เปิด/ปิดแถบข้าง
+toggle_sidebar_notification2.title=เปิด/ปิดแถบข้าง (เอกสารมีเค้าร่าง/ไฟล์แนบ/เลเยอร์)
+toggle_sidebar_label=เปิด/ปิดแถบข้าง
+document_outline.title=แสดงเค้าร่างเอกสาร (คลิกสองครั้งเพื่อขยาย/ยุบรายการทั้งหมด)
+document_outline_label=เค้าร่างเอกสาร
+attachments.title=แสดงไฟล์แนบ
+attachments_label=ไฟล์แนบ
+layers.title=แสดงเลเยอร์ (คลิกสองครั้งเพื่อรีเซ็ตเลเยอร์ทั้งหมดเป็นสถานะเริ่มต้น)
+layers_label=เลเยอร์
+thumbs.title=แสดงภาพขนาดย่อ
+thumbs_label=ภาพขนาดย่อ
+current_outline_item.title=ค้นหารายการเค้าร่างปัจจุบัน
+current_outline_item_label=รายการเค้าร่างปัจจุบัน
+findbar.title=ค้นหาในเอกสาร
+findbar_label=ค้นหา
+
+additional_layers=เลเยอร์เพิ่มเติม
+# LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
+page_landmark=หน้า {{page}}
+# Thumbnails panel item (tooltip and alt text for images)
+# LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
+# number.
+thumb_page_title=หน้า {{page}}
+# LOCALIZATION NOTE (thumb_page_canvas): "{{page}}" will be replaced by the page
+# number.
+thumb_page_canvas=ภาพขนาดย่อของหน้า {{page}}
+
+# Find panel button title and messages
+find_input.title=ค้นหา
+find_input.placeholder=ค้นหาในเอกสาร…
+find_previous.title=หาตำแหน่งก่อนหน้าของวลี
+find_previous_label=ก่อนหน้า
+find_next.title=หาตำแหน่งถัดไปของวลี
+find_next_label=ถัดไป
+find_highlight=เน้นสีทั้งหมด
+find_match_case_label=ตัวพิมพ์ใหญ่เล็กตรงกัน
+find_match_diacritics_label=เครื่องหมายกำกับการออกเสียงตรงกัน
+find_entire_word_label=ทั้งคำ
+find_reached_top=ค้นหาถึงจุดเริ่มต้นของหน้า เริ่มค้นต่อจากด้านล่าง
+find_reached_bottom=ค้นหาถึงจุดสิ้นสุดหน้า เริ่มค้นต่อจากด้านบน
+# LOCALIZATION NOTE (find_match_count): The supported plural forms are
+# [one|two|few|many|other], with [other] as the default value.
+# "{{current}}" and "{{total}}" will be replaced by a number representing the
+# index of the currently active find result, respectively a number representing
+# the total number of matches in the document.
+find_match_count={[ plural(total) ]}
+find_match_count[one]={{current}} จาก {{total}} ที่ตรงกัน
+find_match_count[two]={{current}} จาก {{total}} ที่ตรงกัน
+find_match_count[few]={{current}} จาก {{total}} ที่ตรงกัน
+find_match_count[many]={{current}} จาก {{total}} ที่ตรงกัน
+find_match_count[other]={{current}} จาก {{total}} ที่ตรงกัน
+# LOCALIZATION NOTE (find_match_count_limit): The supported plural forms are
+# [zero|one|two|few|many|other], with [other] as the default value.
+# "{{limit}}" will be replaced by a numerical value.
+find_match_count_limit={[ plural(limit) ]}
+find_match_count_limit[zero]=มากกว่า {{limit}} ที่ตรงกัน
+find_match_count_limit[one]=มากกว่า {{limit}} ที่ตรงกัน
+find_match_count_limit[two]=มากกว่า {{limit}} ที่ตรงกัน
+find_match_count_limit[few]=มากกว่า {{limit}} ที่ตรงกัน
+find_match_count_limit[many]=มากกว่า {{limit}} ที่ตรงกัน
+find_match_count_limit[other]=มากกว่า {{limit}} ที่ตรงกัน
+find_not_found=ไม่พบวลี
+
+# Predefined zoom values
+page_scale_width=ความกว้างหน้า
+page_scale_fit=พอดีหน้า
+page_scale_auto=ซูมอัตโนมัติ
+page_scale_actual=ขนาดจริง
+# LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
+# numerical scale value.
+page_scale_percent={{scale}}%
+
+# Loading indicator messages
+loading_error=เกิดข้อผิดพลาดขณะโหลด PDF
+invalid_file_error=ไฟล์ PDF ไม่ถูกต้องหรือเสียหาย
+missing_file_error=ไฟล์ PDF หายไป
+unexpected_response_error=การตอบสนองของเซิร์ฟเวอร์ที่ไม่คาดคิด
+
+rendering_error=เกิดข้อผิดพลาดขณะเรนเดอร์หน้า
+
+# LOCALIZATION NOTE (annotation_date_string): "{{date}}" and "{{time}}" will be
+# replaced by the modification date, and time, of the annotation.
+annotation_date_string={{date}}, {{time}}
+
+# LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
+# "{{type}}" will be replaced with an annotation type from a list defined in
+# the PDF spec (32000-1:2008 Table 169 – Annotation types).
+# Some common types are e.g.: "Check", "Text", "Comment", "Note"
+text_annotation_type.alt=[คำอธิบายประกอบ {{type}}]
+password_label=ป้อนรหัสผ่านเพื่อเปิดไฟล์ PDF นี้
+password_invalid=รหัสผ่านไม่ถูกต้อง โปรดลองอีกครั้ง
+password_ok=ตกลง
+password_cancel=ยกเลิก
+
+printing_not_supported=คำเตือน: เบราว์เซอร์นี้ไม่ได้สนับสนุนการพิมพ์อย่างเต็มที่
+printing_not_ready=คำเตือน: PDF ไม่ได้รับการโหลดอย่างเต็มที่สำหรับการพิมพ์
+web_fonts_disabled=แบบอักษรเว็บถูกปิดใช้งาน: ไม่สามารถใช้แบบอักษร PDF ฝังตัว
+
+# Editor
+editor_free_text2.title=ข้อความ
+editor_free_text2_label=ข้อความ
+editor_ink2.title=รูปวาด
+editor_ink2_label=รูปวาด
+
+free_text2_default_content=เริ่มพิมพ์…
+
+# Editor Parameters
+editor_free_text_color=สี
+editor_free_text_size=ขนาด
+editor_ink_color=สี
+editor_ink_thickness=ความหนา
+editor_ink_opacity=ความทึบ
+
+# Editor aria
+editor_free_text2_aria_label=ตัวแก้ไขข้อความ
+editor_ink2_aria_label=ตัวแก้ไขรูปวาด
+editor_ink_canvas_aria_label=ภาพที่ผู้ใช้สร้างขึ้น

--- a/js/pdfjs/web/locale/tl/viewer.properties
+++ b/js/pdfjs/web/locale/tl/viewer.properties
@@ -1,0 +1,222 @@
+# Copyright 2012 Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Main toolbar buttons (tooltips and alt text for images)
+previous.title=Naunang Pahina
+previous_label=Nakaraan
+next.title=Sunod na Pahina
+next_label=Sunod
+
+# LOCALIZATION NOTE (page.title): The tooltip for the pageNumber input.
+page.title=Pahina
+# LOCALIZATION NOTE (of_pages): "{{pagesCount}}" will be replaced by a number
+# representing the total number of pages in the document.
+of_pages=ng {{pagesCount}}
+# LOCALIZATION NOTE (page_of_pages): "{{pageNumber}}" and "{{pagesCount}}"
+# will be replaced by a number representing the currently visible page,
+# respectively a number representing the total number of pages in the document.
+page_of_pages=({{pageNumber}} ng {{pagesCount}})
+
+zoom_out.title=Paliitin
+zoom_out_label=Paliitin
+zoom_in.title=Palakihin
+zoom_in_label=Palakihin
+zoom.title=Mag-zoom
+presentation_mode.title=Lumipat sa Presentation Mode
+presentation_mode_label=Presentation Mode
+open_file.title=Magbukas ng file
+open_file_label=Buksan
+print.title=i-Print
+print_label=i-Print
+
+# Secondary toolbar and context menu
+tools.title=Mga Kagamitan
+tools_label=Mga Kagamitan
+first_page.title=Pumunta sa Unang Pahina
+first_page_label=Pumunta sa Unang Pahina
+last_page.title=Pumunta sa Huling Pahina
+last_page_label=Pumunta sa Huling Pahina
+page_rotate_cw.title=Paikutin Pakanan
+page_rotate_cw_label=Paikutin Pakanan
+page_rotate_ccw.title=Paikutin Pakaliwa
+page_rotate_ccw_label=Paikutin Pakaliwa
+
+cursor_text_select_tool.title=I-enable ang Text Selection Tool
+cursor_text_select_tool_label=Text Selection Tool
+cursor_hand_tool.title=I-enable ang Hand Tool
+cursor_hand_tool_label=Hand Tool
+
+scroll_vertical.title=Gumamit ng Vertical Scrolling
+scroll_vertical_label=Vertical Scrolling
+scroll_horizontal.title=Gumamit ng Horizontal Scrolling
+scroll_horizontal_label=Horizontal Scrolling
+scroll_wrapped.title=Gumamit ng Wrapped Scrolling
+scroll_wrapped_label=Wrapped Scrolling
+
+spread_none.title=Huwag pagsamahin ang mga page spread
+spread_none_label=No Spreads
+spread_odd.title=Join page spreads starting with odd-numbered pages
+spread_odd_label=Mga Odd Spread
+spread_even.title=Pagsamahin ang mga page spread na nagsisimula sa mga even-numbered na pahina
+spread_even_label=Mga Even Spread
+
+# Document properties dialog box
+document_properties.title=Mga Katangian ng Dokumento…
+document_properties_label=Mga Katangian ng Dokumento…
+document_properties_file_name=File name:
+document_properties_file_size=File size:
+# LOCALIZATION NOTE (document_properties_kb): "{{size_kb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in kilobytes, respectively in bytes.
+document_properties_kb={{size_kb}} KB ({{size_b}} bytes)
+# LOCALIZATION NOTE (document_properties_mb): "{{size_mb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in megabytes, respectively in bytes.
+document_properties_mb={{size_mb}} MB ({{size_b}} bytes)
+document_properties_title=Pamagat:
+document_properties_author=May-akda:
+document_properties_subject=Paksa:
+document_properties_keywords=Mga keyword:
+document_properties_creation_date=Petsa ng Pagkakagawa:
+document_properties_modification_date=Petsa ng Pagkakabago:
+# LOCALIZATION NOTE (document_properties_date_string): "{{date}}" and "{{time}}"
+# will be replaced by the creation/modification date, and time, of the PDF file.
+document_properties_date_string={{date}}, {{time}}
+document_properties_creator=Tagalikha:
+document_properties_producer=PDF Producer:
+document_properties_version=PDF Version:
+document_properties_page_count=Bilang ng Pahina:
+document_properties_page_size=Laki ng Pahina:
+document_properties_page_size_unit_inches=pulgada
+document_properties_page_size_unit_millimeters=mm
+document_properties_page_size_orientation_portrait=patayo
+document_properties_page_size_orientation_landscape=pahiga
+document_properties_page_size_name_a3=A3
+document_properties_page_size_name_a4=A4
+document_properties_page_size_name_letter=Letter
+document_properties_page_size_name_legal=Legal
+# LOCALIZATION NOTE (document_properties_page_size_dimension_string):
+# "{{width}}", "{{height}}", {{unit}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement and orientation, of the (current) page.
+document_properties_page_size_dimension_string={{width}} × {{height}} {{unit}} ({{orientation}})
+# LOCALIZATION NOTE (document_properties_page_size_dimension_name_string):
+# "{{width}}", "{{height}}", {{unit}}, {{name}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement, name, and orientation, of the (current) page.
+document_properties_page_size_dimension_name_string={{width}} × {{height}} {{unit}} ({{name}}, {{orientation}})
+# LOCALIZATION NOTE (document_properties_linearized): The linearization status of
+# the document; usually called "Fast Web View" in English locales of Adobe software.
+document_properties_linearized=Fast Web View:
+document_properties_linearized_yes=Oo
+document_properties_linearized_no=Hindi
+document_properties_close=Isara
+
+print_progress_message=Inihahanda ang dokumento para sa pag-print…
+# LOCALIZATION NOTE (print_progress_percent): "{{progress}}" will be replaced by
+# a numerical per cent value.
+print_progress_percent={{progress}}%
+print_progress_close=Kanselahin
+
+# Tooltips and alt text for side panel toolbar buttons
+# (the _label strings are alt text for the buttons, the .title strings are
+# tooltips)
+toggle_sidebar.title=Ipakita/Itago ang Sidebar
+toggle_sidebar_notification2.title=Ipakita/Itago ang Sidebar (nagtataglay ang dokumento ng balangkas/mga attachment/mga layer)
+toggle_sidebar_label=Ipakita/Itago ang Sidebar
+document_outline.title=Ipakita ang Document Outline (mag-double-click para i-expand/collapse ang laman)
+document_outline_label=Balangkas ng Dokumento
+attachments.title=Ipakita ang mga Attachment
+attachments_label=Mga attachment
+layers.title=Ipakita ang mga Layer (mag-double click para mareset ang lahat ng layer sa orihinal na estado)
+layers_label=Mga layer
+thumbs.title=Ipakita ang mga Thumbnail
+thumbs_label=Mga thumbnail
+findbar.title=Hanapin sa Dokumento
+findbar_label=Hanapin
+
+additional_layers=Mga Karagdagang Layer
+# Thumbnails panel item (tooltip and alt text for images)
+# LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
+# number.
+thumb_page_title=Pahina {{page}}
+# LOCALIZATION NOTE (thumb_page_canvas): "{{page}}" will be replaced by the page
+# number.
+thumb_page_canvas=Thumbnail ng Pahina {{page}}
+
+# Find panel button title and messages
+find_input.title=Hanapin
+find_input.placeholder=Hanapin sa dokumento…
+find_previous.title=Hanapin ang nakaraang pangyayari ng parirala
+find_previous_label=Nakaraan
+find_next.title=Hanapin ang susunod na pangyayari ng parirala
+find_next_label=Susunod
+find_highlight=I-highlight lahat
+find_match_case_label=Itugma ang case
+find_entire_word_label=Buong salita
+find_reached_top=Naabot na ang tuktok ng dokumento, ipinagpatuloy mula sa ilalim
+find_reached_bottom=Naabot na ang dulo ng dokumento, ipinagpatuloy mula sa tuktok
+# LOCALIZATION NOTE (find_match_count): The supported plural forms are
+# [one|two|few|many|other], with [other] as the default value.
+# "{{current}}" and "{{total}}" will be replaced by a number representing the
+# index of the currently active find result, respectively a number representing
+# the total number of matches in the document.
+find_match_count={[ plural(total) ]}
+find_match_count[one]={{current}} ng {{total}} tugma
+find_match_count[two]={{current}} ng {{total}} tugma
+find_match_count[few]={{current}} ng {{total}} tugma
+find_match_count[many]={{current}} ng {{total}} tugma
+find_match_count[other]={{current}} ng {{total}} tugma
+# LOCALIZATION NOTE (find_match_count_limit): The supported plural forms are
+# [zero|one|two|few|many|other], with [other] as the default value.
+# "{{limit}}" will be replaced by a numerical value.
+find_match_count_limit={[ plural(limit) ]}
+find_match_count_limit[zero]=Higit sa {{limit}} tugma
+find_match_count_limit[one]=Higit sa {{limit}} tugma
+find_match_count_limit[two]=Higit sa {{limit}} tugma
+find_match_count_limit[few]=Higit sa {{limit}} tugma
+find_match_count_limit[many]=Higit sa {{limit}} tugma
+find_match_count_limit[other]=Higit sa {{limit}} tugma
+find_not_found=Hindi natagpuan ang parirala
+
+# Predefined zoom values
+page_scale_width=Lapad ng Pahina
+page_scale_fit=Pagkasyahin ang Pahina
+page_scale_auto=Automatic Zoom
+page_scale_actual=Totoong sukat
+# LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
+# numerical scale value.
+page_scale_percent={{scale}}%
+
+loading_error=Nagkaproblema habang niloload ang PDF.
+invalid_file_error=Di-wasto o sira ang PDF file.
+missing_file_error=Nawawalang PDF file.
+unexpected_response_error=Hindi inaasahang tugon ng server.
+
+rendering_error=Nagkaproblema habang nirerender ang pahina.
+
+# LOCALIZATION NOTE (annotation_date_string): "{{date}}" and "{{time}}" will be
+# replaced by the modification date, and time, of the annotation.
+annotation_date_string={{date}}, {{time}}
+
+# LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
+# "{{type}}" will be replaced with an annotation type from a list defined in
+# the PDF spec (32000-1:2008 Table 169 – Annotation types).
+# Some common types are e.g.: "Check", "Text", "Comment", "Note"
+text_annotation_type.alt=[{{type}} Annotation]
+password_label=Ipasok ang password upang buksan ang PDF file na ito.
+password_invalid=Maling password. Subukan uli.
+password_ok=OK
+password_cancel=Kanselahin
+
+printing_not_supported=Babala: Hindi pa ganap na suportado ang pag-print sa browser na ito.
+printing_not_ready=Babala: Hindi ganap na nabuksan ang PDF para sa pag-print.
+web_fonts_disabled=Naka-disable ang mga Web font: hindi kayang gamitin ang mga naka-embed na PDF font.
+

--- a/js/pdfjs/web/locale/tr/viewer.properties
+++ b/js/pdfjs/web/locale/tr/viewer.properties
@@ -1,0 +1,259 @@
+# Copyright 2012 Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Main toolbar buttons (tooltips and alt text for images)
+previous.title=Önceki sayfa
+previous_label=Önceki
+next.title=Sonraki sayfa
+next_label=Sonraki
+
+# LOCALIZATION NOTE (page.title): The tooltip for the pageNumber input.
+page.title=Sayfa
+# LOCALIZATION NOTE (of_pages): "{{pagesCount}}" will be replaced by a number
+# representing the total number of pages in the document.
+of_pages=/ {{pagesCount}}
+# LOCALIZATION NOTE (page_of_pages): "{{pageNumber}}" and "{{pagesCount}}"
+# will be replaced by a number representing the currently visible page,
+# respectively a number representing the total number of pages in the document.
+page_of_pages=({{pageNumber}} / {{pagesCount}})
+
+zoom_out.title=Uzaklaştır
+zoom_out_label=Uzaklaştır
+zoom_in.title=Yaklaştır
+zoom_in_label=Yaklaştır
+zoom.title=Yakınlaştırma
+presentation_mode.title=Sunum moduna geç
+presentation_mode_label=Sunum modu
+open_file.title=Dosya aç
+open_file_label=Aç
+print.title=Yazdır
+print_label=Yazdır
+save.title=Kaydet
+save_label=Kaydet
+bookmark1.title=Geçerli sayfa (geçerli sayfanın adresini görüntüle)
+bookmark1_label=Geçerli sayfa
+# LOCALIZATION NOTE (open_in_app.title): This string is used in Firefox for Android.
+open_in_app.title=Uygulamada aç
+# LOCALIZATION NOTE (open_in_app_label): This string is used in Firefox for Android. Length of the translation matters since we are in a mobile context, with limited screen estate.
+open_in_app_label=Uygulamada aç
+
+# Secondary toolbar and context menu
+tools.title=Araçlar
+tools_label=Araçlar
+first_page.title=İlk sayfaya git
+first_page_label=İlk sayfaya git
+last_page.title=Son sayfaya git
+last_page_label=Son sayfaya git
+page_rotate_cw.title=Saat yönünde döndür
+page_rotate_cw_label=Saat yönünde döndür
+page_rotate_ccw.title=Saat yönünün tersine döndür
+page_rotate_ccw_label=Saat yönünün tersine döndür
+
+cursor_text_select_tool.title=Metin seçme aracını etkinleştir
+cursor_text_select_tool_label=Metin seçme aracı
+cursor_hand_tool.title=El aracını etkinleştir
+cursor_hand_tool_label=El aracı
+
+scroll_page.title=Sayfa kaydırmayı kullan
+scroll_page_label=Sayfa kaydırma
+scroll_vertical.title=Dikey kaydırma kullan
+scroll_vertical_label=Dikey kaydırma
+scroll_horizontal.title=Yatay kaydırma kullan
+scroll_horizontal_label=Yatay kaydırma
+scroll_wrapped.title=Yan yana kaydırmayı kullan
+scroll_wrapped_label=Yan yana kaydırma
+
+spread_none.title=Yan yana sayfaları birleştirme
+spread_none_label=Birleştirme
+spread_odd.title=Yan yana sayfaları tek numaralı sayfalardan başlayarak birleştir
+spread_odd_label=Tek numaralı
+spread_even.title=Yan yana sayfaları çift numaralı sayfalardan başlayarak birleştir
+spread_even_label=Çift numaralı
+
+# Document properties dialog box
+document_properties.title=Belge özellikleri…
+document_properties_label=Belge özellikleri…
+document_properties_file_name=Dosya adı:
+document_properties_file_size=Dosya boyutu:
+# LOCALIZATION NOTE (document_properties_kb): "{{size_kb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in kilobytes, respectively in bytes.
+document_properties_kb={{size_kb}} KB ({{size_b}} bayt)
+# LOCALIZATION NOTE (document_properties_mb): "{{size_mb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in megabytes, respectively in bytes.
+document_properties_mb={{size_mb}} MB ({{size_b}} bayt)
+document_properties_title=Başlık:
+document_properties_author=Yazar:
+document_properties_subject=Konu:
+document_properties_keywords=Anahtar kelimeler:
+document_properties_creation_date=Oluturma tarihi:
+document_properties_modification_date=Değiştirme tarihi:
+# LOCALIZATION NOTE (document_properties_date_string): "{{date}}" and "{{time}}"
+# will be replaced by the creation/modification date, and time, of the PDF file.
+document_properties_date_string={{date}} {{time}}
+document_properties_creator=Oluşturan:
+document_properties_producer=PDF üreticisi:
+document_properties_version=PDF sürümü:
+document_properties_page_count=Sayfa sayısı:
+document_properties_page_size=Sayfa boyutu:
+document_properties_page_size_unit_inches=inç
+document_properties_page_size_unit_millimeters=mm
+document_properties_page_size_orientation_portrait=dikey
+document_properties_page_size_orientation_landscape=yatay
+document_properties_page_size_name_a3=A3
+document_properties_page_size_name_a4=A4
+document_properties_page_size_name_letter=Letter
+document_properties_page_size_name_legal=Legal
+# LOCALIZATION NOTE (document_properties_page_size_dimension_string):
+# "{{width}}", "{{height}}", {{unit}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement and orientation, of the (current) page.
+document_properties_page_size_dimension_string={{width}} × {{height}} {{unit}} ({{orientation}})
+# LOCALIZATION NOTE (document_properties_page_size_dimension_name_string):
+# "{{width}}", "{{height}}", {{unit}}, {{name}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement, name, and orientation, of the (current) page.
+document_properties_page_size_dimension_name_string={{width}} × {{height}} {{unit}} ({{name}}, {{orientation}})
+# LOCALIZATION NOTE (document_properties_linearized): The linearization status of
+# the document; usually called "Fast Web View" in English locales of Adobe software.
+document_properties_linearized=Hızlı web görünümü:
+document_properties_linearized_yes=Evet
+document_properties_linearized_no=Hayır
+document_properties_close=Kapat
+
+print_progress_message=Belge yazdırılmaya hazırlanıyor…
+# LOCALIZATION NOTE (print_progress_percent): "{{progress}}" will be replaced by
+# a numerical per cent value.
+print_progress_percent=%{{progress}}
+print_progress_close=İptal
+
+# Tooltips and alt text for side panel toolbar buttons
+# (the _label strings are alt text for the buttons, the .title strings are
+# tooltips)
+toggle_sidebar.title=Kenar çubuğunu aç/kapat
+toggle_sidebar_notification2.title=Kenar çubuğunu aç/kapat (Belge ana hat/ekler/katmanlar içeriyor)
+toggle_sidebar_label=Kenar çubuğunu aç/kapat
+document_outline.title=Belge ana hatlarını göster (Tüm öğeleri genişletmek/daraltmak için çift tıklayın)
+document_outline_label=Belge ana hatları
+attachments.title=Ekleri göster
+attachments_label=Ekler
+layers.title=Katmanları göster (tüm katmanları varsayılan duruma sıfırlamak için çift tıklayın)
+layers_label=Katmanlar
+thumbs.title=Küçük resimleri göster
+thumbs_label=Küçük resimler
+current_outline_item.title=Mevcut ana hat öğesini bul
+current_outline_item_label=Mevcut ana hat öğesi
+findbar.title=Belgede bul
+findbar_label=Bul
+
+additional_layers=Ek katmanlar
+# LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
+page_landmark=Sayfa {{page}}
+# Thumbnails panel item (tooltip and alt text for images)
+# LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
+# number.
+thumb_page_title=Sayfa {{page}}
+# LOCALIZATION NOTE (thumb_page_canvas): "{{page}}" will be replaced by the page
+# number.
+thumb_page_canvas={{page}}. sayfanın küçük hâli
+
+# Find panel button title and messages
+find_input.title=Bul
+find_input.placeholder=Belgede bul…
+find_previous.title=Önceki eşleşmeyi bul
+find_previous_label=Önceki
+find_next.title=Sonraki eşleşmeyi bul
+find_next_label=Sonraki
+find_highlight=Tümünü vurgula
+find_match_case_label=Büyük-küçük harfe duyarlı
+find_match_diacritics_label=Fonetik işaretleri bul
+find_entire_word_label=Tam sözcükler
+find_reached_top=Belgenin başına ulaşıldı, sonundan devam edildi
+find_reached_bottom=Belgenin sonuna ulaşıldı, başından devam edildi
+# LOCALIZATION NOTE (find_match_count): The supported plural forms are
+# [one|two|few|many|other], with [other] as the default value.
+# "{{current}}" and "{{total}}" will be replaced by a number representing the
+# index of the currently active find result, respectively a number representing
+# the total number of matches in the document.
+find_match_count={[ plural(total) ]}
+find_match_count[one]={{total}} eşleşmeden {{current}}. eşleşme
+find_match_count[two]={{total}} eşleşmeden {{current}}. eşleşme
+find_match_count[few]={{total}} eşleşmeden {{current}}. eşleşme
+find_match_count[many]={{total}} eşleşmeden {{current}}. eşleşme
+find_match_count[other]={{total}} eşleşmeden {{current}}. eşleşme
+# LOCALIZATION NOTE (find_match_count_limit): The supported plural forms are
+# [zero|one|two|few|many|other], with [other] as the default value.
+# "{{limit}}" will be replaced by a numerical value.
+find_match_count_limit={[ plural(limit) ]}
+find_match_count_limit[zero]={{limit}} eşleşmeden fazla
+find_match_count_limit[one]={{limit}} eşleşmeden fazla
+find_match_count_limit[two]={{limit}} eşleşmeden fazla
+find_match_count_limit[few]={{limit}} eşleşmeden fazla
+find_match_count_limit[many]={{limit}} eşleşmeden fazla
+find_match_count_limit[other]={{limit}} eşleşmeden fazla
+find_not_found=Eşleşme bulunamadı
+
+# Predefined zoom values
+page_scale_width=Sayfa genişliği
+page_scale_fit=Sayfayı sığdır
+page_scale_auto=Otomatik yakınlaştır
+page_scale_actual=Gerçek boyut
+# LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
+# numerical scale value.
+page_scale_percent=%{{scale}}
+
+# Loading indicator messages
+loading_error=PDF yüklenirken bir hata oluştu.
+invalid_file_error=Geçersiz veya bozulmuş PDF dosyası.
+missing_file_error=PDF dosyası eksik.
+unexpected_response_error=Beklenmeyen sunucu yanıtı.
+rendering_error=Sayfa yorumlanırken bir hata oluştu.
+
+# LOCALIZATION NOTE (annotation_date_string): "{{date}}" and "{{time}}" will be
+# replaced by the modification date, and time, of the annotation.
+annotation_date_string={{date}}, {{time}}
+
+# LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
+# "{{type}}" will be replaced with an annotation type from a list defined in
+# the PDF spec (32000-1:2008 Table 169 – Annotation types).
+# Some common types are e.g.: "Check", "Text", "Comment", "Note"
+text_annotation_type.alt=[{{type}} işareti]
+password_label=Bu PDF dosyasını açmak için parolasını yazın.
+password_invalid=Geçersiz parola. Lütfen yeniden deneyin.
+password_ok=Tamam
+password_cancel=İptal
+
+printing_not_supported=Uyarı: Yazdırma bu tarayıcı tarafından tam olarak desteklenmemektedir.
+printing_not_ready=Uyarı: PDF tamamen yüklenmedi ve yazdırmaya hazır değil.
+web_fonts_disabled=Web fontları devre dışı: Gömülü PDF fontları kullanılamıyor.
+
+# Editor
+editor_free_text2.title=Metin
+editor_free_text2_label=Metin
+editor_ink2.title=Çiz
+editor_ink2_label=Çiz
+
+editor_stamp.title=Resim ekle
+editor_stamp_label=Resim ekle
+
+free_text2_default_content=Yazmaya başlayın…
+
+# Editor Parameters
+editor_free_text_color=Renk
+editor_free_text_size=Boyut
+editor_ink_color=Renk
+editor_ink_thickness=Kalınlık
+editor_ink_opacity=Saydamlık
+
+# Editor aria
+editor_free_text2_aria_label=Metin düzenleyicisi
+editor_ink2_aria_label=Çizim düzenleyicisi
+editor_ink_canvas_aria_label=Kullanıcı tarafından oluşturulan resim

--- a/js/pdfjs/web/locale/trs/viewer.properties
+++ b/js/pdfjs/web/locale/trs/viewer.properties
@@ -1,0 +1,184 @@
+# Copyright 2012 Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Main toolbar buttons (tooltips and alt text for images)
+previous.title=Pajinâ gunâj rukùu
+previous_label=Sa gachin
+next.title=Pajinâ 'na' ñaan
+next_label=Ne' ñaan
+
+# LOCALIZATION NOTE (page.title): The tooltip for the pageNumber input.
+page.title=Ñanj
+# LOCALIZATION NOTE (of_pages): "{{pagesCount}}" will be replaced by a number
+# representing the total number of pages in the document.
+of_pages=si'iaj {{pagesCount}}
+# LOCALIZATION NOTE (page_of_pages): "{{pageNumber}}" and "{{pagesCount}}"
+# will be replaced by a number representing the currently visible page,
+# respectively a number representing the total number of pages in the document.
+page_of_pages=({{pageNumber}} of {{pagesCount}})
+
+zoom_out.title=Nagi'iaj li'
+zoom_out_label=Nagi'iaj li'
+zoom_in.title=Nagi'iaj niko'
+zoom_in_label=Nagi'iaj niko'
+zoom.title=dàj nìko ma'an
+presentation_mode.title=Naduno' daj ga ma
+presentation_mode_label=Daj gà ma
+open_file.title=Na'nïn' chrû ñanj
+open_file_label=Na'nïn
+print.title=Nari' ña du'ua
+print_label=Nari' ñadu'ua
+
+# Secondary toolbar and context menu
+tools.title=Rasun
+tools_label=Nej rasùun
+first_page.title=gun' riña pajina asiniin
+first_page_label=Gun' riña pajina asiniin
+last_page.title=Gun' riña pajina rukù ni'in
+last_page_label=Gun' riña pajina rukù ni'inj
+page_rotate_cw.title=Tanikaj ne' huat
+page_rotate_cw_label=Tanikaj ne' huat
+page_rotate_ccw.title=Tanikaj ne' chînt'
+page_rotate_ccw_label=Tanikaj ne' chint
+
+cursor_text_select_tool.title=Dugi'iaj sun' sa ganahui texto
+cursor_text_select_tool_label=Nej rasun arajsun' da' nahui' texto
+cursor_hand_tool.title=Nachrun' nej rasun
+cursor_hand_tool_label=Sa rajsun ro'o'
+
+scroll_vertical.title=Garasun' dukuán runūu
+scroll_vertical_label=Dukuán runūu
+scroll_horizontal.title=Garasun' dukuán nikin' nahui
+scroll_horizontal_label=Dukuán nikin' nahui
+scroll_wrapped.title=Garasun' sa nachree
+scroll_wrapped_label=Sa nachree
+
+spread_none.title=Si nagi'iaj nugun'un' nej pagina hua ninin
+spread_none_label=Ni'io daj hua pagina
+spread_odd.title=Nagi'iaj nugua'ant nej pajina
+spread_odd_label=Ni'io' daj hua libro gurin
+spread_even.title=Nakāj dugui' ngà nej pajinâ ayi'ì ngà da' hùi hùi
+spread_even_label=Nahuin nìko nej
+
+# Document properties dialog box
+document_properties.title=Nej sa nikāj ñanj…
+document_properties_label=Nej sa nikāj ñanj…
+document_properties_file_name=Si yugui archîbo:
+document_properties_file_size=Dàj yachìj archîbo:
+# LOCALIZATION NOTE (document_properties_kb): "{{size_kb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in kilobytes, respectively in bytes.
+document_properties_kb={{size_kb}} KB ({{size_b}} bytes)
+# LOCALIZATION NOTE (document_properties_mb): "{{size_mb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in megabytes, respectively in bytes.
+document_properties_mb={{size_mb}} MB ({{size_b}} bytes)
+document_properties_title=Si yugui:
+document_properties_author=Sí girirà:
+document_properties_subject=Dugui':
+document_properties_keywords=Nej nuguan' huìi:
+document_properties_creation_date=Gui gurugui' man:
+document_properties_modification_date=Nuguan' nahuin nakà:
+# LOCALIZATION NOTE (document_properties_date_string): "{{date}}" and "{{time}}"
+# will be replaced by the creation/modification date, and time, of the PDF file.
+document_properties_date_string={{date}}, {{time}}
+document_properties_creator=Guiri ro'
+document_properties_producer=Sa ri PDF:
+document_properties_version=PDF Version:
+document_properties_page_count=Si Guendâ Pâjina:
+document_properties_page_size=Dàj yachìj pâjina:
+document_properties_page_size_unit_inches=riña
+document_properties_page_size_unit_millimeters=mm
+document_properties_page_size_orientation_portrait=nadu'ua
+document_properties_page_size_orientation_landscape=dàj huaj
+document_properties_page_size_name_a3=A3
+document_properties_page_size_name_a4=A4
+document_properties_page_size_name_letter=Da'ngà'a
+document_properties_page_size_name_legal=Nuguan' a'nï'ïn
+# LOCALIZATION NOTE (document_properties_page_size_dimension_string):
+# "{{width}}", "{{height}}", {{unit}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement and orientation, of the (current) page.
+document_properties_page_size_dimension_string={{width}} × {{height}} {{unit}} ({{orientation}})
+# LOCALIZATION NOTE (document_properties_page_size_dimension_name_string):
+# "{{width}}", "{{height}}", {{unit}}, {{name}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement, name, and orientation, of the (current) page.
+document_properties_page_size_dimension_name_string={{width}} × {{height}} {{unit}} ({{name}}, {{orientation}})
+# LOCALIZATION NOTE (document_properties_linearized): The linearization status of
+# the document; usually called "Fast Web View" in English locales of Adobe software.
+document_properties_linearized=Nanèt chre ni'iajt riña Web:
+document_properties_linearized_yes=Ga'ue
+document_properties_linearized_no=Si ga'ue
+document_properties_close=Narán
+
+# LOCALIZATION NOTE (print_progress_percent): "{{progress}}" will be replaced by
+# a numerical per cent value.
+print_progress_percent={{progress}}%
+print_progress_close=Duyichin'
+
+# Tooltips and alt text for side panel toolbar buttons
+# (the _label strings are alt text for the buttons, the .title strings are
+# tooltips)
+toggle_sidebar.title=Nadunā barrâ nù yi'nïn
+toggle_sidebar_label=Nadunā barrâ nù yi'nïn
+findbar_label=Narì'
+
+# Thumbnails panel item (tooltip and alt text for images)
+# LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
+# number.
+# LOCALIZATION NOTE (thumb_page_canvas): "{{page}}" will be replaced by the page
+# number.
+
+# Find panel button title and messages
+find_input.title=Narì'
+find_previous_label=Sa gachîn
+find_next_label=Ne' ñaan
+find_highlight=Daran' sa ña'an 
+find_match_case_label=Match case
+# LOCALIZATION NOTE (find_match_count): The supported plural forms are
+# [one|two|few|many|other], with [other] as the default value.
+# "{{current}}" and "{{total}}" will be replaced by a number representing the
+# index of the currently active find result, respectively a number representing
+# the total number of matches in the document.
+find_match_count={[ plural(total) ]}
+find_match_count[one]={{current}} si'iaj {{total}} guña gè huaj
+find_match_count[two]={{current}} si'iaj {{total}} guña gè huaj
+find_match_count[few]={{current}} si'iaj {{total}} guña gè huaj
+find_match_count[many]={{current}} si'iaj {{total}} guña gè huaj
+find_match_count[other]={{current}} of {{total}} matches
+# LOCALIZATION NOTE (find_match_count_limit): The supported plural forms are
+# [zero|one|two|few|many|other], with [other] as the default value.
+# "{{limit}}" will be replaced by a numerical value.
+find_match_count_limit={[ plural(limit) ]}
+find_match_count_limit[zero]=Doj ngà da' {{limit}} nej sa nari' dugui'i
+find_match_count_limit[one]=Doj ngà da' {{limit}} sa nari' dugui'i
+find_match_count_limit[two]=Doj ngà da' {{limit}} nej sa nari' dugui'i
+find_match_count_limit[few]=Doj ngà da' {{limit}} nej sa nari' dugui'i
+find_match_count_limit[many]=Doj ngà da' {{limit}} nej sa nari' dugui'i
+find_match_count_limit[other]=Doj ngà da' {{limit}} nej sa nari' dugui'i
+find_not_found=Nu narì'ij nugua'anj
+
+# Predefined zoom values
+page_scale_actual=Dàj yàchi akuan' nín
+# LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
+# numerical scale value.
+page_scale_percent={{scale}}%
+
+# LOCALIZATION NOTE (annotation_date_string): "{{date}}" and "{{time}}" will be
+# replaced by the modification date, and time, of the annotation.
+
+# LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
+# "{{type}}" will be replaced with an annotation type from a list defined in
+# the PDF spec (32000-1:2008 Table 169 – Annotation types).
+# Some common types are e.g.: "Check", "Text", "Comment", "Note"
+password_ok=Ga'ue
+password_cancel=Duyichin'
+

--- a/js/pdfjs/web/locale/uk/viewer.properties
+++ b/js/pdfjs/web/locale/uk/viewer.properties
@@ -1,0 +1,257 @@
+# Copyright 2012 Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Main toolbar buttons (tooltips and alt text for images)
+previous.title=Попередня сторінка
+previous_label=Попередня
+next.title=Наступна сторінка
+next_label=Наступна
+
+# LOCALIZATION NOTE (page.title): The tooltip for the pageNumber input.
+page.title=Сторінка
+# LOCALIZATION NOTE (of_pages): "{{pagesCount}}" will be replaced by a number
+# representing the total number of pages in the document.
+of_pages=із {{pagesCount}}
+# LOCALIZATION NOTE (page_of_pages): "{{pageNumber}}" and "{{pagesCount}}"
+# will be replaced by a number representing the currently visible page,
+# respectively a number representing the total number of pages in the document.
+page_of_pages=({{pageNumber}} із {{pagesCount}})
+
+zoom_out.title=Зменшити
+zoom_out_label=Зменшити
+zoom_in.title=Збільшити
+zoom_in_label=Збільшити
+zoom.title=Масштаб
+presentation_mode.title=Перейти в режим презентації
+presentation_mode_label=Режим презентації
+open_file.title=Відкрити файл
+open_file_label=Відкрити
+print.title=Друк
+print_label=Друк
+
+save.title=Зберегти
+save_label=Зберегти
+bookmark1.title=Поточна сторінка (перегляд URL-адреси з поточної сторінки)
+bookmark1_label=Поточна сторінка
+
+open_in_app.title=Відкрити у програмі
+open_in_app_label=Відкрити у програмі
+
+# Secondary toolbar and context menu
+tools.title=Інструменти
+tools_label=Інструменти
+first_page.title=На першу сторінку
+first_page_label=На першу сторінку
+last_page.title=На останню сторінку
+last_page_label=На останню сторінку
+page_rotate_cw.title=Повернути за годинниковою стрілкою
+page_rotate_cw_label=Повернути за годинниковою стрілкою
+page_rotate_ccw.title=Повернути проти годинникової стрілки
+page_rotate_ccw_label=Повернути проти годинникової стрілки
+
+cursor_text_select_tool.title=Увімкнути інструмент вибору тексту
+cursor_text_select_tool_label=Інструмент вибору тексту
+cursor_hand_tool.title=Увімкнути інструмент "Рука"
+cursor_hand_tool_label=Інструмент "Рука"
+
+scroll_page.title=Використовувати прокручування сторінки
+scroll_page_label=Прокручування сторінки
+scroll_vertical.title=Використовувати вертикальне прокручування
+scroll_vertical_label=Вертикальне прокручування
+scroll_horizontal.title=Використовувати горизонтальне прокручування
+scroll_horizontal_label=Горизонтальне прокручування
+scroll_wrapped.title=Використовувати масштабоване прокручування
+scroll_wrapped_label=Масштабоване прокручування
+
+spread_none.title=Не використовувати розгорнуті сторінки
+spread_none_label=Без розгорнутих сторінок
+spread_odd.title=Розгорнуті сторінки починаються з непарних номерів
+spread_odd_label=Непарні сторінки зліва
+spread_even.title=Розгорнуті сторінки починаються з парних номерів
+spread_even_label=Парні сторінки зліва
+
+# Document properties dialog box
+document_properties.title=Властивості документа…
+document_properties_label=Властивості документа…
+document_properties_file_name=Назва файла:
+document_properties_file_size=Розмір файла:
+# LOCALIZATION NOTE (document_properties_kb): "{{size_kb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in kilobytes, respectively in bytes.
+document_properties_kb={{size_kb}} КБ ({{size_b}} bytes)
+# LOCALIZATION NOTE (document_properties_mb): "{{size_mb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in megabytes, respectively in bytes.
+document_properties_mb={{size_mb}} МБ ({{size_b}} bytes)
+document_properties_title=Заголовок:
+document_properties_author=Автор:
+document_properties_subject=Тема:
+document_properties_keywords=Ключові слова:
+document_properties_creation_date=Дата створення:
+document_properties_modification_date=Дата зміни:
+# LOCALIZATION NOTE (document_properties_date_string): "{{date}}" and "{{time}}"
+# will be replaced by the creation/modification date, and time, of the PDF file.
+document_properties_date_string={{date}}, {{time}}
+document_properties_creator=Створено:
+document_properties_producer=Виробник PDF:
+document_properties_version=Версія PDF:
+document_properties_page_count=Кількість сторінок:
+document_properties_page_size=Розмір сторінки:
+document_properties_page_size_unit_inches=дюймів
+document_properties_page_size_unit_millimeters=мм
+document_properties_page_size_orientation_portrait=книжкова
+document_properties_page_size_orientation_landscape=альбомна
+document_properties_page_size_name_a3=A3
+document_properties_page_size_name_a4=A4
+document_properties_page_size_name_letter=Letter
+document_properties_page_size_name_legal=Legal
+# LOCALIZATION NOTE (document_properties_page_size_dimension_string):
+# "{{width}}", "{{height}}", {{unit}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement and orientation, of the (current) page.
+document_properties_page_size_dimension_string={{width}} × {{height}} {{unit}} ({{orientation}})
+# LOCALIZATION NOTE (document_properties_page_size_dimension_name_string):
+# "{{width}}", "{{height}}", {{unit}}, {{name}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement, name, and orientation, of the (current) page.
+document_properties_page_size_dimension_name_string={{width}} × {{height}} {{unit}} ({{name}}, {{orientation}})
+# LOCALIZATION NOTE (document_properties_linearized): The linearization status of
+# the document; usually called "Fast Web View" in English locales of Adobe software.
+document_properties_linearized=Швидкий перегляд в Інтернеті:
+document_properties_linearized_yes=Так
+document_properties_linearized_no=Ні
+document_properties_close=Закрити
+
+print_progress_message=Підготовка документу до друку…
+# LOCALIZATION NOTE (print_progress_percent): "{{progress}}" will be replaced by
+# a numerical per cent value.
+print_progress_percent={{progress}}%
+print_progress_close=Скасувати
+
+# Tooltips and alt text for side panel toolbar buttons
+# (the _label strings are alt text for the buttons, the .title strings are
+# tooltips)
+toggle_sidebar.title=Бічна панель
+toggle_sidebar_notification2.title=Перемкнути бічну панель (документ містить ескіз/вкладення/шари)
+toggle_sidebar_label=Перемкнути бічну панель
+document_outline.title=Показати схему документу (подвійний клік для розгортання/згортання елементів)
+document_outline_label=Схема документа
+attachments.title=Показати прикріплення
+attachments_label=Прикріплення
+layers.title=Показати шари (двічі клацніть, щоб скинути всі шари до типового стану)
+layers_label=Шари
+thumbs.title=Показувати ескізи
+thumbs_label=Ескізи
+current_outline_item.title=Знайти поточний елемент змісту
+current_outline_item_label=Поточний елемент змісту
+findbar.title=Знайти в документі
+findbar_label=Знайти
+
+additional_layers=Додаткові шари
+# LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
+page_landmark=Сторінка {{page}}
+# Thumbnails panel item (tooltip and alt text for images)
+# LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
+# number.
+thumb_page_title=Сторінка {{page}}
+# LOCALIZATION NOTE (thumb_page_canvas): "{{page}}" will be replaced by the page
+# number.
+thumb_page_canvas=Ескіз сторінки {{page}}
+
+# Find panel button title and messages
+find_input.title=Знайти
+find_input.placeholder=Знайти в документі…
+find_previous.title=Знайти попереднє входження фрази
+find_previous_label=Попереднє
+find_next.title=Знайти наступне входження фрази
+find_next_label=Наступне
+find_highlight=Підсвітити все
+find_match_case_label=З урахуванням регістру
+find_match_diacritics_label=Відповідність діакритичних знаків
+find_entire_word_label=Цілі слова
+find_reached_top=Досягнуто початку документу, продовжено з кінця
+find_reached_bottom=Досягнуто кінця документу, продовжено з початку
+# LOCALIZATION NOTE (find_match_count): The supported plural forms are
+# [one|two|few|many|other], with [other] as the default value.
+# "{{current}}" and "{{total}}" will be replaced by a number representing the
+# index of the currently active find result, respectively a number representing
+# the total number of matches in the document.
+find_match_count={[ plural(total) ]}
+find_match_count[one]={{current}} збіг із {{total}}
+find_match_count[two]={{current}} збіги з {{total}}
+find_match_count[few]={{current}} збігів із {{total}}
+find_match_count[many]={{current}} збігів із {{total}}
+find_match_count[other]={{current}} збігів із {{total}}
+# LOCALIZATION NOTE (find_match_count_limit): The supported plural forms are
+# [zero|one|two|few|many|other], with [other] as the default value.
+# "{{limit}}" will be replaced by a numerical value.
+find_match_count_limit={[ plural(limit) ]}
+find_match_count_limit[zero]=Понад {{limit}} збігів
+find_match_count_limit[one]=Більше, ніж {{limit}} збіг
+find_match_count_limit[two]=Більше, ніж {{limit}} збіги
+find_match_count_limit[few]=Більше, ніж {{limit}} збігів
+find_match_count_limit[many]=Понад {{limit}} збігів
+find_match_count_limit[other]=Понад {{limit}} збігів
+find_not_found=Фразу не знайдено
+
+# Predefined zoom values
+page_scale_width=За шириною
+page_scale_fit=Вмістити
+page_scale_auto=Автомасштаб
+page_scale_actual=Дійсний розмір
+# LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
+# numerical scale value.
+page_scale_percent={{scale}}%
+
+# Loading indicator messages
+loading_error=Під час завантаження PDF сталася помилка.
+invalid_file_error=Недійсний або пошкоджений PDF-файл.
+missing_file_error=Відсутній PDF-файл.
+unexpected_response_error=Неочікувана відповідь сервера.
+
+rendering_error=Під час виведення сторінки сталася помилка.
+
+# LOCALIZATION NOTE (annotation_date_string): "{{date}}" and "{{time}}" will be
+# replaced by the modification date, and time, of the annotation.
+annotation_date_string={{date}}, {{time}}
+
+# LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
+# "{{type}}" will be replaced with an annotation type from a list defined in
+# the PDF spec (32000-1:2008 Table 169 – Annotation types).
+# Some common types are e.g.: "Check", "Text", "Comment", "Note"
+text_annotation_type.alt=[{{type}}-анотація]
+password_label=Введіть пароль для відкриття цього PDF-файла.
+password_invalid=Невірний пароль. Спробуйте ще.
+password_ok=Гаразд
+password_cancel=Скасувати
+
+printing_not_supported=Попередження: Цей браузер не повністю підтримує друк.
+printing_not_ready=Попередження: PDF не повністю завантажений для друку.
+web_fonts_disabled=Веб-шрифти вимкнено: неможливо використати вбудовані у PDF шрифти.
+
+# Editor
+editor_free_text2.title=Текст
+editor_free_text2_label=Текст
+editor_ink2.title=Малювати
+editor_ink2_label=Малювати
+
+free_text2_default_content=Почніть вводити…
+
+# Editor Parameters
+editor_free_text_color=Колір
+editor_free_text_size=Розмір
+editor_ink_color=Колір
+editor_ink_thickness=Товщина
+editor_ink_opacity=Прозорість
+
+# Editor aria
+editor_free_text2_aria_label=Текстовий редактор
+editor_ink2_aria_label=Графічний редактор
+editor_ink_canvas_aria_label=Зображення, створене користувачем

--- a/js/pdfjs/web/locale/ur/viewer.properties
+++ b/js/pdfjs/web/locale/ur/viewer.properties
@@ -1,0 +1,218 @@
+# Copyright 2012 Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Main toolbar buttons (tooltips and alt text for images)
+previous.title=پچھلا صفحہ
+previous_label=پچھلا
+next.title=اگلا صفحہ
+next_label=آگے
+
+# LOCALIZATION NOTE (page.title): The tooltip for the pageNumber input.
+page.title=صفحہ
+# LOCALIZATION NOTE (of_pages): "{{pagesCount}}" will be replaced by a number
+# representing the total number of pages in the document.
+of_pages={{pagesCount}} کا
+# LOCALIZATION NOTE (page_of_pages): "{{pageNumber}}" and "{{pagesCount}}"
+# will be replaced by a number representing the currently visible page,
+# respectively a number representing the total number of pages in the document.
+page_of_pages=({{pageNumber}} کا {{pagesCount}})
+
+zoom_out.title=باہر زوم کریں
+zoom_out_label=باہر زوم کریں
+zoom_in.title=اندر زوم کریں
+zoom_in_label=اندر زوم کریں
+zoom.title=زوم
+presentation_mode.title=پیشکش موڈ میں چلے جائیں
+presentation_mode_label=پیشکش موڈ
+open_file.title=مسل کھولیں
+open_file_label=کھولیں
+print.title=چھاپیں
+print_label=چھاپیں
+
+# Secondary toolbar and context menu
+tools.title=آلات
+tools_label=آلات
+first_page.title=پہلے صفحہ پر جائیں
+first_page_label=پہلے صفحہ پر جائیں
+last_page.title=آخری صفحہ پر جائیں
+last_page_label=آخری صفحہ پر جائیں
+page_rotate_cw.title=گھڑی وار گھمائیں
+page_rotate_cw_label=گھڑی وار گھمائیں
+page_rotate_ccw.title=ضد گھڑی وار گھمائیں
+page_rotate_ccw_label=ضد گھڑی وار گھمائیں
+
+cursor_text_select_tool.title=متن کے انتخاب کے ٹول کو فعال بناے
+cursor_text_select_tool_label=متن کے انتخاب کا آلہ
+cursor_hand_tool.title=ہینڈ ٹول کو فعال بناییں
+cursor_hand_tool_label=ہاتھ کا آلہ
+
+scroll_vertical.title=عمودی اسکرولنگ کا استعمال کریں
+scroll_vertical_label=عمودی اسکرولنگ
+scroll_horizontal.title=افقی سکرولنگ کا استعمال کریں
+scroll_horizontal_label=افقی سکرولنگ
+
+spread_none.title=صفحہ پھیلانے میں شامل نہ ہوں
+spread_none_label=کوئی پھیلاؤ نہیں
+spread_odd_label=تاک پھیلاؤ
+spread_even_label=جفت پھیلاؤ
+
+# Document properties dialog box
+document_properties.title=دستاویز خواص…
+document_properties_label=دستاویز خواص…\u0020
+document_properties_file_name=نام مسل:
+document_properties_file_size=مسل سائز:
+# LOCALIZATION NOTE (document_properties_kb): "{{size_kb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in kilobytes, respectively in bytes.
+document_properties_kb={{size_kb}} KB ({{size_b}} bytes)
+# LOCALIZATION NOTE (document_properties_mb): "{{size_mb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in megabytes, respectively in bytes.
+document_properties_mb={{size_mb}} MB ({{size_b}} bytes)
+document_properties_title=عنوان:
+document_properties_author=تخلیق کار:
+document_properties_subject=موضوع:
+document_properties_keywords=کلیدی الفاظ:
+document_properties_creation_date=تخلیق کی تاریخ:
+document_properties_modification_date=ترمیم کی تاریخ:
+# LOCALIZATION NOTE (document_properties_date_string): "{{date}}" and "{{time}}"
+# will be replaced by the creation/modification date, and time, of the PDF file.
+document_properties_date_string={{date}}، {{time}}
+document_properties_creator=تخلیق کار:
+document_properties_producer=PDF پیدا کار:
+document_properties_version=PDF ورژن:
+document_properties_page_count=صفحہ شمار:
+document_properties_page_size=صفہ کی لمبائ:
+document_properties_page_size_unit_inches=میں
+document_properties_page_size_unit_millimeters=mm
+document_properties_page_size_orientation_portrait=عمودی انداز
+document_properties_page_size_orientation_landscape=افقى انداز
+document_properties_page_size_name_a3=A3
+document_properties_page_size_name_a4=A4
+document_properties_page_size_name_letter=خط
+document_properties_page_size_name_legal=قانونی
+# LOCALIZATION NOTE (document_properties_page_size_dimension_string):
+# "{{width}}", "{{height}}", {{unit}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement and orientation, of the (current) page.
+document_properties_page_size_dimension_string={{width}} × {{height}} {{unit}} ({{orientation}})
+# LOCALIZATION NOTE (document_properties_page_size_dimension_name_string):
+# "{{width}}", "{{height}}", {{unit}}, {{name}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement, name, and orientation, of the (current) page.
+document_properties_page_size_dimension_name_string={{width}} × {{height}} {{unit}} {{name}} {{orientation}}
+# LOCALIZATION NOTE (document_properties_linearized): The linearization status of
+# the document; usually called "Fast Web View" in English locales of Adobe software.
+document_properties_linearized=تیز ویب دیکھیں:
+document_properties_linearized_yes=ہاں
+document_properties_linearized_no=نہیں
+document_properties_close=بند کریں
+
+print_progress_message=چھاپنے کرنے کے لیے دستاویز تیار کیے جا رھے ھیں
+# LOCALIZATION NOTE (print_progress_percent): "{{progress}}" will be replaced by
+# a numerical per cent value.
+print_progress_percent=*{{progress}}%*
+print_progress_close=منسوخ کریں
+
+# Tooltips and alt text for side panel toolbar buttons
+# (the _label strings are alt text for the buttons, the .title strings are
+# tooltips)
+toggle_sidebar.title=سلائیڈ ٹوگل کریں
+toggle_sidebar_label=سلائیڈ ٹوگل کریں
+document_outline.title=دستاویز کی سرخیاں دکھایں (تمام اشیاء وسیع / غائب کرنے کے لیے ڈبل کلک کریں)
+document_outline_label=دستاویز آؤٹ لائن
+attachments.title=منسلکات دکھائیں
+attachments_label=منسلکات
+thumbs.title=تھمبنیل دکھائیں
+thumbs_label=مجمل
+findbar.title=دستاویز میں ڈھونڈیں
+findbar_label=ڈھونڈیں
+
+# LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
+page_landmark=صفحہ {{page}}
+# Thumbnails panel item (tooltip and alt text for images)
+# LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
+# number.
+thumb_page_title=صفحہ {{page}}
+# LOCALIZATION NOTE (thumb_page_canvas): "{{page}}" will be replaced by the page
+# number.
+thumb_page_canvas=صفحے کا مجمل {{page}}
+
+# Find panel button title and messages
+find_input.title=ڈھونڈیں
+find_input.placeholder=دستاویز… میں ڈھونڈیں
+find_previous.title=فقرے کا پچھلا وقوع ڈھونڈیں
+find_previous_label=پچھلا
+find_next.title=فقرے کا اگلہ وقوع ڈھونڈیں
+find_next_label=آگے
+find_highlight=تمام نمایاں کریں
+find_match_case_label=حروف مشابہ کریں
+find_entire_word_label=تمام الفاظ
+find_reached_top=صفحہ کے شروع پر پہنچ گیا، نیچے سے جاری کیا
+find_reached_bottom=صفحہ کے اختتام پر پہنچ گیا، اوپر سے جاری کیا
+# LOCALIZATION NOTE (find_match_count): The supported plural forms are
+# [one|two|few|many|other], with [other] as the default value.
+# "{{current}}" and "{{total}}" will be replaced by a number representing the
+# index of the currently active find result, respectively a number representing
+# the total number of matches in the document.
+find_match_count={[ plural(total) ]}
+find_match_count[one]={{total}} میچ کا {{current}}
+find_match_count[few]={{total}} میچوں میں سے {{current}}
+find_match_count[many]={{total}} میچوں میں سے {{current}}
+find_match_count[other]={{total}} میچوں میں سے {{current}}
+# LOCALIZATION NOTE (find_match_count_limit): The supported plural forms are
+# [zero|one|two|few|many|other], with [other] as the default value.
+# "{{limit}}" will be replaced by a numerical value.
+find_match_count_limit={[ plural(total) ]}
+find_match_count_limit[zero]={{limit}} سے زیادہ میچ
+find_match_count_limit[one]={{limit}} سے زیادہ میچ
+find_match_count_limit[two]={{limit}} سے زیادہ میچ
+find_match_count_limit[few]={{limit}} سے زیادہ میچ
+find_match_count_limit[many]={{limit}} سے زیادہ میچ
+find_match_count_limit[other]={{limit}} سے زیادہ میچ
+find_not_found=فقرا نہیں ملا
+
+# Predefined zoom values
+page_scale_width=صفحہ چوڑائی
+page_scale_fit=صفحہ فٹنگ
+page_scale_auto=خودکار زوم
+page_scale_actual=اصل سائز
+# LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
+# numerical scale value.
+page_scale_percent={{scale}}%
+
+# Loading indicator messages
+loading_error=PDF لوڈ کرتے وقت نقص آ گیا۔
+invalid_file_error=ناجائز یا خراب PDF مسل
+missing_file_error=PDF مسل غائب ہے۔
+unexpected_response_error=غیرمتوقع پیش کار جواب
+
+rendering_error=صفحہ بناتے ہوئے نقص آ گیا۔
+
+# LOCALIZATION NOTE (annotation_date_string): "{{date}}" and "{{time}}" will be
+# replaced by the modification date, and time, of the annotation.
+annotation_date_string={{date}}.{{time}}
+
+# LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
+# "{{type}}" will be replaced with an annotation type from a list defined in
+# the PDF spec (32000-1:2008 Table 169 – Annotation types).
+# Some common types are e.g.: "Check", "Text", "Comment", "Note"
+text_annotation_type.alt=[{{type}} نوٹ]
+password_label=PDF مسل کھولنے کے لیے پاس ورڈ داخل کریں.
+password_invalid=ناجائز پاس ورڈ. براےؑ کرم دوبارہ کوشش کریں.
+password_ok=ٹھیک ہے
+password_cancel=منسوخ کریں
+
+printing_not_supported=تنبیہ:چھاپنا اس براؤزر پر پوری طرح معاونت شدہ نہیں ہے۔
+printing_not_ready=تنبیہ: PDF چھپائی کے لیے پوری طرح لوڈ نہیں ہوئی۔
+web_fonts_disabled=ویب فانٹ نا اہل ہیں: شامل PDF فانٹ استعمال کرنے میں ناکام۔
+# LOCALIZATION NOTE (unsupported_feature_signatures): Should contain the same
+# exact string as in the `chrome.properties` file.
+

--- a/js/pdfjs/web/locale/uz/viewer.properties
+++ b/js/pdfjs/web/locale/uz/viewer.properties
@@ -1,0 +1,142 @@
+# Copyright 2012 Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Main toolbar buttons (tooltips and alt text for images)
+previous.title=Oldingi sahifa
+previous_label=Oldingi
+next.title=Keyingi sahifa
+next_label=Keyingi
+
+# LOCALIZATION NOTE (page.title): The tooltip for the pageNumber input.
+# LOCALIZATION NOTE (of_pages): "{{pagesCount}}" will be replaced by a number
+# representing the total number of pages in the document.
+of_pages=/{{pagesCount}}
+# LOCALIZATION NOTE (page_of_pages): "{{pageNumber}}" and "{{pagesCount}}"
+# will be replaced by a number representing the currently visible page,
+# respectively a number representing the total number of pages in the document.
+
+zoom_out.title=Kichiklashtirish
+zoom_out_label=Kichiklashtirish
+zoom_in.title=Kattalashtirish
+zoom_in_label=Kattalashtirish
+zoom.title=Masshtab
+presentation_mode.title=Namoyish usuliga oʻtish
+presentation_mode_label=Namoyish usuli
+open_file.title=Faylni ochish
+open_file_label=Ochish
+print.title=Chop qilish
+print_label=Chop qilish
+
+# Secondary toolbar and context menu
+tools.title=Vositalar
+tools_label=Vositalar
+first_page.title=Birinchi sahifaga oʻtish
+first_page_label=Birinchi sahifaga oʻtish
+last_page.title=Soʻnggi sahifaga oʻtish
+last_page_label=Soʻnggi sahifaga oʻtish
+page_rotate_cw.title=Soat yoʻnalishi boʻyicha burish
+page_rotate_cw_label=Soat yoʻnalishi boʻyicha burish
+page_rotate_ccw.title=Soat yoʻnalishiga qarshi burish
+page_rotate_ccw_label=Soat yoʻnalishiga qarshi burish
+
+
+# Document properties dialog box
+document_properties.title=Hujjat xossalari
+document_properties_label=Hujjat xossalari
+document_properties_file_name=Fayl nomi:
+document_properties_file_size=Fayl hajmi:
+# LOCALIZATION NOTE (document_properties_kb): "{{size_kb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in kilobytes, respectively in bytes.
+document_properties_kb={{size_kb}} KB ({{size_b}} bytes)
+# LOCALIZATION NOTE (document_properties_mb): "{{size_mb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in megabytes, respectively in bytes.
+document_properties_mb={{size_mb}} MB ({{size_b}} bytes)
+document_properties_title=Nomi:
+document_properties_author=Muallifi:
+document_properties_subject=Mavzusi:
+document_properties_keywords=Kalit so‘zlar
+document_properties_creation_date=Yaratilgan sanasi:
+document_properties_modification_date=O‘zgartirilgan sanasi
+# LOCALIZATION NOTE (document_properties_date_string): "{{date}}" and "{{time}}"
+# will be replaced by the creation/modification date, and time, of the PDF file.
+document_properties_date_string={{date}}, {{time}}
+document_properties_creator=Yaratuvchi:
+document_properties_producer=PDF ishlab chiqaruvchi:
+document_properties_version=PDF versiyasi:
+document_properties_page_count=Sahifa soni:
+document_properties_close=Yopish
+
+# LOCALIZATION NOTE (print_progress_percent): "{{progress}}" will be replaced by
+# a numerical per cent value.
+
+# Tooltips and alt text for side panel toolbar buttons
+# (the _label strings are alt text for the buttons, the .title strings are
+# tooltips)
+toggle_sidebar.title=Yon panelni yoqib/oʻchirib qoʻyish
+toggle_sidebar_label=Yon panelni yoqib/oʻchirib qoʻyish
+document_outline_label=Hujjat tuzilishi
+attachments.title=Ilovalarni ko‘rsatish
+attachments_label=Ilovalar
+thumbs.title=Nishonchalarni koʻrsatish
+thumbs_label=Nishoncha
+findbar.title=Hujjat ichidan topish
+
+# Thumbnails panel item (tooltip and alt text for images)
+# LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
+# number.
+thumb_page_title={{page}} sahifa
+# LOCALIZATION NOTE (thumb_page_canvas): "{{page}}" will be replaced by the page
+# number.
+thumb_page_canvas={{page}} sahifa nishonchasi
+
+# Find panel button title and messages
+find_previous.title=Soʻzlardagi oldingi hodisani topish
+find_previous_label=Oldingi
+find_next.title=Iboradagi keyingi hodisani topish
+find_next_label=Keyingi
+find_highlight=Barchasini ajratib koʻrsatish
+find_match_case_label=Katta-kichik harflarni farqlash
+find_reached_top=Hujjatning boshigacha yetib keldik, pastdan davom ettiriladi
+find_reached_bottom=Hujjatning oxiriga yetib kelindi, yuqoridan davom ettirladi
+find_not_found=Soʻzlar topilmadi
+
+# Predefined zoom values
+page_scale_width=Sahifa eni
+page_scale_fit=Sahifani moslashtirish
+page_scale_auto=Avtomatik masshtab
+page_scale_actual=Haqiqiy hajmi
+# LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
+# numerical scale value.
+page_scale_percent={{scale}}%
+
+loading_error=PDF yuklanayotganda xato yuz berdi.
+invalid_file_error=Xato yoki buzuq PDF fayli.
+missing_file_error=PDF fayl kerak.
+unexpected_response_error=Kutilmagan server javobi.
+
+rendering_error=Sahifa renderlanayotganda xato yuz berdi.
+
+# LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
+# "{{type}}" will be replaced with an annotation type from a list defined in
+# the PDF spec (32000-1:2008 Table 169 – Annotation types).
+# Some common types are e.g.: "Check", "Text", "Comment", "Note"
+text_annotation_type.alt=[{{type}} Annotation]
+password_label=PDF faylni ochish uchun parolni kiriting.
+password_invalid=Parol - notoʻgʻri. Qaytadan urinib koʻring.
+password_ok=OK
+
+printing_not_supported=Diqqat: chop qilish bruzer tomonidan toʻliq qoʻllab-quvvatlanmaydi.
+printing_not_ready=Diqqat: PDF fayl chop qilish uchun toʻliq yuklanmadi.
+web_fonts_disabled=Veb shriftlar oʻchirilgan: ichki PDF shriftlardan foydalanib boʻlmmaydi.
+

--- a/js/pdfjs/web/locale/vi/viewer.properties
+++ b/js/pdfjs/web/locale/vi/viewer.properties
@@ -1,0 +1,257 @@
+# Copyright 2012 Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Main toolbar buttons (tooltips and alt text for images)
+previous.title=Trang trước
+previous_label=Trước
+next.title=Trang Sau
+next_label=Tiếp
+
+# LOCALIZATION NOTE (page.title): The tooltip for the pageNumber input.
+page.title=Trang
+# LOCALIZATION NOTE (of_pages): "{{pagesCount}}" will be replaced by a number
+# representing the total number of pages in the document.
+of_pages=trên {{pagesCount}}
+# LOCALIZATION NOTE (page_of_pages): "{{pageNumber}}" and "{{pagesCount}}"
+# will be replaced by a number representing the currently visible page,
+# respectively a number representing the total number of pages in the document.
+page_of_pages=({{pageNumber}} trên {{pagesCount}})
+
+zoom_out.title=Thu nhỏ
+zoom_out_label=Thu nhỏ
+zoom_in.title=Phóng to
+zoom_in_label=Phóng to
+zoom.title=Thu phóng
+presentation_mode.title=Chuyển sang chế độ trình chiếu
+presentation_mode_label=Chế độ trình chiếu
+open_file.title=Mở tập tin
+open_file_label=Mở tập tin
+print.title=In
+print_label=In
+
+save.title=Lưu
+save_label=Lưu
+bookmark1.title=Trang hiện tại (xem URL từ trang hiện tại)
+bookmark1_label=Trang hiện tại
+
+open_in_app.title=Mở trong ứng dụng
+open_in_app_label=Mở trong ứng dụng
+
+# Secondary toolbar and context menu
+tools.title=Công cụ
+tools_label=Công cụ
+first_page.title=Về trang đầu
+first_page_label=Về trang đầu
+last_page.title=Đến trang cuối
+last_page_label=Đến trang cuối
+page_rotate_cw.title=Xoay theo chiều kim đồng hồ
+page_rotate_cw_label=Xoay theo chiều kim đồng hồ
+page_rotate_ccw.title=Xoay ngược chiều kim đồng hồ
+page_rotate_ccw_label=Xoay ngược chiều kim đồng hồ
+
+cursor_text_select_tool.title=Kích hoạt công cụ chọn vùng văn bản
+cursor_text_select_tool_label=Công cụ chọn vùng văn bản
+cursor_hand_tool.title=Kích hoạt công cụ con trỏ
+cursor_hand_tool_label=Công cụ con trỏ
+
+scroll_page.title=Sử dụng cuộn trang hiện tại
+scroll_page_label=Cuộn trang hiện tại
+scroll_vertical.title=Sử dụng cuộn dọc
+scroll_vertical_label=Cuộn dọc
+scroll_horizontal.title=Sử dụng cuộn ngang
+scroll_horizontal_label=Cuộn ngang
+scroll_wrapped.title=Sử dụng cuộn ngắt dòng
+scroll_wrapped_label=Cuộn ngắt dòng
+
+spread_none.title=Không nối rộng trang
+spread_none_label=Không có phân cách
+spread_odd.title=Nối trang bài bắt đầu với các trang được đánh số lẻ
+spread_odd_label=Phân cách theo số lẻ
+spread_even.title=Nối trang bài bắt đầu với các trang được đánh số chẵn
+spread_even_label=Phân cách theo số chẵn
+
+# Document properties dialog box
+document_properties.title=Thuộc tính của tài liệu…
+document_properties_label=Thuộc tính của tài liệu…
+document_properties_file_name=Tên tập tin:
+document_properties_file_size=Kích thước:
+# LOCALIZATION NOTE (document_properties_kb): "{{size_kb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in kilobytes, respectively in bytes.
+document_properties_kb={{size_kb}} KB ({{size_b}} byte)
+# LOCALIZATION NOTE (document_properties_mb): "{{size_mb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in megabytes, respectively in bytes.
+document_properties_mb={{size_mb}} MB ({{size_b}} byte)
+document_properties_title=Tiêu đề:
+document_properties_author=Tác giả:
+document_properties_subject=Chủ đề:
+document_properties_keywords=Từ khóa:
+document_properties_creation_date=Ngày tạo:
+document_properties_modification_date=Ngày sửa đổi:
+# LOCALIZATION NOTE (document_properties_date_string): "{{date}}" and "{{time}}"
+# will be replaced by the creation/modification date, and time, of the PDF file.
+document_properties_date_string={{date}}, {{time}}
+document_properties_creator=Người tạo:
+document_properties_producer=Phần mềm tạo PDF:
+document_properties_version=Phiên bản PDF:
+document_properties_page_count=Tổng số trang:
+document_properties_page_size=Kích thước trang:
+document_properties_page_size_unit_inches=in
+document_properties_page_size_unit_millimeters=mm
+document_properties_page_size_orientation_portrait=khổ dọc
+document_properties_page_size_orientation_landscape=khổ ngang
+document_properties_page_size_name_a3=A3
+document_properties_page_size_name_a4=A4
+document_properties_page_size_name_letter=Thư
+document_properties_page_size_name_legal=Pháp lý
+# LOCALIZATION NOTE (document_properties_page_size_dimension_string):
+# "{{width}}", "{{height}}", {{unit}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement and orientation, of the (current) page.
+document_properties_page_size_dimension_string={{width}} × {{height}} {{unit}} ({{orientation}})
+# LOCALIZATION NOTE (document_properties_page_size_dimension_name_string):
+# "{{width}}", "{{height}}", {{unit}}, {{name}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement, name, and orientation, of the (current) page.
+document_properties_page_size_dimension_name_string={{width}} × {{height}} {{unit}} ({{name}}, {{orientation}})
+# LOCALIZATION NOTE (document_properties_linearized): The linearization status of
+# the document; usually called "Fast Web View" in English locales of Adobe software.
+document_properties_linearized=Xem nhanh trên web:
+document_properties_linearized_yes=Có
+document_properties_linearized_no=Không
+document_properties_close=Ðóng
+
+print_progress_message=Chuẩn bị trang để in…
+# LOCALIZATION NOTE (print_progress_percent): "{{progress}}" will be replaced by
+# a numerical per cent value.
+print_progress_percent={{progress}}%
+print_progress_close=Hủy bỏ
+
+# Tooltips and alt text for side panel toolbar buttons
+# (the _label strings are alt text for the buttons, the .title strings are
+# tooltips)
+toggle_sidebar.title=Bật/Tắt thanh lề
+toggle_sidebar_notification2.title=Bật tắt thanh lề (tài liệu bao gồm bản phác thảo/tập tin đính kèm/lớp)
+toggle_sidebar_label=Bật/Tắt thanh lề
+document_outline.title=Hiển thị tài liệu phác thảo (nhấp đúp vào để mở rộng/thu gọn tất cả các mục)
+document_outline_label=Bản phác tài liệu
+attachments.title=Hiện nội dung đính kèm
+attachments_label=Nội dung đính kèm
+layers.title=Hiển thị các lớp (nhấp đúp để đặt lại tất cả các lớp về trạng thái mặc định)
+layers_label=Lớp
+thumbs.title=Hiển thị ảnh thu nhỏ
+thumbs_label=Ảnh thu nhỏ
+current_outline_item.title=Tìm mục phác thảo hiện tại
+current_outline_item_label=Mục phác thảo hiện tại
+findbar.title=Tìm trong tài liệu
+findbar_label=Tìm
+
+additional_layers=Các lớp bổ sung
+# LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
+page_landmark=Trang {{page}}
+# Thumbnails panel item (tooltip and alt text for images)
+# LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
+# number.
+thumb_page_title=Trang {{page}}
+# LOCALIZATION NOTE (thumb_page_canvas): "{{page}}" will be replaced by the page
+# number.
+thumb_page_canvas=Ảnh thu nhỏ của trang {{page}}
+
+# Find panel button title and messages
+find_input.title=Tìm
+find_input.placeholder=Tìm trong tài liệu…
+find_previous.title=Tìm cụm từ ở phần trước
+find_previous_label=Trước
+find_next.title=Tìm cụm từ ở phần sau
+find_next_label=Tiếp
+find_highlight=Tô sáng tất cả
+find_match_case_label=Phân biệt hoa, thường
+find_match_diacritics_label=Khớp dấu phụ
+find_entire_word_label=Toàn bộ từ
+find_reached_top=Đã đến phần đầu tài liệu, quay trở lại từ cuối
+find_reached_bottom=Đã đến phần cuối của tài liệu, quay trở lại từ đầu
+# LOCALIZATION NOTE (find_match_count): The supported plural forms are
+# [one|two|few|many|other], with [other] as the default value.
+# "{{current}}" and "{{total}}" will be replaced by a number representing the
+# index of the currently active find result, respectively a number representing
+# the total number of matches in the document.
+find_match_count={[ plural(total) ]}
+find_match_count[one]={{current}} của {{total}} đã trùng
+find_match_count[two]={{current}} của {{total}} đã trùng
+find_match_count[few]={{current}} của {{total}} đã trùng
+find_match_count[many]={{current}} của {{total}} đã trùng
+find_match_count[other]={{current}} của {{total}} đã trùng
+# LOCALIZATION NOTE (find_match_count_limit): The supported plural forms are
+# [zero|one|two|few|many|other], with [other] as the default value.
+# "{{limit}}" will be replaced by a numerical value.
+find_match_count_limit={[ plural(limit) ]}
+find_match_count_limit[zero]=Nhiều hơn {{limit}} đã trùng
+find_match_count_limit[one]=Nhiều hơn {{limit}} đã trùng
+find_match_count_limit[two]=Nhiều hơn {{limit}} đã trùng
+find_match_count_limit[few]=Nhiều hơn {{limit}} đã trùng
+find_match_count_limit[many]=Nhiều hơn {{limit}} đã trùng
+find_match_count_limit[other]=Nhiều hơn {{limit}} đã trùng
+find_not_found=Không tìm thấy cụm từ này
+
+# Predefined zoom values
+page_scale_width=Vừa chiều rộng
+page_scale_fit=Vừa chiều cao
+page_scale_auto=Tự động chọn kích thước
+page_scale_actual=Kích thước thực
+# LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
+# numerical scale value.
+page_scale_percent={{scale}}%
+
+# Loading indicator messages
+loading_error=Lỗi khi tải tài liệu PDF.
+invalid_file_error=Tập tin PDF hỏng hoặc không hợp lệ.
+missing_file_error=Thiếu tập tin PDF.
+unexpected_response_error=Máy chủ có phản hồi lạ.
+
+rendering_error=Lỗi khi hiển thị trang.
+
+# LOCALIZATION NOTE (annotation_date_string): "{{date}}" and "{{time}}" will be
+# replaced by the modification date, and time, of the annotation.
+annotation_date_string={{date}}, {{time}}
+
+# LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
+# "{{type}}" will be replaced with an annotation type from a list defined in
+# the PDF spec (32000-1:2008 Table 169 – Annotation types).
+# Some common types are e.g.: "Check", "Text", "Comment", "Note"
+text_annotation_type.alt=[{{type}} Chú thích]
+password_label=Nhập mật khẩu để mở tập tin PDF này.
+password_invalid=Mật khẩu không đúng. Vui lòng thử lại.
+password_ok=OK
+password_cancel=Hủy bỏ
+
+printing_not_supported=Cảnh báo: In ấn không được hỗ trợ đầy đủ ở trình duyệt này.
+printing_not_ready=Cảnh báo: PDF chưa được tải hết để in.
+web_fonts_disabled=Phông chữ Web bị vô hiệu hóa: không thể sử dụng các phông chữ PDF được nhúng.
+
+# Editor
+editor_free_text2.title=Văn bản
+editor_free_text2_label=Văn bản
+editor_ink2.title=Vẽ
+editor_ink2_label=Vẽ
+
+free_text2_default_content=Bắt đầu nhập…
+
+# Editor Parameters
+editor_free_text_color=Màu
+editor_free_text_size=Kích cỡ
+editor_ink_color=Màu
+editor_ink_thickness=Độ dày
+editor_ink_opacity=Độ mờ
+
+# Editor aria
+editor_free_text2_aria_label=Trình sửa văn bản
+editor_ink2_aria_label=Trình sửa nét vẽ
+editor_ink_canvas_aria_label=Hình ảnh do người dùng tạo

--- a/js/pdfjs/web/locale/wo/viewer.properties
+++ b/js/pdfjs/web/locale/wo/viewer.properties
@@ -1,0 +1,104 @@
+# Copyright 2012 Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Main toolbar buttons (tooltips and alt text for images)
+previous.title=Xët wi jiitu
+previous_label=Bi jiitu
+next.title=Xët wi ci topp
+next_label=Bi ci topp
+
+# LOCALIZATION NOTE (page.title): The tooltip for the pageNumber input.
+# LOCALIZATION NOTE (of_pages): "{{pagesCount}}" will be replaced by a number
+# representing the total number of pages in the document.
+# LOCALIZATION NOTE (page_of_pages): "{{pageNumber}}" and "{{pagesCount}}"
+# will be replaced by a number representing the currently visible page,
+# respectively a number representing the total number of pages in the document.
+
+zoom_out.title=Wàññi
+zoom_out_label=Wàññi
+zoom_in.title=Yaatal
+zoom_in_label=Yaatal
+zoom.title=Yambalaŋ
+presentation_mode.title=Wañarñil ci anamu wone
+presentation_mode_label=Anamu Wone
+open_file.title=Ubbi benn dencukaay
+open_file_label=Ubbi
+print.title=Móol
+print_label=Móol
+
+# Secondary toolbar and context menu
+
+
+# Document properties dialog box
+# LOCALIZATION NOTE (document_properties_kb): "{{size_kb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in kilobytes, respectively in bytes.
+# LOCALIZATION NOTE (document_properties_mb): "{{size_mb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in megabytes, respectively in bytes.
+document_properties_title=Bopp:
+# LOCALIZATION NOTE (document_properties_date_string): "{{date}}" and "{{time}}"
+# will be replaced by the creation/modification date, and time, of the PDF file.
+
+# LOCALIZATION NOTE (print_progress_percent): "{{progress}}" will be replaced by
+# a numerical per cent value.
+
+# Tooltips and alt text for side panel toolbar buttons
+# (the _label strings are alt text for the buttons, the .title strings are
+# tooltips)
+thumbs.title=Wone nataal yu ndaw yi
+thumbs_label=Nataal yu ndaw yi
+findbar.title=Gis ci biir jukki bi
+findbar_label=Wut
+
+# Thumbnails panel item (tooltip and alt text for images)
+# LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
+# number.
+thumb_page_title=Xët {{page}}
+# LOCALIZATION NOTE (thumb_page_canvas): "{{page}}" will be replaced by the page
+# number.
+thumb_page_canvas=Wiñet bu xët {{page}}
+
+# Find panel button title and messages
+find_previous.title=Seet beneen kaddu bu ni mel te jiitu
+find_previous_label=Bi jiitu
+find_next.title=Seet beneen kaddu bu ni mel
+find_next_label=Bi ci topp
+find_highlight=Melaxal lépp
+find_match_case_label=Sàmm jëmmalin wi
+find_reached_top=Jot nañu ndorteel xët wi, kontine dale ko ci suuf
+find_reached_bottom=Jot nañu jeexitalu xët wi, kontine ci ndorte
+find_not_found=Gisiñu kaddu gi
+
+# Predefined zoom values
+page_scale_width=Yaatuwaay bu mët
+page_scale_fit=Xët lëmm
+page_scale_auto=Yambalaŋ ci saa si
+page_scale_actual=Dayo bi am
+# LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
+# numerical scale value.
+
+loading_error=Am na njumte ci yebum dencukaay PDF bi.
+invalid_file_error=Dencukaay PDF bi baaxul walla mu sankar.
+
+rendering_error=Am njumte bu am bi xët bi di wonewu.
+
+# LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
+# "{{type}}" will be replaced with an annotation type from a list defined in
+# the PDF spec (32000-1:2008 Table 169 – Annotation types).
+# Some common types are e.g.: "Check", "Text", "Comment", "Note"
+text_annotation_type.alt=[Karmat {{type}}]
+password_ok=OK
+password_cancel=Neenal
+
+printing_not_supported=Artu: Joowkat bii nanguwul lool mool.
+

--- a/js/pdfjs/web/locale/xh/viewer.properties
+++ b/js/pdfjs/web/locale/xh/viewer.properties
@@ -1,0 +1,156 @@
+# Copyright 2012 Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Main toolbar buttons (tooltips and alt text for images)
+previous.title=Iphepha langaphambili
+previous_label=Okwangaphambili
+next.title=Iphepha elilandelayo
+next_label=Okulandelayo
+
+# LOCALIZATION NOTE (page.title): The tooltip for the pageNumber input.
+page.title=Iphepha
+# LOCALIZATION NOTE (of_pages): "{{pagesCount}}" will be replaced by a number
+# representing the total number of pages in the document.
+of_pages=kwali- {{pagesCount}}
+# LOCALIZATION NOTE (page_of_pages): "{{pageNumber}}" and "{{pagesCount}}"
+# will be replaced by a number representing the currently visible page,
+# respectively a number representing the total number of pages in the document.
+page_of_pages=({{pageNumber}} kwali {{pagesCount}})
+
+zoom_out.title=Bhekelisela Kudana
+zoom_out_label=Bhekelisela Kudana
+zoom_in.title=Sondeza Kufuphi
+zoom_in_label=Sondeza Kufuphi
+zoom.title=Yandisa / Nciphisa
+presentation_mode.title=Tshintshela kwimo yonikezelo
+presentation_mode_label=Imo yonikezelo
+open_file.title=Vula Ifayile
+open_file_label=Vula
+print.title=Printa
+print_label=Printa
+
+# Secondary toolbar and context menu
+tools.title=Izixhobo zemiyalelo
+tools_label=Izixhobo zemiyalelo
+first_page.title=Yiya kwiphepha lokuqala
+first_page_label=Yiya kwiphepha lokuqala
+last_page.title=Yiya kwiphepha lokugqibela
+last_page_label=Yiya kwiphepha lokugqibela
+page_rotate_cw.title=Jikelisa ngasekunene
+page_rotate_cw_label=Jikelisa ngasekunene
+page_rotate_ccw.title=Jikelisa ngasekhohlo
+page_rotate_ccw_label=Jikelisa ngasekhohlo
+
+cursor_text_select_tool.title=Vumela iSixhobo sokuKhetha iTeksti
+cursor_text_select_tool_label=ISixhobo sokuKhetha iTeksti
+cursor_hand_tool.title=Yenza iSixhobo seSandla siSebenze
+cursor_hand_tool_label=ISixhobo seSandla
+
+# Document properties dialog box
+document_properties.title=Iipropati zoxwebhu…
+document_properties_label=Iipropati zoxwebhu…
+document_properties_file_name=Igama lefayile:
+document_properties_file_size=Isayizi yefayile:
+# LOCALIZATION NOTE (document_properties_kb): "{{size_kb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in kilobytes, respectively in bytes.
+document_properties_kb={{size_kb}} KB (iibhayiti{{size_b}})
+# LOCALIZATION NOTE (document_properties_mb): "{{size_mb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in megabytes, respectively in bytes.
+document_properties_mb={{size_mb}} MB (iibhayithi{{size_b}})
+document_properties_title=Umxholo:
+document_properties_author=Umbhali:
+document_properties_subject=Umbandela:
+document_properties_keywords=Amagama aphambili:
+document_properties_creation_date=Umhla wokwenziwa kwayo:
+document_properties_modification_date=Umhla wokulungiswa kwayo:
+# LOCALIZATION NOTE (document_properties_date_string): "{{date}}" and "{{time}}"
+# will be replaced by the creation/modification date, and time, of the PDF file.
+document_properties_date_string={{date}}, {{time}}
+document_properties_creator=Umntu oyenzileyo:
+document_properties_producer=Umvelisi we-PDF:
+document_properties_version=Uhlelo lwe-PDF:
+document_properties_page_count=Inani lamaphepha:
+document_properties_close=Vala
+
+print_progress_message=Ilungisa uxwebhu ukuze iprinte…
+# LOCALIZATION NOTE (print_progress_percent): "{{progress}}" will be replaced by
+# a numerical per cent value.
+print_progress_percent={{progress}}%
+print_progress_close=Rhoxisa
+
+# Tooltips and alt text for side panel toolbar buttons
+# (the _label strings are alt text for the buttons, the .title strings are
+# tooltips)
+toggle_sidebar.title=Togola ngebha eseCaleni
+toggle_sidebar_label=Togola ngebha eseCaleni
+document_outline.title=Bonisa uLwandlalo loXwebhu (cofa kabini ukuze wandise/diliza zonke izinto)
+document_outline_label=Isishwankathelo soxwebhu
+attachments.title=Bonisa iziqhotyoshelwa
+attachments_label=Iziqhoboshelo
+thumbs.title=Bonisa ukrobiso kumfanekiso
+thumbs_label=Ukrobiso kumfanekiso
+findbar.title=Fumana kuXwebhu
+findbar_label=Fumana
+
+# Thumbnails panel item (tooltip and alt text for images)
+# LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
+# number.
+thumb_page_title=Iphepha {{page}}
+# LOCALIZATION NOTE (thumb_page_canvas): "{{page}}" will be replaced by the page
+# number.
+thumb_page_canvas=Ukrobiso kumfanekiso wephepha {{page}}
+
+# Find panel button title and messages
+find_input.title=Fumana
+find_input.placeholder=Fumana kuXwebhu…
+find_previous.title=Fumanisa isenzeko sangaphambili sebinzana lamagama
+find_previous_label=Okwangaphambili
+find_next.title=Fumanisa isenzeko esilandelayo sebinzana lamagama
+find_next_label=Okulandelayo
+find_highlight=Qaqambisa konke
+find_match_case_label=Tshatisa ngobukhulu bukanobumba
+find_reached_top=Ufike ngaphezulu ephepheni, kusukwa ngezantsi
+find_reached_bottom=Ufike ekupheleni kwephepha, kusukwa ngaphezulu
+find_not_found=Ibinzana alifunyenwanga
+
+# Predefined zoom values
+page_scale_width=Ububanzi bephepha
+page_scale_fit=Ukulinganiswa kwephepha
+page_scale_auto=Ukwandisa/Ukunciphisa Ngokwayo
+page_scale_actual=Ubungakanani bokwenene
+# LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
+# numerical scale value.
+page_scale_percent={{scale}}%
+
+loading_error=Imposiso yenzekile xa kulayishwa i-PDF.
+invalid_file_error=Ifayile ye-PDF engeyiyo okanye eyonakalisiweyo.
+missing_file_error=Ifayile ye-PDF edukileyo.
+unexpected_response_error=Impendulo yeseva engalindelekanga.
+
+rendering_error=Imposiso yenzekile xa bekunikezelwa iphepha.
+
+# LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
+# "{{type}}" will be replaced with an annotation type from a list defined in
+# the PDF spec (32000-1:2008 Table 169 – Annotation types).
+# Some common types are e.g.: "Check", "Text", "Comment", "Note"
+text_annotation_type.alt=[{{type}} Ubhalo-nqaku]
+password_label=Faka ipasiwedi ukuze uvule le fayile yePDF.
+password_invalid=Ipasiwedi ayisebenzi. Nceda uzame kwakhona.
+password_ok=KULUNGILE
+password_cancel=Rhoxisa
+
+printing_not_supported=Isilumkiso: Ukuprinta akuxhaswa ngokupheleleyo yile bhrawuza.
+printing_not_ready=Isilumkiso: IPDF ayihlohlwanga ngokupheleleyo ukwenzela ukuprinta.
+web_fonts_disabled=Iifonti zewebhu ziqhwalelisiwe: ayikwazi ukusebenzisa iifonti ze-PDF ezincanyathelisiweyo.
+

--- a/js/pdfjs/web/locale/zh-CN/viewer.properties
+++ b/js/pdfjs/web/locale/zh-CN/viewer.properties
@@ -1,0 +1,259 @@
+# Copyright 2012 Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Main toolbar buttons (tooltips and alt text for images)
+previous.title=上一页
+previous_label=上一页
+next.title=下一页
+next_label=下一页
+
+# LOCALIZATION NOTE (page.title): The tooltip for the pageNumber input.
+page.title=页面
+# LOCALIZATION NOTE (of_pages): "{{pagesCount}}" will be replaced by a number
+# representing the total number of pages in the document.
+of_pages=/ {{pagesCount}}
+# LOCALIZATION NOTE (page_of_pages): "{{pageNumber}}" and "{{pagesCount}}"
+# will be replaced by a number representing the currently visible page,
+# respectively a number representing the total number of pages in the document.
+page_of_pages=({{pageNumber}} / {{pagesCount}})
+
+zoom_out.title=缩小
+zoom_out_label=缩小
+zoom_in.title=放大
+zoom_in_label=放大
+zoom.title=缩放
+presentation_mode.title=切换到演示模式
+presentation_mode_label=演示模式
+open_file.title=打开文件
+open_file_label=打开
+print.title=打印
+print_label=打印
+save.title=保存
+save_label=保存
+bookmark1.title=当前页面（在当前页面查看 URL）
+bookmark1_label=当前页面
+# LOCALIZATION NOTE (open_in_app.title): This string is used in Firefox for Android.
+open_in_app.title=在应用中打开
+# LOCALIZATION NOTE (open_in_app_label): This string is used in Firefox for Android. Length of the translation matters since we are in a mobile context, with limited screen estate.
+open_in_app_label=在应用中打开
+
+# Secondary toolbar and context menu
+tools.title=工具
+tools_label=工具
+first_page.title=转到第一页
+first_page_label=转到第一页
+last_page.title=转到最后一页
+last_page_label=转到最后一页
+page_rotate_cw.title=顺时针旋转
+page_rotate_cw_label=顺时针旋转
+page_rotate_ccw.title=逆时针旋转
+page_rotate_ccw_label=逆时针旋转
+
+cursor_text_select_tool.title=启用文本选择工具
+cursor_text_select_tool_label=文本选择工具
+cursor_hand_tool.title=启用手形工具
+cursor_hand_tool_label=手形工具
+
+scroll_page.title=使用页面滚动
+scroll_page_label=页面滚动
+scroll_vertical.title=使用垂直滚动
+scroll_vertical_label=垂直滚动
+scroll_horizontal.title=使用水平滚动
+scroll_horizontal_label=水平滚动
+scroll_wrapped.title=使用平铺滚动
+scroll_wrapped_label=平铺滚动
+
+spread_none.title=不加入衔接页
+spread_none_label=单页视图
+spread_odd.title=加入衔接页使奇数页作为起始页
+spread_odd_label=双页视图
+spread_even.title=加入衔接页使偶数页作为起始页
+spread_even_label=书籍视图
+
+# Document properties dialog box
+document_properties.title=文档属性…
+document_properties_label=文档属性…
+document_properties_file_name=文件名:
+document_properties_file_size=文件大小:
+# LOCALIZATION NOTE (document_properties_kb): "{{size_kb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in kilobytes, respectively in bytes.
+document_properties_kb={{size_kb}} KB ({{size_b}} 字节)
+# LOCALIZATION NOTE (document_properties_mb): "{{size_mb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in megabytes, respectively in bytes.
+document_properties_mb={{size_mb}} MB ({{size_b}} 字节)
+document_properties_title=标题:
+document_properties_author=作者:
+document_properties_subject=主题:
+document_properties_keywords=关键词:
+document_properties_creation_date=创建日期:
+document_properties_modification_date=修改日期:
+# LOCALIZATION NOTE (document_properties_date_string): "{{date}}" and "{{time}}"
+# will be replaced by the creation/modification date, and time, of the PDF file.
+document_properties_date_string={{date}}, {{time}}
+document_properties_creator=创建者:
+document_properties_producer=PDF 生成器：
+document_properties_version=PDF 版本:
+document_properties_page_count=页数:
+document_properties_page_size=页面大小：
+document_properties_page_size_unit_inches=英寸
+document_properties_page_size_unit_millimeters=毫米
+document_properties_page_size_orientation_portrait=纵向
+document_properties_page_size_orientation_landscape=横向
+document_properties_page_size_name_a3=A3
+document_properties_page_size_name_a4=A4
+document_properties_page_size_name_letter=文本
+document_properties_page_size_name_legal=法律
+# LOCALIZATION NOTE (document_properties_page_size_dimension_string):
+# "{{width}}", "{{height}}", {{unit}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement and orientation, of the (current) page.
+document_properties_page_size_dimension_string={{width}} × {{height}} {{unit}}（{{orientation}}）
+# LOCALIZATION NOTE (document_properties_page_size_dimension_name_string):
+# "{{width}}", "{{height}}", {{unit}}, {{name}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement, name, and orientation, of the (current) page.
+document_properties_page_size_dimension_name_string={{width}} × {{height}} {{unit}}（{{name}}，{{orientation}}）
+# LOCALIZATION NOTE (document_properties_linearized): The linearization status of
+# the document; usually called "Fast Web View" in English locales of Adobe software.
+document_properties_linearized=快速 Web 视图：
+document_properties_linearized_yes=是
+document_properties_linearized_no=否
+document_properties_close=关闭
+
+print_progress_message=正在准备打印文档…
+# LOCALIZATION NOTE (print_progress_percent): "{{progress}}" will be replaced by
+# a numerical per cent value.
+print_progress_percent={{progress}}%
+print_progress_close=取消
+
+# Tooltips and alt text for side panel toolbar buttons
+# (the _label strings are alt text for the buttons, the .title strings are
+# tooltips)
+toggle_sidebar.title=切换侧栏
+toggle_sidebar_notification2.title=切换侧栏（文档所含的大纲/附件/图层）
+toggle_sidebar_label=切换侧栏
+document_outline.title=显示文档大纲（双击展开/折叠所有项）
+document_outline_label=文档大纲
+attachments.title=显示附件
+attachments_label=附件
+layers.title=显示图层（双击即可将所有图层重置为默认状态）
+layers_label=图层
+thumbs.title=显示缩略图
+thumbs_label=缩略图
+current_outline_item.title=查找当前大纲项目
+current_outline_item_label=当前大纲项目
+findbar.title=在文档中查找
+findbar_label=查找
+
+additional_layers=其他图层
+# LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
+page_landmark=第 {{page}} 页
+# Thumbnails panel item (tooltip and alt text for images)
+# LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
+# number.
+thumb_page_title=第 {{page}} 页
+# LOCALIZATION NOTE (thumb_page_canvas): "{{page}}" will be replaced by the page
+# number.
+thumb_page_canvas=页面 {{page}} 的缩略图
+
+# Find panel button title and messages
+find_input.title=查找
+find_input.placeholder=在文档中查找…
+find_previous.title=查找词语上一次出现的位置
+find_previous_label=上一页
+find_next.title=查找词语后一次出现的位置
+find_next_label=下一页
+find_highlight=全部高亮显示
+find_match_case_label=区分大小写
+find_match_diacritics_label=匹配变音符号
+find_entire_word_label=全词匹配
+find_reached_top=到达文档开头，从末尾继续
+find_reached_bottom=到达文档末尾，从开头继续
+# LOCALIZATION NOTE (find_match_count): The supported plural forms are
+# [one|two|few|many|other], with [other] as the default value.
+# "{{current}}" and "{{total}}" will be replaced by a number representing the
+# index of the currently active find result, respectively a number representing
+# the total number of matches in the document.
+find_match_count={[ plural(total) ]}
+find_match_count[one]=第 {{current}} 项，共匹配 {{total}} 项
+find_match_count[two]=第 {{current}} 项，共匹配 {{total}} 项
+find_match_count[few]=第 {{current}} 项，共匹配 {{total}} 项
+find_match_count[many]=第 {{current}} 项，共匹配 {{total}} 项
+find_match_count[other]=第 {{current}} 项，共匹配 {{total}} 项
+# LOCALIZATION NOTE (find_match_count_limit): The supported plural forms are
+# [zero|one|two|few|many|other], with [other] as the default value.
+# "{{limit}}" will be replaced by a numerical value.
+find_match_count_limit={[ plural(limit) ]}
+find_match_count_limit[zero]=超过 {{limit}} 项匹配
+find_match_count_limit[one]=超过 {{limit}} 项匹配
+find_match_count_limit[two]=超过 {{limit}} 项匹配
+find_match_count_limit[few]=超过 {{limit}} 项匹配
+find_match_count_limit[many]=超过 {{limit}} 项匹配
+find_match_count_limit[other]=超过 {{limit}} 项匹配
+find_not_found=找不到指定词语
+
+# Predefined zoom values
+page_scale_width=适合页宽
+page_scale_fit=适合页面
+page_scale_auto=自动缩放
+page_scale_actual=实际大小
+# LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
+# numerical scale value.
+page_scale_percent={{scale}}%
+
+# Loading indicator messages
+loading_error=加载 PDF 时发生错误。
+invalid_file_error=无效或损坏的 PDF 文件。
+missing_file_error=缺少 PDF 文件。
+unexpected_response_error=意外的服务器响应。
+rendering_error=渲染页面时发生错误。
+
+# LOCALIZATION NOTE (annotation_date_string): "{{date}}" and "{{time}}" will be
+# replaced by the modification date, and time, of the annotation.
+annotation_date_string={{date}}，{{time}}
+
+# LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
+# "{{type}}" will be replaced with an annotation type from a list defined in
+# the PDF spec (32000-1:2008 Table 169 – Annotation types).
+# Some common types are e.g.: "Check", "Text", "Comment", "Note"
+text_annotation_type.alt=[{{type}} 注释]
+password_label=输入密码以打开此 PDF 文件。
+password_invalid=密码无效。请重试。
+password_ok=确定
+password_cancel=取消
+
+printing_not_supported=警告：此浏览器尚未完整支持打印功能。
+printing_not_ready=警告：此 PDF 未完成加载，无法打印。
+web_fonts_disabled=Web 字体已被禁用：无法使用嵌入的 PDF 字体。
+
+# Editor
+editor_free_text2.title=文本
+editor_free_text2_label=文本
+editor_ink2.title=绘图
+editor_ink2_label=绘图
+
+editor_stamp.title=添加图像
+editor_stamp_label=添加图像
+
+free_text2_default_content=开始输入…
+
+# Editor Parameters
+editor_free_text_color=颜色
+editor_free_text_size=字号
+editor_ink_color=颜色
+editor_ink_thickness=粗细
+editor_ink_opacity=不透明度
+
+# Editor aria
+editor_free_text2_aria_label=文本编辑器
+editor_ink2_aria_label=绘图编辑器
+editor_ink_canvas_aria_label=用户创建图像

--- a/js/pdfjs/web/locale/zh-TW/viewer.properties
+++ b/js/pdfjs/web/locale/zh-TW/viewer.properties
@@ -1,0 +1,259 @@
+# Copyright 2012 Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Main toolbar buttons (tooltips and alt text for images)
+previous.title=上一頁
+previous_label=上一頁
+next.title=下一頁
+next_label=下一頁
+
+# LOCALIZATION NOTE (page.title): The tooltip for the pageNumber input.
+page.title=第
+# LOCALIZATION NOTE (of_pages): "{{pagesCount}}" will be replaced by a number
+# representing the total number of pages in the document.
+of_pages=頁，共 {{pagesCount}} 頁
+# LOCALIZATION NOTE (page_of_pages): "{{pageNumber}}" and "{{pagesCount}}"
+# will be replaced by a number representing the currently visible page,
+# respectively a number representing the total number of pages in the document.
+page_of_pages=（第 {{pageNumber}} 頁，共 {{pagesCount}} 頁）
+
+zoom_out.title=縮小
+zoom_out_label=縮小
+zoom_in.title=放大
+zoom_in_label=放大
+zoom.title=縮放
+presentation_mode.title=切換至簡報模式
+presentation_mode_label=簡報模式
+open_file.title=開啟檔案
+open_file_label=開啟
+print.title=列印
+print_label=列印
+save.title=儲存
+save_label=儲存
+bookmark1.title=目前頁面（含目前檢視頁面的網址）
+bookmark1_label=目前頁面
+# LOCALIZATION NOTE (open_in_app.title): This string is used in Firefox for Android.
+open_in_app.title=在應用程式中開啟
+# LOCALIZATION NOTE (open_in_app_label): This string is used in Firefox for Android. Length of the translation matters since we are in a mobile context, with limited screen estate.
+open_in_app_label=用程式開啟
+
+# Secondary toolbar and context menu
+tools.title=工具
+tools_label=工具
+first_page.title=跳到第一頁
+first_page_label=跳到第一頁
+last_page.title=跳到最後一頁
+last_page_label=跳到最後一頁
+page_rotate_cw.title=順時針旋轉
+page_rotate_cw_label=順時針旋轉
+page_rotate_ccw.title=逆時針旋轉
+page_rotate_ccw_label=逆時針旋轉
+
+cursor_text_select_tool.title=開啟文字選擇工具
+cursor_text_select_tool_label=文字選擇工具
+cursor_hand_tool.title=開啟頁面移動工具
+cursor_hand_tool_label=頁面移動工具
+
+scroll_page.title=使用頁面捲動功能
+scroll_page_label=頁面捲動功能
+scroll_vertical.title=使用垂直捲動版面
+scroll_vertical_label=垂直捲動
+scroll_horizontal.title=使用水平捲動版面
+scroll_horizontal_label=水平捲動
+scroll_wrapped.title=使用多頁捲動版面
+scroll_wrapped_label=多頁捲動
+
+spread_none.title=不要進行跨頁顯示
+spread_none_label=不跨頁
+spread_odd.title=從奇數頁開始跨頁
+spread_odd_label=奇數跨頁
+spread_even.title=從偶數頁開始跨頁
+spread_even_label=偶數跨頁
+
+# Document properties dialog box
+document_properties.title=文件內容…
+document_properties_label=文件內容…
+document_properties_file_name=檔案名稱:
+document_properties_file_size=檔案大小:
+# LOCALIZATION NOTE (document_properties_kb): "{{size_kb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in kilobytes, respectively in bytes.
+document_properties_kb={{size_kb}} KB（{{size_b}} 位元組）
+# LOCALIZATION NOTE (document_properties_mb): "{{size_mb}}" and "{{size_b}}"
+# will be replaced by the PDF file size in megabytes, respectively in bytes.
+document_properties_mb={{size_mb}} MB（{{size_b}} 位元組）
+document_properties_title=標題:
+document_properties_author=作者:
+document_properties_subject=主旨:
+document_properties_keywords=關鍵字:
+document_properties_creation_date=建立日期:
+document_properties_modification_date=修改日期:
+# LOCALIZATION NOTE (document_properties_date_string): "{{date}}" and "{{time}}"
+# will be replaced by the creation/modification date, and time, of the PDF file.
+document_properties_date_string={{date}} {{time}}
+document_properties_creator=建立者:
+document_properties_producer=PDF 產生器:
+document_properties_version=PDF 版本:
+document_properties_page_count=頁數:
+document_properties_page_size=頁面大小:
+document_properties_page_size_unit_inches=in
+document_properties_page_size_unit_millimeters=mm
+document_properties_page_size_orientation_portrait=垂直
+document_properties_page_size_orientation_landscape=水平
+document_properties_page_size_name_a3=A3
+document_properties_page_size_name_a4=A4
+document_properties_page_size_name_letter=Letter
+document_properties_page_size_name_legal=Legal
+# LOCALIZATION NOTE (document_properties_page_size_dimension_string):
+# "{{width}}", "{{height}}", {{unit}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement and orientation, of the (current) page.
+document_properties_page_size_dimension_string={{width}} × {{height}} {{unit}}（{{orientation}}）
+# LOCALIZATION NOTE (document_properties_page_size_dimension_name_string):
+# "{{width}}", "{{height}}", {{unit}}, {{name}}, and {{orientation}} will be replaced by
+# the size, respectively their unit of measurement, name, and orientation, of the (current) page.
+document_properties_page_size_dimension_name_string={{width}} × {{height}} {{unit}}（{{name}}，{{orientation}}）
+# LOCALIZATION NOTE (document_properties_linearized): The linearization status of
+# the document; usually called "Fast Web View" in English locales of Adobe software.
+document_properties_linearized=快速 Web 檢視:
+document_properties_linearized_yes=是
+document_properties_linearized_no=否
+document_properties_close=關閉
+
+print_progress_message=正在準備列印文件…
+# LOCALIZATION NOTE (print_progress_percent): "{{progress}}" will be replaced by
+# a numerical per cent value.
+print_progress_percent={{progress}}%
+print_progress_close=取消
+
+# Tooltips and alt text for side panel toolbar buttons
+# (the _label strings are alt text for the buttons, the .title strings are
+# tooltips)
+toggle_sidebar.title=切換側邊欄
+toggle_sidebar_notification2.title=切換側邊欄（包含大綱、附件、圖層的文件）
+toggle_sidebar_label=切換側邊欄
+document_outline.title=顯示文件大綱（雙擊展開/摺疊所有項目）
+document_outline_label=文件大綱
+attachments.title=顯示附件
+attachments_label=附件
+layers.title=顯示圖層（滑鼠雙擊即可將所有圖層重設為預設狀態）
+layers_label=圖層
+thumbs.title=顯示縮圖
+thumbs_label=縮圖
+current_outline_item.title=尋找目前的大綱項目
+current_outline_item_label=目前的大綱項目
+findbar.title=在文件中尋找
+findbar_label=尋找
+
+additional_layers=其他圖層
+# LOCALIZATION NOTE (page_landmark): "{{page}}" will be replaced by the page number.
+page_landmark=第 {{page}} 頁
+# Thumbnails panel item (tooltip and alt text for images)
+# LOCALIZATION NOTE (thumb_page_title): "{{page}}" will be replaced by the page
+# number.
+thumb_page_title=第 {{page}} 頁
+# LOCALIZATION NOTE (thumb_page_canvas): "{{page}}" will be replaced by the page
+# number.
+thumb_page_canvas=第 {{page}} 頁的縮圖
+
+# Find panel button title and messages
+find_input.title=尋找
+find_input.placeholder=在文件中搜尋…
+find_previous.title=尋找文字前次出現的位置
+find_previous_label=上一個
+find_next.title=尋找文字下次出現的位置
+find_next_label=下一個
+find_highlight=全部強調標示
+find_match_case_label=區分大小寫
+find_match_diacritics_label=符合變音符號
+find_entire_word_label=符合整個字
+find_reached_top=已搜尋至文件頂端，自底端繼續搜尋
+find_reached_bottom=已搜尋至文件底端，自頂端繼續搜尋
+# LOCALIZATION NOTE (find_match_count): The supported plural forms are
+# [one|two|few|many|other], with [other] as the default value.
+# "{{current}}" and "{{total}}" will be replaced by a number representing the
+# index of the currently active find result, respectively a number representing
+# the total number of matches in the document.
+find_match_count={[ plural(total) ]}
+find_match_count[one]=第 {{current}} 筆，共找到 {{total}} 筆
+find_match_count[two]=第 {{current}} 筆，共找到 {{total}} 筆
+find_match_count[few]=第 {{current}} 筆，共找到 {{total}} 筆
+find_match_count[many]=第 {{current}} 筆，共找到 {{total}} 筆
+find_match_count[other]=第 {{current}} 筆，共找到 {{total}} 筆
+# LOCALIZATION NOTE (find_match_count_limit): The supported plural forms are
+# [zero|one|two|few|many|other], with [other] as the default value.
+# "{{limit}}" will be replaced by a numerical value.
+find_match_count_limit={[ plural(limit) ]}
+find_match_count_limit[zero]=找到超過 {{limit}} 筆
+find_match_count_limit[one]=找到超過 {{limit}} 筆
+find_match_count_limit[two]=找到超過 {{limit}} 筆
+find_match_count_limit[few]=找到超過 {{limit}} 筆
+find_match_count_limit[many]=找到超過 {{limit}} 筆
+find_match_count_limit[other]=找到超過 {{limit}} 筆
+find_not_found=找不到指定文字
+
+# Predefined zoom values
+page_scale_width=頁面寬度
+page_scale_fit=縮放至頁面大小
+page_scale_auto=自動縮放
+page_scale_actual=實際大小
+# LOCALIZATION NOTE (page_scale_percent): "{{scale}}" will be replaced by a
+# numerical scale value.
+page_scale_percent={{scale}}%
+
+# Loading indicator messages
+loading_error=載入 PDF 時發生錯誤。
+invalid_file_error=無效或毀損的 PDF 檔案。
+missing_file_error=找不到 PDF 檔案。
+unexpected_response_error=伺服器回應未預期的內容。
+rendering_error=描繪頁面時發生錯誤。
+
+# LOCALIZATION NOTE (annotation_date_string): "{{date}}" and "{{time}}" will be
+# replaced by the modification date, and time, of the annotation.
+annotation_date_string={{date}} {{time}}
+
+# LOCALIZATION NOTE (text_annotation_type.alt): This is used as a tooltip.
+# "{{type}}" will be replaced with an annotation type from a list defined in
+# the PDF spec (32000-1:2008 Table 169 – Annotation types).
+# Some common types are e.g.: "Check", "Text", "Comment", "Note"
+text_annotation_type.alt=[{{type}} 註解]
+password_label=請輸入用來開啟此 PDF 檔案的密碼。
+password_invalid=密碼不正確，請再試一次。
+password_ok=確定
+password_cancel=取消
+
+printing_not_supported=警告: 此瀏覽器未完整支援列印功能。
+printing_not_ready=警告: 此 PDF 未完成下載以供列印。
+web_fonts_disabled=已停用網路字型 (Web fonts): 無法使用 PDF 內嵌字型。
+
+# Editor
+editor_free_text2.title=文字
+editor_free_text2_label=文字
+editor_ink2.title=繪圖
+editor_ink2_label=繪圖
+
+editor_stamp.title=新增圖片
+editor_stamp_label=新增圖片
+
+free_text2_default_content=開始打字…
+
+# Editor Parameters
+editor_free_text_color=色彩
+editor_free_text_size=大小
+editor_ink_color=色彩
+editor_ink_thickness=線條粗細
+editor_ink_opacity=透​明度
+
+# Editor aria
+editor_free_text2_aria_label=文本編輯器
+editor_ink2_aria_label=圖形編輯器
+editor_ink_canvas_aria_label=使用者建立的圖片

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,9 +19,9 @@
         "@nextcloud/eslint-config": "^8.2.1",
         "@nextcloud/stylelint-config": "^2.3.1",
         "@nextcloud/webpack-vue-config": "^5.5.1",
+        "adm-zip": "^0.5.10",
         "axios": "^1.4.0",
-        "cli-progress": "^3.12.0",
-        "unzipper": "^0.10.14"
+        "cli-progress": "^3.12.0"
       },
       "engines": {
         "node": "^16.0.0",
@@ -3408,6 +3408,15 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/adm-zip": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.10.tgz",
+      "integrity": "sha512-x0HvcHqVJNTPk/Bw8JbLWlWoo6Wwnsug0fnYYro1HBrjxZ3G7/AZk7Ahv8JwDe1uIcz8eBqvu86FuF1POiG7vQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
     "node_modules/agent-base": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
@@ -3844,34 +3853,12 @@
       "dev": true,
       "peer": true
     },
-    "node_modules/big-integer": {
-      "version": "1.6.48",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.48.tgz",
-      "integrity": "sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
     "node_modules/big.js": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
       "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
       "dev": true,
       "peer": true,
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/binary": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
-      "integrity": "sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk=",
-      "dev": true,
-      "dependencies": {
-        "buffers": "~0.1.1",
-        "chainsaw": "~0.1.0"
-      },
       "engines": {
         "node": "*"
       }
@@ -3890,7 +3877,8 @@
       "version": "3.4.7",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
       "integrity": "sha1-9y12C+Cbf3bQjtj66Ysomo0F+rM=",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/bn.js": {
       "version": "5.2.1",
@@ -4182,30 +4170,12 @@
       "dev": true,
       "peer": true
     },
-    "node_modules/buffer-indexof-polyfill": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
-      "integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
     "node_modules/buffer-xor": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
       "integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==",
       "dev": true,
       "peer": true
-    },
-    "node_modules/buffers": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
-      "integrity": "sha1-skV5w77U1tOWru5tmorn9Ugqt7s=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.2.0"
-      }
     },
     "node_modules/builtin-status-codes": {
       "version": "3.0.0",
@@ -4360,18 +4330,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/chainsaw": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
-      "integrity": "sha1-XqtQsor+WAdNDVgpE4iCi15fvJg=",
-      "dev": true,
-      "dependencies": {
-        "traverse": ">=0.3.0 <0.4"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/chalk": {
@@ -4747,7 +4705,8 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/cosmiconfig": {
       "version": "8.2.0",
@@ -5301,39 +5260,6 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domutils?sponsor=1"
-      }
-    },
-    "node_modules/duplexer2": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
-      "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
-      "dev": true,
-      "dependencies": {
-        "readable-stream": "^2.0.2"
-      }
-    },
-    "node_modules/duplexer2/node_modules/readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-      "dev": true,
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/duplexer2/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/ee-first": {
@@ -6931,33 +6857,6 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
-    "node_modules/fstream": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
-      "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "inherits": "~2.0.0",
-        "mkdirp": ">=0.5 0",
-        "rimraf": "2"
-      },
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
-    "node_modules/fstream/node_modules/rimraf": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-      "dev": true,
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      }
-    },
     "node_modules/function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -7221,7 +7120,8 @@
       "version": "4.2.9",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz",
       "integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/grapheme-splitter": {
       "version": "1.0.4",
@@ -8234,7 +8134,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -8429,12 +8330,6 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true,
       "peer": true
-    },
-    "node_modules/listenercount": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
-      "integrity": "sha1-hMinKrWcRyUyFIDJdeZQg0LnCTc=",
-      "dev": true
     },
     "node_modules/loader-runner": {
       "version": "4.2.0",
@@ -8784,7 +8679,8 @@
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
       "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/minimist-options": {
       "version": "4.1.0",
@@ -8840,18 +8736,6 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "optional": true
-    },
-    "node_modules/mkdirp": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-      "dev": true,
-      "dependencies": {
-        "minimist": "^1.2.5"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      }
     },
     "node_modules/ms": {
       "version": "2.1.2",
@@ -9857,7 +9741,8 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
@@ -10406,7 +10291,8 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/safe-regex-test": {
       "version": "1.0.0",
@@ -10744,7 +10630,8 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -11730,15 +11617,6 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "optional": true
     },
-    "node_modules/traverse": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
-      "integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk=",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/trim-newlines": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-4.1.1.tgz",
@@ -11945,48 +11823,6 @@
       "peer": true,
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/unzipper": {
-      "version": "0.10.14",
-      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.14.tgz",
-      "integrity": "sha512-ti4wZj+0bQTiX2KmKWuwj7lhV+2n//uXEotUmGuQqrbVZSEGFMbI68+c6JCQ8aAmUWYvtHEz2A8K6wXvueR/6g==",
-      "dev": true,
-      "dependencies": {
-        "big-integer": "^1.6.17",
-        "binary": "~0.3.0",
-        "bluebird": "~3.4.1",
-        "buffer-indexof-polyfill": "~1.0.0",
-        "duplexer2": "~0.1.4",
-        "fstream": "^1.0.12",
-        "graceful-fs": "^4.2.2",
-        "listenercount": "~1.0.1",
-        "readable-stream": "~2.3.6",
-        "setimmediate": "~1.0.4"
-      }
-    },
-    "node_modules/unzipper/node_modules/readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-      "dev": true,
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/unzipper/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -15277,6 +15113,12 @@
       "peer": true,
       "requires": {}
     },
+    "adm-zip": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.10.tgz",
+      "integrity": "sha512-x0HvcHqVJNTPk/Bw8JbLWlWoo6Wwnsug0fnYYro1HBrjxZ3G7/AZk7Ahv8JwDe1uIcz8eBqvu86FuF1POiG7vQ==",
+      "dev": true
+    },
     "agent-base": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
@@ -15611,28 +15453,12 @@
       "dev": true,
       "peer": true
     },
-    "big-integer": {
-      "version": "1.6.48",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.48.tgz",
-      "integrity": "sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w==",
-      "dev": true
-    },
     "big.js": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
       "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
       "dev": true,
       "peer": true
-    },
-    "binary": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
-      "integrity": "sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk=",
-      "dev": true,
-      "requires": {
-        "buffers": "~0.1.1",
-        "chainsaw": "~0.1.0"
-      }
     },
     "binary-extensions": {
       "version": "2.2.0",
@@ -15645,7 +15471,8 @@
       "version": "3.4.7",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
       "integrity": "sha1-9y12C+Cbf3bQjtj66Ysomo0F+rM=",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "bn.js": {
       "version": "5.2.1",
@@ -15877,24 +15704,12 @@
       "dev": true,
       "peer": true
     },
-    "buffer-indexof-polyfill": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
-      "integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==",
-      "dev": true
-    },
     "buffer-xor": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
       "integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==",
       "dev": true,
       "peer": true
-    },
-    "buffers": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
-      "integrity": "sha1-skV5w77U1tOWru5tmorn9Ugqt7s=",
-      "dev": true
     },
     "builtin-status-codes": {
       "version": "3.0.0",
@@ -16003,15 +15818,6 @@
         "@mapbox/node-pre-gyp": "^1.0.0",
         "nan": "^2.17.0",
         "simple-get": "^3.0.3"
-      }
-    },
-    "chainsaw": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
-      "integrity": "sha1-XqtQsor+WAdNDVgpE4iCi15fvJg=",
-      "dev": true,
-      "requires": {
-        "traverse": ">=0.3.0 <0.4"
       }
     },
     "chalk": {
@@ -16312,7 +16118,8 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "cosmiconfig": {
       "version": "8.2.0",
@@ -16743,41 +16550,6 @@
         "dom-serializer": "^1.0.1",
         "domelementtype": "^2.2.0",
         "domhandler": "^4.2.0"
-      }
-    },
-    "duplexer2": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
-      "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
-      "dev": true,
-      "requires": {
-        "readable-stream": "^2.0.2"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        }
       }
     },
     "ee-first": {
@@ -17991,29 +17763,6 @@
       "optional": true,
       "peer": true
     },
-    "fstream": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
-      "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.1.2",
-        "inherits": "~2.0.0",
-        "mkdirp": ">=0.5 0",
-        "rimraf": "2"
-      },
-      "dependencies": {
-        "rimraf": {
-          "version": "2.7.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-          "dev": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        }
-      }
-    },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -18213,7 +17962,8 @@
       "version": "4.2.9",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz",
       "integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "grapheme-splitter": {
       "version": "1.0.4",
@@ -18943,7 +18693,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "isexe": {
       "version": "2.0.0",
@@ -19094,12 +18845,6 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true,
       "peer": true
-    },
-    "listenercount": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
-      "integrity": "sha1-hMinKrWcRyUyFIDJdeZQg0LnCTc=",
-      "dev": true
     },
     "loader-runner": {
       "version": "4.2.0",
@@ -19375,7 +19120,8 @@
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
       "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "minimist-options": {
       "version": "4.1.0",
@@ -19420,15 +19166,6 @@
           "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
           "optional": true
         }
-      }
-    },
-    "mkdirp": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-      "dev": true,
-      "requires": {
-        "minimist": "^1.2.5"
       }
     },
     "ms": {
@@ -20161,7 +19898,8 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "proxy-addr": {
       "version": "2.0.7",
@@ -20573,7 +20311,8 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "safe-regex-test": {
       "version": "1.0.0",
@@ -20844,7 +20583,8 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "setprototypeof": {
       "version": "1.2.0",
@@ -21598,12 +21338,6 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "optional": true
     },
-    "traverse": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
-      "integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk=",
-      "dev": true
-    },
     "trim-newlines": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-4.1.1.tgz",
@@ -21758,50 +21492,6 @@
       "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
       "dev": true,
       "peer": true
-    },
-    "unzipper": {
-      "version": "0.10.14",
-      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.14.tgz",
-      "integrity": "sha512-ti4wZj+0bQTiX2KmKWuwj7lhV+2n//uXEotUmGuQqrbVZSEGFMbI68+c6JCQ8aAmUWYvtHEz2A8K6wXvueR/6g==",
-      "dev": true,
-      "requires": {
-        "big-integer": "^1.6.17",
-        "binary": "~0.3.0",
-        "bluebird": "~3.4.1",
-        "buffer-indexof-polyfill": "~1.0.0",
-        "duplexer2": "~0.1.4",
-        "fstream": "^1.0.12",
-        "graceful-fs": "^4.2.2",
-        "listenercount": "~1.0.1",
-        "readable-stream": "~2.3.6",
-        "setimmediate": "~1.0.4"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        }
-      }
     },
     "update-browserslist-db": {
       "version": "1.0.11",

--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
     "@nextcloud/eslint-config": "^8.2.1",
     "@nextcloud/stylelint-config": "^2.3.1",
     "@nextcloud/webpack-vue-config": "^5.5.1",
+    "adm-zip": "^0.5.10",
     "axios": "^1.4.0",
-    "cli-progress": "^3.12.0",
-    "unzipper": "^0.10.14"
+    "cli-progress": "^3.12.0"
   }
 }

--- a/pdfjs-get.js
+++ b/pdfjs-get.js
@@ -1,5 +1,5 @@
 const path = require('path')
-const unzipper = require('unzipper')
+const AdmZip = require('adm-zip')
 const axios = require('axios')
 const cliProgress = require('cli-progress')
 const npmPackage = require('./package.json')
@@ -22,9 +22,10 @@ axios.get(`https://github.com/mozilla/pdf.js/releases/download/v${PDFJSversion}/
 			console.info('Done! \n')
 		}
 	},
-	responseType: 'stream',
+	responseType: 'arraybuffer',
 }).then(response => {
-	response.data.pipe(unzipper.Extract({ path: path.resolve(__dirname, 'js', 'pdfjs') }))
+	const zip = new AdmZip(response.data)
+	zip.extractAllTo(path.resolve(__dirname, 'js', 'pdfjs'))
 }).catch(err => {
 	console.error(err)
 	throw new Error('Unable to download pdfjs dist')


### PR DESCRIPTION
It seems that in some cases `unzipper` may not extract all the files (see 278 in https://github.com/ZJONSSON/node-unzipper/issues, not linking directly to avoid polluting it with back references) and, with some node versions, it may corrupt some of the extracted files (see 271 in https://github.com/ZJONSSON/node-unzipper/issues). As there is no fix for all that yet (downgrading `unzipper` to 0.10.11 might solve the missing extracted files, but it would still be affected by the corrupted files and thus prevent upgrading to a newer node version) `unzipper` was replaced by [`adm-zip`](https://www.npmjs.com/package/adm-zip).

This could explain [the strange errors seen when building the PDF viewer](https://github.com/nextcloud/files_pdfviewer/pull/789#issuecomment-1669559535), as well as [why the UI was broken after updating the node engines](https://github.com/nextcloud/files_pdfviewer/pull/776) (it would not be a problem in the JavaScript files but in the extracted files, which can be noticed for example in [_viewer.html_](https://github.com/nextcloud/files_pdfviewer/commit/08ad83221b05c54a3ff8374df097dbf39aba98f0#diff-b0e73f4391c0f98303bb616d5a1b8d7a085a5924a37edd31a84abbb9940e7cf5)).

It would explain too [the deleted locale files after the bump to PDF.js 3.9.179](https://github.com/nextcloud/files_pdfviewer/pull/792/files#diff-4d939e501772e8fba731ef3503cbf45cb6abba1b560079f3bfaa0db1ad809e84) (which are fixed in this pull request).
