### PR TITLE
Re: [nextcloud/files_pdfviewer] Last Page of PDF cut off on Android Mobile (Issue #660)

### DIFF
--- a/src/views/PDFView.vue
+++ b/src/views/PDFView.vue
@@ -52,9 +52,9 @@ export default {
 		if (isPublicPage() && isPdf()) {
 			// Force style for public shares of a single PDF file, as there are
 			// no CSS selectors that could be used only for that case.
-			this.$refs.iframe.style.height = '100%'
-			this.$refs.iframe.style.position = 'absolute'
-			this.$refs.iframe.style.marginTop = 'unset'
+			//this.$refs.iframe.style.height = '100%'
+			//this.$refs.iframe.style.position = 'absolute'
+			//this.$refs.iframe.style.marginTop = 'unset'
 		}
 
 		this.doneLoading()

--- a/src/views/PDFView.vue
+++ b/src/views/PDFView.vue
@@ -189,7 +189,9 @@ export default {
 iframe {
 	width: 100%;
 	height: calc(100vh - var(--header-height));
+	height: calc(100dvh - var(--header-height));
 	margin-top: var(--header-height);
+	top: calc(var(--header-height) * -1);
 	position: absolute;
 }
 


### PR DESCRIPTION
PDFView.vue is patched to set vertical size correctly.