### PR TITLE
Get PDF.js version from "package-lock.json"

### DIFF
--- a/pdfjs-get.js
+++ b/pdfjs-get.js
@@ -6,10 +6,10 @@ const path = require('path')
 const AdmZip = require('adm-zip')
 const axios = require('axios')
 const cliProgress = require('cli-progress')
-const npmPackage = require('./package.json')
+const npmPackageLock = require('./package-lock.json')
 
 // Fetching pdf.js build release
-const PDFJSversion = npmPackage.dependencies['pdfjs-dist'].slice(1)
+const PDFJSversion = npmPackageLock.dependencies['pdfjs-dist']['version']
 console.info('Fetching pdfjs', PDFJSversion)
 
 // Init progress


### PR DESCRIPTION
The `pdfjs-get.js` script downloads and unpacks _pdfjs-dist_ in _js/pdfjs_ so it can be loaded from the PDF viewer. However, the PDF.js version to download was got from _package.json_, which just specifies the desired ranges of versions to use, but not the exact versions actually being built.

Due to that it could happen, for example after running `npm audit fix`, that `pdfjs-get.js` downloaded version X.Y, as it was the minimum desired version specified in _package.json_, but the dependencies were resolved and built against version X.Z, as it was the actual version specified in _package-lock.json_.

To solve that now the PDF.js version is got from _package-lock.json_ instead, which provides the exact version to use.

Note, however, that this is just a "safety net" to avoid unexpected mismatches as a result of running `npm audit fix` or similar (see, for example, https://github.com/nextcloud/files_pdfviewer/pull/1146); in general the PDF.js version is expected to be in sync between _package.json_ and _package-lock.json_.