### PR TITLE
fix: update CSP

### DIFF
--- a/lib/Controller/DisplayController.php
+++ b/lib/Controller/DisplayController.php
@@ -63,7 +63,7 @@ class DisplayController extends Controller {
 		$response = new TemplateResponse(Application::APP_ID, 'viewer', $params, TemplateResponse::RENDER_AS_BLANK);
 
 		$policy = new ContentSecurityPolicy();
-		$policy->addAllowedChildSrcDomain('\'self\'');
+		$policy->addAllowedWorkerSrcDomain('\'self\'');
 		$policy->addAllowedFontDomain('data:');
 		$policy->addAllowedImageDomain('*');
 		// Needed for the ES5 compatible build of PDF.js

--- a/lib/Controller/DisplayController.php
+++ b/lib/Controller/DisplayController.php
@@ -66,8 +66,7 @@ class DisplayController extends Controller {
 		$policy->addAllowedWorkerSrcDomain('\'self\'');
 		$policy->addAllowedFontDomain('data:');
 		$policy->addAllowedImageDomain('*');
-		// Needed for the ES5 compatible build of PDF.js
-		$policy->allowEvalScript(true);
+		$policy->addAllowedScriptDomain('\'wasm-unsafe-eval\'');
 		$response->setContentSecurityPolicy($policy);
 
 		return $response;

--- a/tests/Unit/Controller/DisplayControllerTest.php
+++ b/tests/Unit/Controller/DisplayControllerTest.php
@@ -67,7 +67,7 @@ class DisplayControllerTest extends TestCase {
 		$policy->addAllowedWorkerSrcDomain('\'self\'');
 		$policy->addAllowedFontDomain('data:');
 		$policy->addAllowedImageDomain('*');
-		$policy->allowEvalScript(true);
+		$policy->addAllowedScriptDomain('\'wasm-unsafe-eval\'');
 		$expectedResponse->setContentSecurityPolicy($policy);
 
 		$this->assertEquals($expectedResponse, $this->controller->showPdfViewer());

--- a/tests/Unit/Controller/DisplayControllerTest.php
+++ b/tests/Unit/Controller/DisplayControllerTest.php
@@ -64,7 +64,7 @@ class DisplayControllerTest extends TestCase {
 		];
 		$expectedResponse = new TemplateResponse(Application::APP_ID, 'viewer', $params, TemplateResponse::RENDER_AS_BLANK);
 		$policy = new ContentSecurityPolicy();
-		$policy->addAllowedChildSrcDomain('\'self\'');
+		$policy->addAllowedWorkerSrcDomain('\'self\'');
 		$policy->addAllowedFontDomain('data:');
 		$policy->addAllowedImageDomain('*');
 		$policy->allowEvalScript(true);


### PR DESCRIPTION
The `child-src` directive is deprecated and `ContentSecurityPolicy::addAllowedChildSrcDomain()` [was removed in Nextcloud 34](https://github.com/nextcloud/server/commit/78fd649e475). Instead we can use `addAllowedWorkerSrcDomain()` and `addAllowedFrameDomain()`.

Additionally, the `allowEvalScript` method call was causing errors as well, and it seems like that can just be removed since the app is using the ESM build now.

After these, the app now properly display PDFs for me, whereas there was an internal server error before.