### PR TITLE
[stable32] fix: Bust the cache of the static assets when Nextcloud is updated

### DIFF
--- a/lib/Controller/DisplayController.php
+++ b/lib/Controller/DisplayController.php
@@ -9,9 +9,11 @@
 namespace OCA\Files_PDFViewer\Controller;
 
 use OCA\Files_PDFViewer\AppInfo\Application;
+use OCP\App\IAppManager;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\ContentSecurityPolicy;
 use OCP\AppFramework\Http\TemplateResponse;
+use OCP\IConfig;
 use OCP\IRequest;
 use OCP\IURLGenerator;
 
@@ -20,14 +22,26 @@ class DisplayController extends Controller {
 	/** @var IURLGenerator */
 	private $urlGenerator;
 
+	/** @var IAppManager */
+	private $appManager;
+
+	/** @var IConfig */
+	private $config;
+
 	/**
 	 * @param IRequest $request
 	 * @param IURLGenerator $urlGenerator
+	 * @param IAppManager $appManager
+	 * @param IConfig $config
 	 */
 	public function __construct(IRequest $request,
-		IURLGenerator $urlGenerator) {
+		IURLGenerator $urlGenerator,
+		IAppManager $appManager,
+		IConfig $config) {
 		parent::__construct(Application::APP_ID, $request);
 		$this->urlGenerator = $urlGenerator;
+		$this->appManager = $appManager;
+		$this->config = $config;
 	}
 
 	/**
@@ -40,7 +54,9 @@ class DisplayController extends Controller {
 	public function showPdfViewer(bool $minmode = false): TemplateResponse {
 		$params = [
 			'urlGenerator' => $this->urlGenerator,
-			'minmode' => $minmode
+			'minmode' => $minmode,
+			'version' => $this->appManager->getAppVersion(Application::APP_ID),
+			'enableScripting' => $this->config->getAppValue(Application::APP_ID, 'enable_scripting', 'no') === 'yes',
 		];
 
 		$response = new TemplateResponse(Application::APP_ID, 'viewer', $params, 'blank');

--- a/lib/Controller/DisplayController.php
+++ b/lib/Controller/DisplayController.php
@@ -16,6 +16,7 @@ use OCP\AppFramework\Http\TemplateResponse;
 use OCP\IConfig;
 use OCP\IRequest;
 use OCP\IURLGenerator;
+use OCP\ServerVersion;
 
 class DisplayController extends Controller {
 
@@ -28,20 +29,26 @@ class DisplayController extends Controller {
 	/** @var IConfig */
 	private $config;
 
+	/** @var ServerVersion */
+	private $serverVersion;
+
 	/**
 	 * @param IRequest $request
 	 * @param IURLGenerator $urlGenerator
 	 * @param IAppManager $appManager
 	 * @param IConfig $config
+	 * @param ServerVersion $serverVersion
 	 */
 	public function __construct(IRequest $request,
 		IURLGenerator $urlGenerator,
 		IAppManager $appManager,
-		IConfig $config) {
+		IConfig $config,
+		ServerVersion $serverVersion) {
 		parent::__construct(Application::APP_ID, $request);
 		$this->urlGenerator = $urlGenerator;
 		$this->appManager = $appManager;
 		$this->config = $config;
+		$this->serverVersion = $serverVersion;
 	}
 
 	/**
@@ -55,7 +62,7 @@ class DisplayController extends Controller {
 		$params = [
 			'urlGenerator' => $this->urlGenerator,
 			'minmode' => $minmode,
-			'version' => $this->appManager->getAppVersion(Application::APP_ID),
+			'version' => $this->getVersionHash(),
 			'enableScripting' => $this->config->getAppValue(Application::APP_ID, 'enable_scripting', 'no') === 'yes',
 		];
 
@@ -70,5 +77,24 @@ class DisplayController extends Controller {
 		$response->setContentSecurityPolicy($policy);
 
 		return $response;
+	}
+
+	/**
+	 * Returns the value used to bust the cache of the static assets.
+	 *
+	 * Assets requested with a "v" parameter are served as immutable, so
+	 * browsers keep them for months without checking again whether they
+	 * changed. The app version can not be used on its own for that, as it is
+	 * the same in every patch release of a Nextcloud version. Therefore,
+	 * the Nextcloud version is taken into account too, like the server does
+	 * for the assets that it links itself.
+	 *
+	 * @return string
+	 */
+	private function getVersionHash(): string {
+		$appVersion = $this->appManager->getAppVersion(Application::APP_ID);
+		$serverVersion = implode('.', $this->serverVersion->getVersion());
+
+		return substr(md5($appVersion . '-' . $serverVersion), 0, 8);
 	}
 }

--- a/templates/viewer.php
+++ b/templates/viewer.php
@@ -9,11 +9,8 @@
 /** @var array $_ */
 /** @var OCP\IURLGenerator $urlGenerator */
 $urlGenerator = $_['urlGenerator'];
-$version = \OC::$server->getAppManager()->getAppVersion('files_pdfviewer');
-$enableScripting = false;
-if (\OC::$server->getConfig()->getAppValue('files_pdfviewer', 'enable_scripting', 'no') === 'yes') {
-	$enableScripting = true;
-}
+$version = $_['version'];
+$enableScripting = $_['enableScripting'];
 ?>
 
 <!DOCTYPE html>

--- a/templates/viewer.php
+++ b/templates/viewer.php
@@ -38,7 +38,7 @@ See https://github.com/adobe-type-tools/cmap-resources
 <html dir="ltr" mozdisallowselectionprint>
   <head data-workersrc="<?php p($urlGenerator->linkTo('files_pdfviewer', 'js/pdfjs/build/pdf.worker.mjs')) ?>?v=<?php p($version) ?>"
         data-enablescripting="<?php p($enableScripting ? 'true' : 'false') ?>"
-        data-sandbox="<?php p($urlGenerator->linkTo('files_pdfviewer', 'js/pdfjs/build/pdf.sandbox.mjs'))?>"
+        data-sandbox="<?php p($urlGenerator->linkTo('files_pdfviewer', 'js/pdfjs/build/pdf.sandbox.mjs'))?>?v=<?php p($version) ?>"
         data-cmapurl="<?php p($urlGenerator->linkTo('files_pdfviewer', 'js/pdfjs/web/cmaps/')) ?>"
         data-imageresourcespath="<?php p($urlGenerator->linkTo('files_pdfviewer', 'js/pdfjs/web/images/')) ?>">
     <meta charset="utf-8">

--- a/tests/Unit/Controller/DisplayControllerTest.php
+++ b/tests/Unit/Controller/DisplayControllerTest.php
@@ -9,8 +9,10 @@ namespace OCA\Files_PDFViewer\Tests\Unit\Controller;
 
 use OCA\Files_PDFViewer\AppInfo\Application;
 use OCA\Files_PDFViewer\Controller\DisplayController;
+use OCP\App\IAppManager;
 use OCP\AppFramework\Http\ContentSecurityPolicy;
 use OCP\AppFramework\Http\TemplateResponse;
+use OCP\IConfig;
 use OCP\IRequest;
 use OCP\IURLGenerator;
 use Test\TestCase;
@@ -22,24 +24,43 @@ class DisplayControllerTest extends TestCase {
 	/** @var IURLGenerator */
 	private $urlGenerator;
 
+	/** @var IAppManager */
+	private $appManager;
+
+	/** @var IConfig */
+	private $config;
+
 	/** @var DisplayController */
 	private $controller;
 
 	protected function setUp(): void {
 		$this->request = $this->createMock(IRequest::class);
 		$this->urlGenerator = $this->createMock(IURLGenerator::class);
+		$this->appManager = $this->createMock(IAppManager::class);
+		$this->config = $this->createMock(IConfig::class);
 		$this->controller = new DisplayController(
 			$this->request,
-			$this->urlGenerator
+			$this->urlGenerator,
+			$this->appManager,
+			$this->config,
 		);
 
 		parent::setUp();
 	}
 
 	public function testShowPdfViewer(): void {
+		$this->appManager->method('getAppVersion')
+			->with(Application::APP_ID)
+			->willReturn('1.0.0');
+		$this->config->method('getAppValue')
+			->with(Application::APP_ID, 'enable_scripting', 'no')
+			->willReturn('no');
+
 		$params = [
 			'urlGenerator' => $this->urlGenerator,
-			'minmode' => false
+			'minmode' => false,
+			'version' => '1.0.0',
+			'enableScripting' => false,
 		];
 		$expectedResponse = new TemplateResponse(Application::APP_ID, 'viewer', $params, 'blank');
 		$policy = new ContentSecurityPolicy();

--- a/tests/Unit/Controller/DisplayControllerTest.php
+++ b/tests/Unit/Controller/DisplayControllerTest.php
@@ -15,6 +15,7 @@ use OCP\AppFramework\Http\TemplateResponse;
 use OCP\IConfig;
 use OCP\IRequest;
 use OCP\IURLGenerator;
+use OCP\ServerVersion;
 use Test\TestCase;
 
 class DisplayControllerTest extends TestCase {
@@ -30,6 +31,9 @@ class DisplayControllerTest extends TestCase {
 	/** @var IConfig */
 	private $config;
 
+	/** @var ServerVersion */
+	private $serverVersion;
+
 	/** @var DisplayController */
 	private $controller;
 
@@ -38,11 +42,13 @@ class DisplayControllerTest extends TestCase {
 		$this->urlGenerator = $this->createMock(IURLGenerator::class);
 		$this->appManager = $this->createMock(IAppManager::class);
 		$this->config = $this->createMock(IConfig::class);
+		$this->serverVersion = \OCP\Server::get(ServerVersion::class);
 		$this->controller = new DisplayController(
 			$this->request,
 			$this->urlGenerator,
 			$this->appManager,
 			$this->config,
+			$this->serverVersion,
 		);
 
 		parent::setUp();
@@ -56,10 +62,16 @@ class DisplayControllerTest extends TestCase {
 			->with(Application::APP_ID, 'enable_scripting', 'no')
 			->willReturn('no');
 
+		// ServerVersion can not be mocked in PHPUnit < 11.2, and PHPUnit
+		// can not be used in PHP < 8.2, so the expected version needs to be
+		// calculated from the actual server version.
+		$serverVersion = implode('.', $this->serverVersion->getVersion());
+		$expectedVersion = substr(md5('1.0.0' . '-' . $serverVersion), 0, 8);
+
 		$params = [
 			'urlGenerator' => $this->urlGenerator,
 			'minmode' => false,
-			'version' => '1.0.0',
+			'version' => $expectedVersion,
 			'enableScripting' => false,
 		];
 		$expectedResponse = new TemplateResponse(Application::APP_ID, 'viewer', $params, 'blank');


### PR DESCRIPTION
Backport of #1522 to stable32. Fixes #1514 on this branch.

**Edited by @danxuliu:**
Originally this branch had [a custom fix](https://github.com/nextcloud/files_pdfviewer/commit/c5a1509363e9c4f157ca6d805d7d2222f532c240), as the code base differed from the master branch. However now 7a44563 (reworded commit description from _removed_ to _deprecated_) and 4397657 were also cherry picked [to be able to apply the same fix](https://github.com/nextcloud/files_pdfviewer/pull/1522#pullrequestreview-4951931297) (even if the needed base changes are indeed questionable in a maintenance release).

Neither the unit tests nor the composer adjustments needed for them were backported, as [Nextcloud 32 is compatible with PHP >= 8.1](https://github.com/nextcloud/server/blob/dcddfc672a4859a1b30698bf0415bacf866b6db9/lib/versioncheck.php#L8-L14), but PHP 8.2 is needed for PHPUnit 11.2.