### PR TITLE
fix: remove deprecated CSP methods incompatible with Nextcloud 34

### DIFF
--- a/lib/Controller/DisplayController.php
+++ b/lib/Controller/DisplayController.php
@@ -63,11 +63,9 @@ class DisplayController extends Controller {
 		$response = new TemplateResponse(Application::APP_ID, 'viewer', $params, TemplateResponse::RENDER_AS_BLANK);
 
 		$policy = new ContentSecurityPolicy();
-		$policy->addAllowedChildSrcDomain('\'self\'');
+		$policy->addAllowedFrameDomain('\'self\'');
 		$policy->addAllowedFontDomain('data:');
 		$policy->addAllowedImageDomain('*');
-		// Needed for the ES5 compatible build of PDF.js
-		$policy->allowEvalScript(true);
 		$response->setContentSecurityPolicy($policy);
 
 		return $response;


### PR DESCRIPTION
## Summary

`allowEvalScript()` and `addAllowedChildSrcDomain()` were removed from `ContentSecurityPolicy` in Nextcloud 34, causing a fatal error when opening the PDF viewer:

```
Call to undefined method OCP\AppFramework\Http\ContentSecurityPolicy::allowEvalScript()
```

Both methods were removed by nextcloud/server@78fd649e475 (_"chore: Remove long deprecated methods from OCP — These have been deprecated from before 20"_, Apr 9 2026). The app declares `min-version="34"` but was calling API that no longer exists in that version.

## Changes

- Replace `addAllowedChildSrcDomain("'self'")` with `addAllowedFrameDomain("'self'")` (the correct NC34 equivalent)
- Remove `allowEvalScript(true)` — no longer available in NC34 and not required by modern PDF.js builds