### PR TITLE
Fix saving annotations in paths with special characters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@nextcloud/dialogs": "^6.1.1",
         "@nextcloud/l10n": "^3.2.0",
         "@nextcloud/logger": "^3.0.2",
+        "@nextcloud/paths": "^2.2.1",
         "@nextcloud/router": "^3.0.1",
         "@nextcloud/sharing": "^0.2.4",
         "pdfjs-dist": "^4.0.189"
@@ -2684,6 +2685,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@nextcloud/paths/-/paths-2.2.1.tgz",
       "integrity": "sha512-M3ShLjrxR7B48eKThLMoqbxTqTKyQXcwf9TgeXQGbCIhiHoXU6as5j8l5qNv/uZlANokVdowpuWHBi3b2+YNNA==",
+      "license": "GPL-3.0-or-later",
       "engines": {
         "node": "^20.0.0",
         "npm": "^10.0.0"

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@nextcloud/dialogs": "^6.1.1",
     "@nextcloud/l10n": "^3.2.0",
     "@nextcloud/logger": "^3.0.2",
+    "@nextcloud/paths": "^2.2.1",
     "@nextcloud/router": "^3.0.1",
     "@nextcloud/sharing": "^0.2.4",
     "pdfjs-dist": "^4.0.189"

--- a/src/services/uploadPdfFile.js
+++ b/src/services/uploadPdfFile.js
@@ -4,6 +4,7 @@
  */
 import { getRequestToken } from '@nextcloud/auth'
 import axios from '@nextcloud/axios'
+import { encodePath } from '@nextcloud/paths'
 
 import { getRootPath } from '../utils/davUtils.js'
 import { getSharingToken } from '@nextcloud/sharing/public'
@@ -25,7 +26,7 @@ import { getSharingToken } from '@nextcloud/sharing/public'
 export default async function(filename, data) {
 	// getRootPath takes into account the differences between files of
 	// registered users and public shares.
-	const filePath = getRootPath() + filename
+	const filePath = getRootPath() + encodePath(filename)
 
 	const blob = new Blob([data], { type: 'application/pdf' })
 


### PR DESCRIPTION
Fixes #1102

The filename may contain characters that are not compatible with a URL path, so it needs to be explicitly encoded. Otherwise the upload could fail (for example, if the filename contains `%` followed by a letter, which would cause the server to fail to decode the path and return a `400 Bad request` error) or even overwrite a different file (for example, if the filename contains `#`, which would cause the rest of the path to be ignored).

## How to test (scenario 1)

- Open the Files app
- Ensure that there is no folder or file named just `test`
- Create a new folder named `test#folder`
- Open the new folder
- Upload a PDF file
- Open the PDF file
- Add an annotation
- Save the PDF file
- Close the PDF file
- Open it again

### Result with this pull request

The annotation is in the file

### Result without this pull request

The annotation is not in the file. If the root folder is opened again there is now a file named `test` in it.


## How to test (scenario 2)

- Open the Files app
- Create a new folder named `#test`
- Open the new folder
- Upload a PDF file
- Open the PDF file
- Add an annotation
- Save the PDF file

### Result with this pull request

The file is saved

### Result without this pull request

An error is shown and the file is not saved. The "Network" tab of the browser development tools show that the request failed with "409 Conflict" (as it tried to overwrite the root folder).



## How to test (scenario 3)

- Open the Files app
- Create a new folder named `test%folder`
- Open the new folder
- Upload a PDF file
- Open the PDF file
- Add an annotation
- Save the PDF file

### Result with this pull request

The file is saved

### Result without this pull request

An error is shown and the file is not saved. The "Network" tab of the browser development tools show that the request failed with "400 Bad request" (as `%f` in the path could not be decoded).
