### PR TITLE
[stable29] Update php-cs-fixer to a PHP 8.3 compatible version

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -322,16 +322,16 @@
         },
         {
             "name": "php-cs-fixer/shim",
-            "version": "v3.17.0",
+            "version": "v3.66.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHP-CS-Fixer/shim.git",
-                "reference": "f51b4aed90565c447136f1d015798f6f7c82490f"
+                "reference": "6824b91b16d2e123afed9bf9c96ec283882346c9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHP-CS-Fixer/shim/zipball/f51b4aed90565c447136f1d015798f6f7c82490f",
-                "reference": "f51b4aed90565c447136f1d015798f6f7c82490f",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/shim/zipball/6824b91b16d2e123afed9bf9c96ec283882346c9",
+                "reference": "6824b91b16d2e123afed9bf9c96ec283882346c9",
                 "shasum": ""
             },
             "require": {
@@ -366,7 +366,11 @@
                 }
             ],
             "description": "A tool to automatically fix PHP code style",
-            "time": "2023-05-22T20:00:38+00:00"
+            "support": {
+                "issues": "https://github.com/PHP-CS-Fixer/shim/issues",
+                "source": "https://github.com/PHP-CS-Fixer/shim/tree/v3.66.0"
+            },
+            "time": "2024-12-29T13:46:48+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -1721,5 +1725,5 @@
     "platform-overrides": {
         "php": "7.4"
     },
-    "plugin-api-version": "1.1.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/tests/Unit/Controller/DisplayControllerTest.php
+++ b/tests/Unit/Controller/DisplayControllerTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright 2014 Lukas Reschke lukas@owncloud.com
  *

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright 2014 Lukas Reschke lukas@owncloud.com
  *


### PR DESCRIPTION
Previous php-cs-fixer version was not compatible yet with PHP 8.3, so it may fail when run on CI if PHP 8.3, which is the latest supported version in Nextcloud 29, was used.

See, for example, https://github.com/nextcloud/files_pdfviewer/pull/1084