### PR TITLE
fix: Update engines in package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,8 +30,8 @@
         "cli-progress": "^3.12.0"
       },
       "engines": {
-        "node": "^20.0.0",
-        "npm": "^10.0.0"
+        "node": "^22.0.0",
+        "npm": "^10.5.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {


### PR DESCRIPTION
Follow up to #1245

Yes, it is not really necessary as it will be updated anyway as soon as a dependency is updated, but I want to keep this as a reminder for the next engine version bump ;-)
