### PR TITLE
chore(tests): Cleanup bootstrap.php to be forward-compatible

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,22 +1,28 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2018-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2014-2015 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
+
+use OCP\App\IAppManager;
+use OCP\Server;
+use PHPUnit\Framework\TestCase;
+
 if (!defined('PHPUNIT_RUN')) {
 	define('PHPUNIT_RUN', 1);
 }
 
 require_once __DIR__ . '/../../../lib/base.php';
+require_once __DIR__ . '/../../../tests/autoload.php';
 
-\OC::$loader->addValidRoot(\OC::$SERVERROOT . '/tests');
-\OC_App::loadApp('files_pdfviewer');
+Server::get(IAppManager::class)->loadApp('files_pdfviewer');
 
-if (!class_exists('\PHPUnit\Framework\TestCase')) {
+if (!class_exists(TestCase::class)) {
 	require_once('PHPUnit/Autoload.php');
 }
 
-\OC_App::loadApp('files_pdfviewer');
 OC_Hook::clear();

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -24,5 +24,3 @@ Server::get(IAppManager::class)->loadApp('files_pdfviewer');
 if (!class_exists(TestCase::class)) {
 	require_once('PHPUnit/Autoload.php');
 }
-
-OC_Hook::clear();


### PR DESCRIPTION
This uses the new tests/autoload.php from nextcloud/server instead of messing directly with OC private autoloader.

See https://github.com/nextcloud/server/pull/52951 and https://github.com/nextcloud/server/pull/52945 for context.