### PR TITLE
fix: Pin pdfjs-dist to exact 4.0.189

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@nextcloud/logger": "^3.0.2",
         "@nextcloud/router": "^3.0.1",
         "@nextcloud/sharing": "^0.2.4",
-        "pdfjs-dist": "^4.0.189"
+        "pdfjs-dist": "4.0.189"
       },
       "devDependencies": {
         "@nextcloud/babel-config": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@nextcloud/logger": "^3.0.2",
     "@nextcloud/router": "^3.0.1",
     "@nextcloud/sharing": "^0.2.4",
-    "pdfjs-dist": "^4.0.189"
+    "pdfjs-dist": "4.0.189"
   },
   "browserslist": [
     "extends @nextcloud/browserslist-config"


### PR DESCRIPTION
The PDF viewer [explicitly sets `isEvalSupported` to `false`](https://github.com/nextcloud/files_pdfviewer/blob/f93247e2c0be7665a13484aee3b4df42bed583f2/src/views/PDFView.vue#L127), so it is not affected by [the security issue reported for versions <= 4.1.392, which assume the default value of `true`](https://github.com/advisories/GHSA-wgrm-67xf-hhpq).

pdfjs-dist is the main dependency of the PDF viewer, and any version update requires additional work in the PDF viewer, it is not just increasing the version and that is it.

Due to all of the above, the pdfjs-dist version is pinned for now to exact 4.0.189 to avoid dealing again and again with incorrect updates after running `npm audit fix` (see, for example, https://github.com/nextcloud/files_pdfviewer/pull/1158).