### PR TITLE
chore: Bump PHP version to 8.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
 		"optimize-autoloader": true,
 		"classmap-authoritative": true,
 		"platform": {
-			"php": "8.1"
+			"php": "8.3"
 		},
 		"allow-plugins": {
 			"bamarni/composer-bin-plugin": true

--- a/psalm.xml
+++ b/psalm.xml
@@ -3,7 +3,7 @@
 		errorLevel="4"
 		findUnusedBaselineEntry="true"
 		findUnusedCode="false"
-		phpVersion="8.2"
+		phpVersion="8.3"
 		resolveFromConfigFile="true"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns="https://getpsalm.org/schema/config"

--- a/vendor-bin/psalm/composer.json
+++ b/vendor-bin/psalm/composer.json
@@ -1,7 +1,7 @@
 {
 	"config": {
 		"platform": {
-			"php": "8.2.27"
+			"php": "8.3.16"
 		}
 	},
 	"require-dev": {

--- a/vendor-bin/psalm/composer.lock
+++ b/vendor-bin/psalm/composer.lock
@@ -3491,7 +3491,7 @@
     "platform": [],
     "platform-dev": [],
     "platform-overrides": {
-        "php": "8.2.27"
+        "php": "8.3.16"
     },
     "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
[Nextcloud 35 and later only supports PHP >= 8.3](https://github.com/nextcloud/server/commit/a7da9cd5969c414c66074a3dc4b938e3d6f193ec). Version 8.3.16 had to be explicitly set for psalm, as it is the minimum compatible version with psalm 6.16.1.

This should also fix the [psalm errors in CI](https://github.com/nextcloud/files_pdfviewer/actions/runs/30153587747/job/89667932336) (`Check enforcement of minimum PHP version 8.3 in psalm.xml`).