### PR TITLE
fix: Hide UI elements when printing from mobile

### DIFF
--- a/css/viewer.css
+++ b/css/viewer.css
@@ -9,6 +9,22 @@
 		visibility: hidden;
 		display: none;
 	}
+
+	.toolbar,
+	#secondaryToolbar,
+	#sidebarContainer {
+		display: none;
+	}
+
+	#viewerContainer {
+		top: 0 !important;
+	}
+
+	.pdfViewer .page {
+		margin: 0 !important;
+		border: initial !important;
+		box-shadow: initial !important;
+	}
 }
 
 /* Prevent text selection when the download of a share is hidden. */


### PR DESCRIPTION
## Summary

This commit fixes an issue where the entire PDF viewer user interface was being printed instead of just the PDF document, especially on mobile devices. CSS rules have been added to hide the toolbars and sidebar when printing. Additional styles ensure the PDF content container and pages are correctly sized for the printed output.

## Changes

- **css/viewer.css**: Added CSS rules within the `@media print` block to hide UI elements like toolbars and the sidebar. Also added styles to ensure the PDF viewer container and pages take up the full space and have no extra margins or borders, which fixes the issue of the UI being printed and the PDF content appearing small.

## Related Issue

Closes #1310

