### PR TITLE
Fix viewing of file versions

### DIFF
--- a/src/views/PDFView.vue
+++ b/src/views/PDFView.vue
@@ -48,7 +48,7 @@ export default {
 		},
 
 		isDownloadable() {
-			if (!this.file.shareAttributes) {
+			if (!this.file || !this.file.shareAttributes) {
 				return true
 			}
 

--- a/src/views/PDFView.vue
+++ b/src/views/PDFView.vue
@@ -51,14 +51,19 @@ export default {
 			if (!this.file || !this.file.shareAttributes) {
 				return true
 			}
-
-			const shareAttributes = JSON.parse(this.file.shareAttributes)
-			const downloadPermissions = shareAttributes.find(({ scope, key }) => scope === 'permissions' && key === 'download')
-			if (downloadPermissions) {
-				return downloadPermissions.value
+			try {
+				const shareAttributes = JSON.parse(this.file.shareAttributes)
+				const downloadPermissions = shareAttributes.find(({ scope, key }) => scope === 'permissions' && key === 'download')
+				if (downloadPermissions) {
+					return downloadPermissions.value
+				}
+				return true
+			} catch (e) {
+				logger.error('Error parsing shareAttributes:', e)
+				// If shareAttributes can not be parsed, assume the file is
+				// downloadable to avoid locking users out of their files.
+				return true
 			}
-
-			return true
 		},
 
 		isRichDocumentsAvailable() {


### PR DESCRIPTION
Fixes the issue reported at https://github.com/nextcloud/files_pdfviewer/issues/1269

When trying to look at older versions of a pdf file, there was always an error as this.file was undefined. 
By adding a check for this to isDownloadable() this starts to work without an issue